### PR TITLE
11th Flow: Multi-Provider LLM, Chat Flow, Lyrics AI & Spotify Fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,11 +26,16 @@ ADVISOR_AUTO_START=false
 # ============================================
 # LLM (used by @flows/core for AI insights)
 # ============================================
-# Provider: gemini | groq | openai
+# Provider: gemini | groq | openrouter | cerebras | mistral | rotation
+# "rotation" cycles through all configured free providers with round-robin + 429 fallback.
 LLM_PROVIDER=gemini
 LLM_MODEL=gemini-2.5-flash
 
-# Set the API key matching your LLM_PROVIDER
+# ── Provider API Keys ─────────────
+# Only the key for your selected provider is required.
+# For rotation mode, set keys for all providers you want included.
 GEMINI_API_KEY=
 # GROQ_API_KEY=
-# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+# CEREBRAS_API_KEY=
+# MISTRAL_API_KEY=

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -46,6 +46,43 @@ Flows import the shared database instance:
 import { db } from '@flows/core';
 ```
 
+## LLM Provider Architecture
+
+The `@flows/core/llm` module provides a unified interface for multiple LLM providers.
+
+```text
+@flows/core/src/llm/
+├── llm-client.ts          # LLMClient class (Direct + Rotation modes)
+├── index.ts               # Barrel: re-exports + createLLMClient() factory
+└── providers/
+    ├── types.ts            # Shared types (LLMMessage, ModelInfo, ModelTier, etc.)
+    ├── base-provider.ts    # Abstract BaseLLMProvider
+    ├── gemini/             # Google Gemini (paid, @google/genai SDK)
+    ├── groq/               # GroqCloud (free, OpenAI-compatible)
+    ├── openrouter/         # OpenRouter aggregator (free :free models)
+    ├── cerebras/           # Cerebras (free, 1M tokens/day)
+    └── mistral/            # Mistral La Plateforme (free experiment tier)
+```
+
+Each provider has:
+
+- `models.ts` — Static catalog with `{ id, name, tier, pricing, contextWindow }`
+- `*-provider.ts` — Extends `BaseLLMProvider`, implements `generate()`, `listModels()`, etc.
+
+**Model tiers:** `very_high` (frontier), `high` (near-frontier), `medium` (generalist), `low` (fast/light).
+
+**Two client modes:**
+
+```typescript
+// Direct: use specific provider
+const client = new LLMClient('groq');
+
+// Rotation: round-robin across free providers (fallback on 429)
+const client = LLMClient.createRotation();
+```
+
+Configure via `.env`: `LLM_PROVIDER=rotation` or `LLM_PROVIDER=groq`.
+
 ## Data Flow (Example: Spotify Sync)
 
 ```mermaid

--- a/docs/flow-ideas-backlog.md
+++ b/docs/flow-ideas-backlog.md
@@ -1,0 +1,17 @@
+# Ideas Backlog & Nuevos Flows
+
+Este documento recopila de manera concisa ideas para expandir y agregar nuevos "flows" a la aplicación.
+
+### 1. Spotify Flow: Playlists basadas en "Likes"
+- **Idea**: Crear una playlist conformada exclusivamente por canciones similares a una canción de referencia (ej. "Take On Me"), filtrando únicamente entre la biblioteca de "Canciones que te gustan" (Likes) del usuario.
+
+### 2. Lyrics Flow: Interpretación de Letras
+- **Idea**: Agregar un botón de interpretación en la vista de letras. Al presionarlo, lanza un prompt básico (ej. "¿De qué habla esta letra?") utilizando la IA para generar una explicación del significado del tema.
+
+### 3. Expenses / Gastos Flow
+- **Idea**: Transformar una plantilla de Excel existente de registro de gastos en un módulo programado dentro de la app.
+- **Objetivo**: Crear un modelo de dominio sólido y sistematizar la carga y gestión del dinero.
+
+### 4. Art Flow (Mural / Diario)
+- **Idea**: Crear un "sub baúl" del baúl principal para volcar creatividad pura. No es un flujo con reglas estrictas.
+- **Objetivos**: Servir como diario, repositorio de escritos, terreno para improvisación computacional (fractales, rendering), y ser un espacio (mural/tablero) para tirar ideas sueltas en código y simplemente jugar.

--- a/docs/flows/llm/api-keys.md
+++ b/docs/flows/llm/api-keys.md
@@ -1,0 +1,120 @@
+# LLM API Keys — Getting Started
+
+Step-by-step guides for obtaining a free API key from each LLM provider.
+
+---
+
+## Gemini (Google AI Studio)
+
+> **Pricing:** Paid (trial gives $300 USD / 90 days)
+
+1. Go to [Google AI Studio](https://aistudio.google.com/)
+2. Sign in with your Google account
+3. Click **"Get API key"** in the top-right
+4. Click **"Create API key"** → select or create a Google Cloud project
+5. Copy the key
+
+```env
+GEMINI_API_KEY=AIza...
+```
+
+> **Note:** The free tier has very limited quotas (20-50 RPD for Flash). For higher quotas, activate billing (trial credits count).
+
+---
+
+## Groq
+
+> **Pricing:** Free, no credit card required
+
+1. Go to [console.groq.com](https://console.groq.com/)
+2. Sign up (Google, GitHub, or email)
+3. Go to **API Keys** in the left sidebar
+4. Click **"Create API Key"**
+5. Name it and copy the key
+
+```env
+GROQ_API_KEY=gsk_...
+```
+
+> **Free limits:** 14.4K RPD for 8B models, 1K RPD for 70B models, total 6K-30K TPM depending on model.
+
+---
+
+## OpenRouter
+
+> **Pricing:** Free for `:free` models. Optional $10 deposit (not consumed) unlocks 1K RPD.
+
+1. Go to [openrouter.ai](https://openrouter.ai/)
+2. Sign up (Google, GitHub, or email)
+3. Go to **Settings → API Keys**
+4. Click **"Create Key"**
+5. Copy the key
+
+```env
+OPENROUTER_API_KEY=sk-or-v1-...
+```
+
+> **Tip:** Append `:free` to model IDs for free routing (e.g. `meta-llama/llama-3.3-70b-instruct:free`). Without the suffix, requests use paid credits.
+
+---
+
+## Cerebras
+
+> **Pricing:** Free, 1M tokens/day, 30 RPM
+
+1. Go to [cloud.cerebras.ai](https://cloud.cerebras.ai/)
+2. Sign up (email verification)
+3. Navigate to **API Keys** in the dashboard
+4. Click **"Generate API Key"**
+5. Copy the key
+
+```env
+CEREBRAS_API_KEY=csk-...
+```
+
+> **Note:** All models share the 1M tokens/day pool. Cerebras inference is extremely fast (up to 2K tokens/sec on Llama 70B).
+
+---
+
+## Mistral (La Plateforme)
+
+> **Pricing:** Free "Experiment" plan. 1 req/sec, 50K TPM, ~4M tokens/month.
+
+1. Go to [console.mistral.ai](https://console.mistral.ai/)
+2. Sign up (email or GitHub)
+3. Go to **API Keys** in the left menu
+4. Click **"Create new key"**
+5. Copy the key
+
+```env
+MISTRAL_API_KEY=...
+```
+
+> **Tip:** `mistral-large` has its own quota pool (separate from standard models), giving you effectively double the capacity.
+
+---
+
+## Quick Test
+
+After setting any key, test it:
+
+```env
+LLM_PROVIDER=groq
+GROQ_API_KEY=gsk_your_key_here
+```
+
+Start the server and use the Chat flow to verify the provider responds.
+
+## Rotation
+
+To use all free providers in rotation mode:
+
+```env
+LLM_PROVIDER=rotation
+GROQ_API_KEY=gsk_...
+OPENROUTER_API_KEY=sk-or-v1-...
+CEREBRAS_API_KEY=csk-...
+MISTRAL_API_KEY=...
+```
+
+The client will round-robin through all configured providers, automatically skipping any that return 429 rate limit errors.

--- a/docs/flows/spotify/api-capabilities.md
+++ b/docs/flows/spotify/api-capabilities.md
@@ -1,0 +1,86 @@
+# Spotify Web API — Available Capabilities (Post Feb 2026)
+
+> Reference of what the Spotify API allows in Development Mode after the [February 2026 changes](https://developer.spotify.com/documentation/web-api/references/changes/february-2026).
+> Premium account required. Max 5 authorized users per Client ID.
+
+---
+
+## Library
+
+| Action | Endpoint | Status |
+|--------|----------|:------:|
+| Get Liked Songs | `GET /me/tracks` | ✅ Used |
+| Get Saved Albums | `GET /me/albums` | Available |
+| Get My Playlists | `GET /me/playlists` | Available |
+| Get Followed Artists | `GET /me/following` | Available |
+| Save items (any type) | `PUT /me/library` | Available |
+| Remove items | `DELETE /me/library` | Available |
+| Check if saved | `GET /me/library/contains` | Available |
+
+## Playlists (Full CRUD)
+
+| Action | Endpoint |
+|--------|----------|
+| Create playlist | `POST /me/playlists` |
+| Get playlist details | `GET /playlists/{id}` |
+| Get playlist items | `GET /playlists/{id}/items` |
+| Add items | `POST /playlists/{id}/items` |
+| Remove items | `DELETE /playlists/{id}/items` |
+| Reorder items | `PUT /playlists/{id}/items` |
+| Edit name/description | `PUT /playlists/{id}` |
+| Get/upload cover image | `GET/PUT /playlists/{id}/images` |
+
+## Metadata (Individual only)
+
+| Action | Endpoint | Status |
+|--------|----------|:------:|
+| Get artist (w/ genres) | `GET /artists/{id}` | ✅ Used (cached) |
+| Get artist albums | `GET /artists/{id}/albums` | Available |
+| Get album | `GET /albums/{id}` | Available |
+| Get album tracks | `GET /albums/{id}/tracks` | Available |
+| Get track | `GET /tracks/{id}` | Available |
+| Search | `GET /search` (max 10/page) | Available |
+
+> **Note:** All batch endpoints (`GET /artists`, `GET /tracks`, etc.) were removed. Use individual endpoints.
+
+## Player (Playback Control)
+
+| Action | Endpoint |
+|--------|----------|
+| Playback state | `GET /me/player` |
+| Currently playing | `GET /me/player/currently-playing` |
+| Recently played | `GET /me/player/recently-played` |
+| Play / Pause | `PUT .../play`, `PUT .../pause` |
+| Next / Previous | `POST .../next`, `POST .../previous` |
+| Add to queue | `POST /me/player/queue` |
+| View queue | `GET /me/player/queue` |
+| Volume / Shuffle / Repeat / Seek | `PUT .../volume`, `shuffle`, `repeat`, `seek` |
+| Available devices | `GET /me/player/devices` |
+| Transfer playback | `PUT /me/player` |
+
+## User & Personalization
+
+| Action | Endpoint |
+|--------|----------|
+| My profile | `GET /me` |
+| Top artists/tracks (by period) | `GET /me/top/{type}` |
+
+---
+
+## Removed (Do Not Use)
+
+- All batch endpoints (`GET /artists`, `GET /tracks`, `GET /albums`, etc.)
+- `GET /artists/{id}/top-tracks`
+- `GET /browse/*` (categories, new releases)
+- `GET /users/{id}` (other users' profiles/playlists)
+- Fields: `popularity`, `followers` (artist), `available_markets`, `external_ids`, `linked_from`
+
+---
+
+## Feature Ideas
+
+1. **Auto-curated playlists** — Use cached genre data to group liked songs into playlists
+2. **Top Artists dashboard** — `GET /me/top/{type}` with `short_term`, `medium_term`, `long_term`
+3. **Now Playing widget** — Real-time display via `GET /me/player/currently-playing`
+4. **Listening history** — `GET /me/player/recently-played` for pattern tracking
+5. **Smart search + playlist builder** — Search → curate → create playlist

--- a/docs/flows/spotify/getting-started.md
+++ b/docs/flows/spotify/getting-started.md
@@ -62,8 +62,8 @@ Click **"Sync with Spotify"** to fetch your liked songs.
 The sync process:
 
 1. Fetches all liked tracks (paginated)
-2. Enriches with artist genres and images
-3. Stores in `data/flow.db` (SQLite)
+2. Enriches with artist genres and images (cached in SQLite for performance)
+3. Stores in `data/music.db` (SQLite)
 4. Rebuilds the full-text search index
 
 ---
@@ -76,7 +76,7 @@ The sync process:
 | ------- | ----------- |
 | **Infinite Scroll** | Scroll to load more tracks automatically |
 | **Search** | Real-time full-text search (title, artist, album) |
-| **Filters** | Genre, Year, Popularity, Sort order |
+| **Filters** | Genre, Year, Sort order |
 | **Track Cards** | Album art, artist avatar, genre badges, Spotify link |
 
 ### Insights (Charts)
@@ -107,5 +107,5 @@ The sync process:
 | `pnpm -r run lint` | Lint all packages |
 | `pnpm -r run check` | Type-check all packages |
 | `pnpm -r run test` | Run all tests |
-| `pnpm --filter @flows/backend test` | Run backend tests only |
+| `pnpm --filter @flows/spotify test` | Run Spotify tests only |
 | `pnpm --filter @flows/ui test:e2e` | Run Playwright E2E tests |

--- a/packages/backend/src/api/app.ts
+++ b/packages/backend/src/api/app.ts
@@ -51,12 +51,12 @@ export const app = new Elysia({ adapter: node() })
   .use(
     hasUiDist
       ? staticPlugin({
-        assets: uiDistPath,
-        prefix: '/',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
+          assets: uiDistPath,
+          prefix: '/',
+          headers: {
+            'Cache-Control': 'no-cache',
+          },
+        })
       : new Elysia(),
   )
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,17 +1,95 @@
 # @flows/core
 
-Shared infrastructure utilities for the Flow monorepo.
+Shared infrastructure for the Flow monorepo.
 
 ## What's Inside
 
-- **Logger** — Pre-configured [Pino](https://getpino.io/) logger with pretty-print for development
-- **Shared utilities** — Common helpers used across flow packages
+| Module | Import | Description |
+| ------ | ------ | ----------- |
+| Logger | `@flows/core/logger` | Pre-configured [Pino](https://getpino.io/) logger |
+| Cache | `@flows/core/cache` | In-memory `SimpleCache` with TTL |
+| Database | `@flows/core/db` | SQLite via `better-sqlite3` |
+| LLM | `@flows/core/llm` | Multi-provider LLM client |
 
-## Usage
+## LLM Module
 
-```ts
-import { logger } from '@flows/core';
+Unified interface for 5 LLM providers with a model catalog, tier system, and free-provider rotation.
 
-const log = logger.child({ module: 'MyModule' });
-log.info('Hello from MyModule');
+### Providers
+
+| Provider | Pricing | Env Var | Highlights |
+| -------- | ------- | ------- | ---------- |
+| **Gemini** | paid | `GEMINI_API_KEY` | Google AI Studio / Vertex. Frontier models. |
+| **Groq** | free | `GROQ_API_KEY` | Ultra-fast LPU inference. |
+| **OpenRouter** | free | `OPENROUTER_API_KEY` | Aggregator, 24+ free models. |
+| **Cerebras** | free | `CEREBRAS_API_KEY` | 1M tokens/day, fast inference. |
+| **Mistral** | free | `MISTRAL_API_KEY` | 4M tokens/month experiment tier. |
+
+### Model Tiers
+
+Each model in the catalog has a `tier` and `pricing`:
+
+- **`very_high`** — Frontier (Gemini 3.1 Pro, GPT-5, etc.)
+- **`high`** — Near-frontier (Llama 3.3 70B, Qwen 235B, Mistral Large)
+- **`medium`** — Solid generalist (Qwen 32B, Codestral, Llama 4 Scout)
+- **`low`** — Fast & lightweight (Llama 3.1 8B, Gemma 4B, Mistral Nemo)
+
+### Usage
+
+```typescript
+import { createLLMClient } from '@flows/core';
+
+// Uses LLM_PROVIDER env var (default: gemini)
+const client = createLLMClient();
+const response = await client.generate({
+    messages: [{ role: 'user', content: 'Hello!' }],
+});
+console.log(response.content);   // "Hi there!"
+console.log(response.provider);  // "gemini"
+console.log(response.model);     // "gemini-2.5-flash"
+```
+
+**Direct mode** — target a specific provider:
+
+```typescript
+import { LLMClient } from '@flows/core';
+
+const client = new LLMClient('groq');
+```
+
+**Rotation mode** — round-robin across free providers (auto-fallback on 429):
+
+```typescript
+const client = LLMClient.createRotation();
+// Or via env: LLM_PROVIDER=rotation
+```
+
+### File Structure
+
+```
+src/llm/
+├── llm-client.ts           # LLMClient class
+├── index.ts                # Barrel + createLLMClient()
+└── providers/
+    ├── types.ts            # LLMMessage, ModelInfo, ModelTier, etc.
+    ├── base-provider.ts    # Abstract BaseLLMProvider
+    ├── gemini/             # @google/genai SDK
+    ├── groq/               # OpenAI-compatible (fetch)
+    ├── openrouter/         # OpenAI-compatible (fetch)
+    ├── cerebras/           # OpenAI-compatible (fetch)
+    └── mistral/            # OpenAI-compatible (fetch)
+```
+
+### Getting API Keys
+
+See [docs/flows/llm/api-keys.md](../../docs/flows/llm/api-keys.md) for step-by-step guides.
+
+## Quick Start
+
+```typescript
+import { logger, createLLMClient, SimpleCache } from '@flows/core';
+
+const log = logger.child({ module: 'MyFlow' });
+const llm = createLLMClient();
+const cache = new SimpleCache<string>(300); // 5 min TTL
 ```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,16 +6,27 @@ export { logger } from './logger';
 // Cache
 export { SimpleCache } from './cache';
 
-// LLM
+// LLM — Client
 export { LLMClient, createLLMClient, type LLMProviderType } from './llm';
-export {
-    BaseLLMProvider,
-    type LLMMessage,
-    type LLMRequest,
-    type LLMResponse,
-    type LLMUsage,
+
+// LLM — Types
+export type {
+    LLMMessage,
+    LLMRequest,
+    LLMResponse,
+    LLMUsage,
+    ModelTier,
+    ModelPricing,
+    ModelInfo,
 } from './llm/providers';
+
+// LLM — Providers
+export { BaseLLMProvider } from './llm/providers';
 export { GeminiProvider } from './llm/providers';
+export { GroqProvider } from './llm/providers';
+export { OpenRouterProvider } from './llm/providers';
+export { CerebrasProvider } from './llm/providers';
+export { MistralProvider } from './llm/providers';
 
 // Database
 export { createDatabase } from './db';

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -1,99 +1,54 @@
-import { BaseLLMProvider, type LLMRequest, type LLMResponse } from './providers/base-provider';
-import { GeminiProvider } from './providers/gemini-provider';
-
-export type LLMProviderType = 'gemini' | 'groq' | 'openai';
-
 /**
- * LLMClient: Factory for creating LLM provider instances.
+ * @flows/core/llm — Entry point
  *
- * Usage:
- * ```ts
- * const client = new LLMClient('gemini', process.env.GEMINI_API_KEY!);
- * const response = await client.generate({ messages: [...] });
- * ```
+ * Re-exports the LLMClient, factory, types, and all providers.
  */
-export class LLMClient {
-    private provider: BaseLLMProvider;
 
-    constructor(providerType: LLMProviderType = 'gemini', apiKey?: string) {
-        const key = apiKey || this.getApiKeyForProvider(providerType);
+// ── Client ───────────────────────────────────────────────────────────
+export { LLMClient, type LLMProviderType } from './llm-client';
 
-        if (!key) {
-            throw new Error(
-                `API key not found for provider: ${providerType}. Set the appropriate environment variable.`,
-            );
-        }
-
-        switch (providerType) {
-            case 'gemini':
-                this.provider = new GeminiProvider(key);
-                break;
-            case 'groq':
-                // Groq provider not implemented yet, fall back to Gemini
-                console.warn('[LLMClient] Groq provider not implemented, falling back to Gemini');
-                this.provider = new GeminiProvider(key);
-                break;
-            case 'openai':
-                // OpenAI provider not implemented yet, fall back to Gemini
-                console.warn('[LLMClient] OpenAI provider not implemented, falling back to Gemini');
-                this.provider = new GeminiProvider(key);
-                break;
-            default:
-                throw new Error(`Unsupported LLM provider: ${providerType}`);
-        }
-    }
-
-    /**
-     * Generate a completion from the LLM.
-     */
-    async generate(request: LLMRequest): Promise<LLMResponse> {
-        return this.provider.generate(request);
-    }
-
-    /**
-     * List available models dynamically from the provider.
-     */
-    async listModels(): Promise<string[]> {
-        return this.provider.listModels();
-    }
-
-    /**
-     * Get the default model for the current provider.
-     */
-    get defaultModel(): string {
-        return this.provider.defaultModel;
-    }
-
-    /**
-     * Get the provider name.
-     */
-    get providerName(): string {
-        return this.provider.providerName;
-    }
-
-    /**
-     * Get API key from environment variables based on provider type.
-     */
-    private getApiKeyForProvider(providerType: LLMProviderType): string | undefined {
-        switch (providerType) {
-            case 'gemini':
-                return process.env.GEMINI_API_KEY;
-            case 'groq':
-                return process.env.GROQ_API_KEY;
-            case 'openai':
-                return process.env.OPENAI_API_KEY;
-            default:
-                return undefined;
-        }
-    }
-}
+// ── Factory ──────────────────────────────────────────────────────────
+import { LLMClient, type LLMProviderType } from './llm-client';
 
 /**
- * Create an LLMClient using environment variables for configuration.
+ * Create an LLMClient using environment variables.
+ *
+ * - LLM_PROVIDER=rotation → rotates across free providers
+ * - LLM_PROVIDER=groq     → uses Groq directly
+ * - Defaults to gemini
  */
 export function createLLMClient(): LLMClient {
-    const providerType = (process.env.LLM_PROVIDER || 'gemini') as LLMProviderType;
-    return new LLMClient(providerType);
+    const providerType = process.env.LLM_PROVIDER || 'gemini';
+
+    if (providerType === 'rotation') {
+        return LLMClient.createRotation();
+    }
+
+    return new LLMClient(providerType as LLMProviderType);
 }
 
-export default LLMClient;
+// ── Types ────────────────────────────────────────────────────────────
+export type {
+    LLMMessage,
+    LLMRequest,
+    LLMResponse,
+    LLMUsage,
+    ModelTier,
+    ModelPricing,
+    ModelInfo,
+} from './providers/types';
+
+// ── Providers ────────────────────────────────────────────────────────
+export { BaseLLMProvider } from './providers/base-provider';
+export { GeminiProvider } from './providers/gemini/gemini-provider';
+export { GroqProvider } from './providers/groq/groq-provider';
+export { OpenRouterProvider } from './providers/openrouter/openrouter-provider';
+export { CerebrasProvider } from './providers/cerebras/cerebras-provider';
+export { MistralProvider } from './providers/mistral/mistral-provider';
+
+// ── Model catalogs ──────────────────────────────────────────────────
+export { GEMINI_MODELS } from './providers/gemini/models';
+export { GROQ_MODELS } from './providers/groq/models';
+export { OPENROUTER_MODELS } from './providers/openrouter/models';
+export { CEREBRAS_MODELS } from './providers/cerebras/models';
+export { MISTRAL_MODELS } from './providers/mistral/models';

--- a/packages/core/src/llm/llm-client.ts
+++ b/packages/core/src/llm/llm-client.ts
@@ -1,4 +1,4 @@
-import type { LLMRequest, LLMResponse, ModelInfo } from './providers/types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, ModelInfo } from './providers/types';
 import { BaseLLMProvider } from './providers/base-provider';
 import { GeminiProvider } from './providers/gemini/gemini-provider';
 import { GroqProvider } from './providers/groq/groq-provider';
@@ -94,6 +94,15 @@ export class LLMClient {
         return this.provider.generate(request);
     }
 
+    /** Generate a streaming completion. Yields text deltas, then a final done event. */
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        if (this.rotationProviders) {
+            yield* this.generateStreamWithRotation(request);
+        } else {
+            yield* this.provider.generateStream(request);
+        }
+    }
+
     /** List available models dynamically from the current provider. */
     async listModels(): Promise<string[]> {
         return this.provider.listModels();
@@ -159,6 +168,23 @@ export class LLMClient {
         providerAndModel: string,
         request: LLMRequest,
     ): Promise<LLMResponse> {
+        const { provider, modelId } = LLMClient.parseProviderModel(providerAndModel);
+        return provider.generate({ ...request, model: modelId });
+    }
+
+    /**
+     * One-shot streaming generate with a specific provider + model.
+     * Parses "provider:model" format.
+     */
+    static async *generateStreamForProvider(
+        providerAndModel: string,
+        request: LLMRequest,
+    ): AsyncGenerator<LLMStreamEvent> {
+        const { provider, modelId } = LLMClient.parseProviderModel(providerAndModel);
+        yield* provider.generateStream({ ...request, model: modelId });
+    }
+
+    private static parseProviderModel(providerAndModel: string): { provider: BaseLLMProvider; modelId: string } {
         const colonIdx = providerAndModel.indexOf(':');
         if (colonIdx === -1) {
             throw new Error(
@@ -174,8 +200,7 @@ export class LLMClient {
             throw new Error(`API key not configured for provider: ${providerType}`);
         }
 
-        const provider = LLMClient.getOrCreateProvider(providerType, key);
-        return provider.generate({ ...request, model: modelId });
+        return { provider: LLMClient.getOrCreateProvider(providerType, key), modelId };
     }
 
     private static getOrCreateProvider(type: LLMProviderType, apiKey: string): BaseLLMProvider {
@@ -200,7 +225,6 @@ export class LLMClient {
 
             try {
                 const response = await provider.generate(request);
-                // Advance to next provider for next call (round-robin)
                 this.rotationIndex = (idx + 1) % providers.length;
                 this.provider = providers[this.rotationIndex];
                 return response;
@@ -217,6 +241,42 @@ export class LLMClient {
 
         throw new Error(
             `[LLMClient] All ${providers.length} rotation providers failed. ` +
+            `Last error: ${lastError?.message}`,
+        );
+    }
+
+    private async *generateStreamWithRotation(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const providers = this.rotationProviders!;
+        const startIdx = this.rotationIndex;
+        let lastError: Error | null = null;
+
+        for (let i = 0; i < providers.length; i++) {
+            const idx = (startIdx + i) % providers.length;
+            const provider = providers[idx];
+
+            try {
+                const gen = provider.generateStream(request);
+                let started = false;
+
+                for await (const event of gen) {
+                    started = true;
+                    yield event;
+                }
+
+                if (started) {
+                    this.rotationIndex = (idx + 1) % providers.length;
+                    this.provider = providers[this.rotationIndex];
+                    return;
+                }
+            } catch (error) {
+                const errMsg = error instanceof Error ? error.message : String(error);
+                console.warn(`[LLMClient] ${provider.providerName} stream failed: ${errMsg}`);
+                lastError = error instanceof Error ? error : new Error(errMsg);
+            }
+        }
+
+        throw new Error(
+            `[LLMClient] All ${providers.length} rotation providers failed (stream). ` +
             `Last error: ${lastError?.message}`,
         );
     }

--- a/packages/core/src/llm/llm-client.ts
+++ b/packages/core/src/llm/llm-client.ts
@@ -125,6 +125,68 @@ export class LLMClient {
         return this.rotationProviders !== null;
     }
 
+    // ── Static helpers for per-request usage ─────────────────────────
+
+    /** Cache of provider instances by type (avoids re-creating on every call). */
+    private static providerCache = new Map<LLMProviderType, BaseLLMProvider>();
+
+    /**
+     * Get model catalogs grouped by provider.
+     * Returns all providers that have API keys configured.
+     */
+    static getModelCatalogGrouped(): { provider: string; models: ModelInfo[] }[] {
+        const groups: { provider: string; models: ModelInfo[] }[] = [];
+        const ALL_PROVIDERS: LLMProviderType[] = ['gemini', 'groq', 'openrouter', 'cerebras', 'mistral'];
+
+        for (const type of ALL_PROVIDERS) {
+            const key = getApiKeyForProvider(type);
+            if (!key) continue;
+
+            const provider = LLMClient.getOrCreateProvider(type, key);
+            groups.push({
+                provider: provider.providerName,
+                models: provider.listModelCatalog(),
+            });
+        }
+        return groups;
+    }
+
+    /**
+     * One-shot generate with a specific provider + model.
+     * Parses "provider:model" format (e.g. "groq:llama-3.3-70b-versatile").
+     */
+    static async generateForProvider(
+        providerAndModel: string,
+        request: LLMRequest,
+    ): Promise<LLMResponse> {
+        const colonIdx = providerAndModel.indexOf(':');
+        if (colonIdx === -1) {
+            throw new Error(
+                `Invalid model format "${providerAndModel}". Expected "provider:model" (e.g. "groq:llama-3.3-70b-versatile").`,
+            );
+        }
+
+        const providerType = providerAndModel.slice(0, colonIdx) as LLMProviderType;
+        const modelId = providerAndModel.slice(colonIdx + 1);
+
+        const key = getApiKeyForProvider(providerType);
+        if (!key) {
+            throw new Error(`API key not configured for provider: ${providerType}`);
+        }
+
+        const provider = LLMClient.getOrCreateProvider(providerType, key);
+        return provider.generate({ ...request, model: modelId });
+    }
+
+    private static getOrCreateProvider(type: LLMProviderType, apiKey: string): BaseLLMProvider {
+        let provider = LLMClient.providerCache.get(type);
+        if (!provider) {
+            provider = createProviderInstance(type, apiKey);
+            LLMClient.providerCache.set(type, provider);
+        }
+        return provider;
+    }
+
     // ── Private ──────────────────────────────────────────────────────
 
     private async generateWithRotation(request: LLMRequest): Promise<LLMResponse> {

--- a/packages/core/src/llm/llm-client.ts
+++ b/packages/core/src/llm/llm-client.ts
@@ -1,0 +1,202 @@
+import type { LLMRequest, LLMResponse, ModelInfo } from './providers/types';
+import { BaseLLMProvider } from './providers/base-provider';
+import { GeminiProvider } from './providers/gemini/gemini-provider';
+import { GroqProvider } from './providers/groq/groq-provider';
+import { OpenRouterProvider } from './providers/openrouter/openrouter-provider';
+import { CerebrasProvider } from './providers/cerebras/cerebras-provider';
+import { MistralProvider } from './providers/mistral/mistral-provider';
+
+export type LLMProviderType = 'gemini' | 'groq' | 'openrouter' | 'cerebras' | 'mistral';
+
+// ── Free provider rotation order ─────────────────────────────────────
+const FREE_ROTATION_ORDER: LLMProviderType[] = ['groq', 'openrouter', 'cerebras', 'mistral'];
+
+/**
+ * LLMClient: Factory & facade for LLM providers.
+ *
+ * Two modes of operation:
+ *
+ * 1. **Direct** — Use a specific provider + model:
+ *    ```ts
+ *    const client = new LLMClient('groq');
+ *    const res = await client.generate({ messages: [...] });
+ *    ```
+ *
+ * 2. **Rotation** — Cycle through free providers on 429/error:
+ *    ```ts
+ *    const client = LLMClient.createRotation();
+ *    const res = await client.generate({ messages: [...] });
+ *    // res.provider tells you which one answered
+ *    ```
+ */
+export class LLMClient {
+    private provider: BaseLLMProvider;
+    private rotationProviders: BaseLLMProvider[] | null = null;
+    private rotationIndex = 0;
+
+    constructor(providerType: LLMProviderType = 'gemini', apiKey?: string) {
+        const key = apiKey || getApiKeyForProvider(providerType);
+
+        if (!key) {
+            throw new Error(
+                `API key not found for provider: ${providerType}. ` +
+                `Set the env var: ${getEnvVarName(providerType)}.`,
+            );
+        }
+
+        this.provider = createProviderInstance(providerType, key);
+    }
+
+    // ── Rotation factory ─────────────────────────────────────────────
+
+    /**
+     * Create an LLMClient that rotates through all configured free providers.
+     * On 429 or error, it tries the next provider in the list.
+     * Only providers with API keys set in env will be included.
+     */
+    static createRotation(): LLMClient {
+        const providers: BaseLLMProvider[] = [];
+
+        for (const type of FREE_ROTATION_ORDER) {
+            const key = getApiKeyForProvider(type);
+            if (key) {
+                providers.push(createProviderInstance(type, key));
+            }
+        }
+
+        if (providers.length === 0) {
+            throw new Error(
+                `[LLMClient] No free providers configured. Set at least one of: ` +
+                FREE_ROTATION_ORDER.map((t) => getEnvVarName(t)).join(', '),
+            );
+        }
+
+        // Use first provider as initial, rotation will cycle through all
+        const client = Object.create(LLMClient.prototype) as LLMClient;
+        client.provider = providers[0];
+        client.rotationProviders = providers;
+        client.rotationIndex = 0;
+
+        console.log(
+            `[LLMClient] Rotation mode with ${providers.length} providers: ` +
+            providers.map((p) => p.providerName).join(' → '),
+        );
+        return client;
+    }
+
+    // ── Core methods ─────────────────────────────────────────────────
+
+    /** Generate a completion. In rotation mode, retries with next provider on failure. */
+    async generate(request: LLMRequest): Promise<LLMResponse> {
+        if (this.rotationProviders) {
+            return this.generateWithRotation(request);
+        }
+        return this.provider.generate(request);
+    }
+
+    /** List available models dynamically from the current provider. */
+    async listModels(): Promise<string[]> {
+        return this.provider.listModels();
+    }
+
+    /** Get the static model catalog from the current provider. */
+    listModelCatalog(): ModelInfo[] {
+        return this.provider.listModelCatalog();
+    }
+
+    /** Get all model catalogs across all rotation providers (or just the current one). */
+    listAllModelCatalogs(): ModelInfo[] {
+        if (this.rotationProviders) {
+            return this.rotationProviders.flatMap((p) => p.listModelCatalog());
+        }
+        return this.provider.listModelCatalog();
+    }
+
+    get defaultModel(): string {
+        return this.provider.defaultModel;
+    }
+
+    get providerName(): string {
+        return this.provider.providerName;
+    }
+
+    /** Whether this client is in rotation mode. */
+    get isRotation(): boolean {
+        return this.rotationProviders !== null;
+    }
+
+    // ── Private ──────────────────────────────────────────────────────
+
+    private async generateWithRotation(request: LLMRequest): Promise<LLMResponse> {
+        const providers = this.rotationProviders!;
+        const startIdx = this.rotationIndex;
+        let lastError: Error | null = null;
+
+        for (let i = 0; i < providers.length; i++) {
+            const idx = (startIdx + i) % providers.length;
+            const provider = providers[idx];
+
+            try {
+                const response = await provider.generate(request);
+                // Advance to next provider for next call (round-robin)
+                this.rotationIndex = (idx + 1) % providers.length;
+                this.provider = providers[this.rotationIndex];
+                return response;
+            } catch (error) {
+                const errMsg = error instanceof Error ? error.message : String(error);
+                const is429 = errMsg.includes('429') || errMsg.includes('rate');
+                console.warn(
+                    `[LLMClient] ${provider.providerName} failed` +
+                    `${is429 ? ' (rate limited)' : ''}: ${errMsg}`,
+                );
+                lastError = error instanceof Error ? error : new Error(errMsg);
+            }
+        }
+
+        throw new Error(
+            `[LLMClient] All ${providers.length} rotation providers failed. ` +
+            `Last error: ${lastError?.message}`,
+        );
+    }
+}
+
+// ── Helpers (module-level) ───────────────────────────────────────────
+
+function createProviderInstance(type: LLMProviderType, apiKey: string): BaseLLMProvider {
+    switch (type) {
+        case 'gemini':
+            return new GeminiProvider(apiKey);
+        case 'groq':
+            return new GroqProvider(apiKey);
+        case 'openrouter':
+            return new OpenRouterProvider(apiKey);
+        case 'cerebras':
+            return new CerebrasProvider(apiKey);
+        case 'mistral':
+            return new MistralProvider(apiKey);
+        default:
+            throw new Error(`Unsupported LLM provider: ${type}`);
+    }
+}
+
+function getApiKeyForProvider(providerType: LLMProviderType): string | undefined {
+    const envMap: Record<LLMProviderType, string> = {
+        gemini: 'GEMINI_API_KEY',
+        groq: 'GROQ_API_KEY',
+        openrouter: 'OPENROUTER_API_KEY',
+        cerebras: 'CEREBRAS_API_KEY',
+        mistral: 'MISTRAL_API_KEY',
+    };
+    return process.env[envMap[providerType]];
+}
+
+function getEnvVarName(type: LLMProviderType): string {
+    const envMap: Record<LLMProviderType, string> = {
+        gemini: 'GEMINI_API_KEY',
+        groq: 'GROQ_API_KEY',
+        openrouter: 'OPENROUTER_API_KEY',
+        cerebras: 'CEREBRAS_API_KEY',
+        mistral: 'MISTRAL_API_KEY',
+    };
+    return envMap[type];
+}

--- a/packages/core/src/llm/providers/base-provider.ts
+++ b/packages/core/src/llm/providers/base-provider.ts
@@ -5,7 +5,7 @@
  * Enables provider-agnostic LLM calls across all flows.
  */
 
-import type { LLMRequest, LLMResponse, ModelInfo } from './types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, ModelInfo } from './types';
 
 export abstract class BaseLLMProvider {
     protected apiKey: string;
@@ -16,6 +16,18 @@ export abstract class BaseLLMProvider {
 
     /** Generate a completion from the LLM. */
     abstract generate(request: LLMRequest): Promise<LLMResponse>;
+
+    /**
+     * Generate a streaming completion from the LLM.
+     * Yields text deltas, then a final event with the complete response.
+     *
+     * Default implementation: falls back to `generate()` and yields the full content at once.
+     */
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const response = await this.generate(request);
+        yield { delta: response.content, done: false };
+        yield { delta: '', done: true, response };
+    }
 
     /** Get the default model for this provider. */
     abstract get defaultModel(): string;

--- a/packages/core/src/llm/providers/base-provider.ts
+++ b/packages/core/src/llm/providers/base-provider.ts
@@ -1,39 +1,12 @@
 /**
- * Base LLM Provider Interface
+ * Base LLM Provider
  *
- * Abstract interface for all LLM providers (Gemini, Groq, OpenAI, etc.)
+ * Abstract class for all LLM providers (Gemini, Groq, OpenRouter, etc.)
  * Enables provider-agnostic LLM calls across all flows.
  */
 
-export interface LLMMessage {
-    role: 'system' | 'user' | 'assistant';
-    content: string;
-}
+import type { LLMRequest, LLMResponse, ModelInfo } from './types';
 
-export interface LLMRequest {
-    messages: LLMMessage[];
-    temperature?: number;
-    maxTokens?: number;
-    model?: string; // Optional override for default model
-}
-
-export interface LLMUsage {
-    inputTokens: number;
-    outputTokens: number;
-    totalTokens: number;
-}
-
-export interface LLMResponse {
-    content: string;
-    model: string;
-    usage: LLMUsage;
-    latencyMs: number;
-}
-
-/**
- * Abstract base class for LLM providers.
- * All providers must implement the generate method.
- */
 export abstract class BaseLLMProvider {
     protected apiKey: string;
 
@@ -41,25 +14,20 @@ export abstract class BaseLLMProvider {
         this.apiKey = apiKey;
     }
 
-    /**
-     * Generate a completion from the LLM.
-     */
+    /** Generate a completion from the LLM. */
     abstract generate(request: LLMRequest): Promise<LLMResponse>;
 
-    /**
-     * Get the default model for this provider.
-     */
+    /** Get the default model for this provider. */
     abstract get defaultModel(): string;
 
-    /**
-     * Get the provider name.
-     */
+    /** Get the provider name. */
     abstract get providerName(): string;
 
-    /**
-     * List dynamically fetchable models from this provider, if supported.
-     */
+    /** List dynamically fetchable models from this provider, if supported. */
     abstract listModels(): Promise<string[]>;
+
+    /** Get the static model catalog with tier/pricing metadata. */
+    abstract listModelCatalog(): ModelInfo[];
 }
 
 export default BaseLLMProvider;

--- a/packages/core/src/llm/providers/cerebras/cerebras-provider.ts
+++ b/packages/core/src/llm/providers/cerebras/cerebras-provider.ts
@@ -1,0 +1,78 @@
+import { BaseLLMProvider } from '../base-provider';
+import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import { CEREBRAS_MODELS, CEREBRAS_DEFAULT_MODEL, CEREBRAS_BASE_URL } from './models';
+
+/**
+ * Cerebras LLM Provider
+ *
+ * Fast inference via OpenAI-compatible API.
+ * Free tier: 1M tokens/day, 30 RPM.
+ */
+export class CerebrasProvider extends BaseLLMProvider {
+    private _defaultModel: string;
+    private baseUrl: string;
+
+    constructor(apiKey: string) {
+        super(apiKey);
+        this._defaultModel = process.env.LLM_MODEL || CEREBRAS_DEFAULT_MODEL;
+        this.baseUrl = CEREBRAS_BASE_URL;
+        console.log(`[CerebrasProvider] Initialized with model: ${this._defaultModel}`);
+    }
+
+    get defaultModel(): string {
+        return this._defaultModel;
+    }
+
+    get providerName(): string {
+        return 'cerebras';
+    }
+
+    async generate(request: LLMRequest): Promise<LLMResponse> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[CerebrasProvider] API error ${response.status}: ${error}`);
+        }
+
+        const data = await response.json();
+        const latencyMs = Date.now() - startTime;
+
+        return {
+            content: data.choices?.[0]?.message?.content ?? '',
+            model: data.model ?? modelName,
+            provider: this.providerName,
+            usage: {
+                inputTokens: data.usage?.prompt_tokens ?? 0,
+                outputTokens: data.usage?.completion_tokens ?? 0,
+                totalTokens: data.usage?.total_tokens ?? 0,
+            },
+            latencyMs,
+        };
+    }
+
+    async listModels(): Promise<string[]> {
+        return CEREBRAS_MODELS.map((m) => m.id);
+    }
+
+    listModelCatalog(): ModelInfo[] {
+        return CEREBRAS_MODELS;
+    }
+}
+
+export default CerebrasProvider;

--- a/packages/core/src/llm/providers/cerebras/cerebras-provider.ts
+++ b/packages/core/src/llm/providers/cerebras/cerebras-provider.ts
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from '../base-provider';
-import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, ModelInfo } from '../types';
+import { parseOpenAIStream } from '../stream-parser';
 import { CEREBRAS_MODELS, CEREBRAS_DEFAULT_MODEL, CEREBRAS_BASE_URL } from './models';
 
 /**
@@ -64,6 +65,33 @@ export class CerebrasProvider extends BaseLLMProvider {
             },
             latencyMs,
         };
+    }
+
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+                stream: true,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[CerebrasProvider] API error ${response.status}: ${error}`);
+        }
+
+        yield* parseOpenAIStream(response, this.providerName, modelName, startTime);
     }
 
     async listModels(): Promise<string[]> {

--- a/packages/core/src/llm/providers/cerebras/models.ts
+++ b/packages/core/src/llm/providers/cerebras/models.ts
@@ -4,42 +4,45 @@ import type { ModelInfo } from '../types';
  * Cerebras model catalog — Fast inference
  *
  * Free tier: 1M tokens/day, 30 RPM, 60K TPM. No credit card.
+ * Docs: https://inference-docs.cerebras.ai/models/overview
  * Base URL: https://api.cerebras.ai
  */
 export const CEREBRAS_MODELS: ModelInfo[] = [
+    // ── Production ──
     {
-        id: 'qwen-3-235b-a22b',
+        id: 'gpt-oss-120b',
+        name: 'GPT-OSS 120B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'OpenAI open-weight, fastest on Cerebras.',
+    },
+    {
+        id: 'llama3.1-8b',
+        name: 'Llama 3.1 8B',
+        tier: 'low',
+        pricing: 'free',
+        contextWindow: 8_192,
+        description: 'Ultra-fast lightweight. ~2K tokens/sec.',
+    },
+    // ── Preview ──
+    {
+        id: 'qwen-3-235b-a22b-instruct-2507',
         name: 'Qwen 3 235B',
         tier: 'high',
         pricing: 'free',
         contextWindow: 65_536,
-        description: 'Largest free model. MoE 22B active. Strong reasoning.',
+        description: 'Preview. Largest free model, MoE 22B active.',
     },
     {
-        id: 'llama-3.3-70b',
-        name: 'Llama 3.3 70B',
-        tier: 'high',
-        pricing: 'free',
-        contextWindow: 8_192,
-        description: 'Strong generalist. Limited context on Cerebras.',
-    },
-    {
-        id: 'llama-4-scout-17b-16e',
-        name: 'Llama 4 Scout',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 65_536,
-        description: 'MoE 16 experts. Large context window.',
-    },
-    {
-        id: 'qwen-3-32b',
-        name: 'Qwen 3 32B',
+        id: 'zai-glm-4.7',
+        name: 'Z.ai GLM 4.7',
         tier: 'medium',
         pricing: 'free',
         contextWindow: 32_768,
-        description: 'Solid multilingual generalist.',
+        description: 'Preview. Z.ai / GLM 4.7 foundation model.',
     },
 ];
 
-export const CEREBRAS_DEFAULT_MODEL = 'llama-3.3-70b';
+export const CEREBRAS_DEFAULT_MODEL = 'llama3.1-8b';
 export const CEREBRAS_BASE_URL = 'https://api.cerebras.ai';

--- a/packages/core/src/llm/providers/cerebras/models.ts
+++ b/packages/core/src/llm/providers/cerebras/models.ts
@@ -1,0 +1,45 @@
+import type { ModelInfo } from '../types';
+
+/**
+ * Cerebras model catalog — Fast inference
+ *
+ * Free tier: 1M tokens/day, 30 RPM, 60K TPM. No credit card.
+ * Base URL: https://api.cerebras.ai
+ */
+export const CEREBRAS_MODELS: ModelInfo[] = [
+    {
+        id: 'qwen-3-235b-a22b',
+        name: 'Qwen 3 235B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 65_536,
+        description: 'Largest free model. MoE 22B active. Strong reasoning.',
+    },
+    {
+        id: 'llama-3.3-70b',
+        name: 'Llama 3.3 70B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 8_192,
+        description: 'Strong generalist. Limited context on Cerebras.',
+    },
+    {
+        id: 'llama-4-scout-17b-16e',
+        name: 'Llama 4 Scout',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 65_536,
+        description: 'MoE 16 experts. Large context window.',
+    },
+    {
+        id: 'qwen-3-32b',
+        name: 'Qwen 3 32B',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 32_768,
+        description: 'Solid multilingual generalist.',
+    },
+];
+
+export const CEREBRAS_DEFAULT_MODEL = 'llama-3.3-70b';
+export const CEREBRAS_BASE_URL = 'https://api.cerebras.ai';

--- a/packages/core/src/llm/providers/cerebras/models.ts
+++ b/packages/core/src/llm/providers/cerebras/models.ts
@@ -35,12 +35,12 @@ export const CEREBRAS_MODELS: ModelInfo[] = [
         description: 'Preview. Largest free model, MoE 22B active.',
     },
     {
-        id: 'zai-glm-4.7',
-        name: 'Z.ai GLM 4.7',
-        tier: 'medium',
+        id: 'qwen-3-235b-a22b-instruct-2507',
+        name: 'Qwen 3 235B',
+        tier: 'high',
         pricing: 'free',
-        contextWindow: 32_768,
-        description: 'Preview. Z.ai / GLM 4.7 foundation model.',
+        contextWindow: 65_536,
+        description: 'Preview. Largest free model, MoE 22B active.',
     },
 ];
 

--- a/packages/core/src/llm/providers/gemini/gemini-provider.ts
+++ b/packages/core/src/llm/providers/gemini/gemini-provider.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
 import { BaseLLMProvider } from '../base-provider';
-import type { LLMRequest, LLMResponse, LLMMessage, ModelInfo } from '../types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, LLMMessage, ModelInfo } from '../types';
 import { GEMINI_MODELS, GEMINI_DEFAULT_MODEL } from './models';
 
 /**
@@ -57,6 +57,48 @@ export class GeminiProvider extends BaseLLMProvider {
                 totalTokens: response.usageMetadata?.totalTokenCount ?? 0,
             },
             latencyMs,
+        };
+    }
+
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+        const contents = this.formatMessages(request.messages);
+
+        const stream = await this.client.models.generateContentStream({
+            model: modelName,
+            contents,
+            config: {
+                temperature: request.temperature ?? 0.5,
+                maxOutputTokens: request.maxTokens ?? 1024,
+            },
+        });
+
+        let fullContent = '';
+
+        for await (const chunk of stream) {
+            const text = chunk.text ?? '';
+            if (text) {
+                fullContent += text;
+                yield { delta: text, done: false };
+            }
+        }
+
+        const latencyMs = Date.now() - startTime;
+        yield {
+            delta: '',
+            done: true,
+            response: {
+                content: fullContent,
+                model: modelName,
+                provider: this.providerName,
+                usage: {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    totalTokens: 0,
+                },
+                latencyMs,
+            },
         };
     }
 

--- a/packages/core/src/llm/providers/gemini/gemini-provider.ts
+++ b/packages/core/src/llm/providers/gemini/gemini-provider.ts
@@ -1,10 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
-import {
-    BaseLLMProvider,
-    type LLMRequest,
-    type LLMResponse,
-    type LLMMessage,
-} from './base-provider';
+import { BaseLLMProvider } from '../base-provider';
+import type { LLMRequest, LLMResponse, LLMMessage, ModelInfo } from '../types';
+import { GEMINI_MODELS, GEMINI_DEFAULT_MODEL } from './models';
 
 /**
  * Gemini LLM Provider
@@ -19,7 +16,7 @@ export class GeminiProvider extends BaseLLMProvider {
     constructor(apiKey: string) {
         super(apiKey);
         this.client = new GoogleGenAI({ apiKey });
-        this._defaultModel = process.env.LLM_MODEL || 'gemini-2.5-flash';
+        this._defaultModel = process.env.LLM_MODEL || GEMINI_DEFAULT_MODEL;
         console.log(`[GeminiProvider] Initialized with model: ${this._defaultModel}`);
     }
 
@@ -53,6 +50,7 @@ export class GeminiProvider extends BaseLLMProvider {
         return {
             content: text,
             model: modelName,
+            provider: this.providerName,
             usage: {
                 inputTokens: response.usageMetadata?.promptTokenCount ?? 0,
                 outputTokens: response.usageMetadata?.candidatesTokenCount ?? 0,
@@ -77,15 +75,12 @@ export class GeminiProvider extends BaseLLMProvider {
             return list.length ? list : [this.defaultModel];
         } catch (e) {
             console.error('[GeminiProvider] Error listing models:', e);
-            // Fallback to defaults if SDK list fails or lacks permission
-            return [
-                'gemini-2.5-flash',
-                'gemini-2.5-pro',
-                'gemini-2.0-flash',
-                'gemini-1.5-flash',
-                'gemini-1.5-pro'
-            ];
+            return GEMINI_MODELS.map((m) => m.id);
         }
+    }
+
+    listModelCatalog(): ModelInfo[] {
+        return GEMINI_MODELS;
     }
 
     /**

--- a/packages/core/src/llm/providers/gemini/models.ts
+++ b/packages/core/src/llm/providers/gemini/models.ts
@@ -1,0 +1,44 @@
+import type { ModelInfo } from '../types';
+
+/**
+ * Gemini model catalog — Google AI Studio / Vertex AI
+ *
+ * These models use your Google Cloud billing / AI Studio API key.
+ * Pricing: paid (consumes trial credits or billing).
+ */
+export const GEMINI_MODELS: ModelInfo[] = [
+    {
+        id: 'gemini-3.1-pro',
+        name: 'Gemini 3.1 Pro',
+        tier: 'very_high',
+        pricing: 'paid',
+        contextWindow: 1_000_000,
+        description: 'Frontier model. Top reasoning, coding, and analysis.',
+    },
+    {
+        id: 'gemini-2.5-pro',
+        name: 'Gemini 2.5 Pro',
+        tier: 'very_high',
+        pricing: 'paid',
+        contextWindow: 1_000_000,
+        description: 'Previous-gen flagship. Strong reasoning with thinking.',
+    },
+    {
+        id: 'gemini-2.5-flash',
+        name: 'Gemini 2.5 Flash',
+        tier: 'high',
+        pricing: 'paid',
+        contextWindow: 1_000_000,
+        description: 'Fast and capable. Great balance of speed and quality.',
+    },
+    {
+        id: 'gemini-2.5-flash-lite',
+        name: 'Gemini 2.5 Flash-Lite',
+        tier: 'medium',
+        pricing: 'paid',
+        contextWindow: 1_000_000,
+        description: 'Lightest Gemini. High throughput, lower cost.',
+    },
+];
+
+export const GEMINI_DEFAULT_MODEL = 'gemini-2.5-flash';

--- a/packages/core/src/llm/providers/groq/groq-provider.ts
+++ b/packages/core/src/llm/providers/groq/groq-provider.ts
@@ -1,0 +1,78 @@
+import { BaseLLMProvider } from '../base-provider';
+import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import { GROQ_MODELS, GROQ_DEFAULT_MODEL, GROQ_BASE_URL } from './models';
+
+/**
+ * Groq LLM Provider
+ *
+ * Uses Groq's OpenAI-compatible API with custom LPU hardware.
+ * Free tier, no credit card required.
+ */
+export class GroqProvider extends BaseLLMProvider {
+    private _defaultModel: string;
+    private baseUrl: string;
+
+    constructor(apiKey: string) {
+        super(apiKey);
+        this._defaultModel = process.env.LLM_MODEL || GROQ_DEFAULT_MODEL;
+        this.baseUrl = GROQ_BASE_URL;
+        console.log(`[GroqProvider] Initialized with model: ${this._defaultModel}`);
+    }
+
+    get defaultModel(): string {
+        return this._defaultModel;
+    }
+
+    get providerName(): string {
+        return 'groq';
+    }
+
+    async generate(request: LLMRequest): Promise<LLMResponse> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[GroqProvider] API error ${response.status}: ${error}`);
+        }
+
+        const data = await response.json();
+        const latencyMs = Date.now() - startTime;
+
+        return {
+            content: data.choices?.[0]?.message?.content ?? '',
+            model: data.model ?? modelName,
+            provider: this.providerName,
+            usage: {
+                inputTokens: data.usage?.prompt_tokens ?? 0,
+                outputTokens: data.usage?.completion_tokens ?? 0,
+                totalTokens: data.usage?.total_tokens ?? 0,
+            },
+            latencyMs,
+        };
+    }
+
+    async listModels(): Promise<string[]> {
+        return GROQ_MODELS.map((m) => m.id);
+    }
+
+    listModelCatalog(): ModelInfo[] {
+        return GROQ_MODELS;
+    }
+}
+
+export default GroqProvider;

--- a/packages/core/src/llm/providers/groq/groq-provider.ts
+++ b/packages/core/src/llm/providers/groq/groq-provider.ts
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from '../base-provider';
-import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, ModelInfo } from '../types';
+import { parseOpenAIStream } from '../stream-parser';
 import { GROQ_MODELS, GROQ_DEFAULT_MODEL, GROQ_BASE_URL } from './models';
 
 /**
@@ -64,6 +65,33 @@ export class GroqProvider extends BaseLLMProvider {
             },
             latencyMs,
         };
+    }
+
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+                stream: true,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[GroqProvider] API error ${response.status}: ${error}`);
+        }
+
+        yield* parseOpenAIStream(response, this.providerName, modelName, startTime);
     }
 
     async listModels(): Promise<string[]> {

--- a/packages/core/src/llm/providers/groq/models.ts
+++ b/packages/core/src/llm/providers/groq/models.ts
@@ -4,40 +4,34 @@ import type { ModelInfo } from '../types';
  * Groq model catalog — GroqCloud (LPU inference)
  *
  * Free tier, no credit card. Ultra-fast inference.
+ * Docs: https://console.groq.com/docs/models
  * Base URL: https://api.groq.com/openai
  */
 export const GROQ_MODELS: ModelInfo[] = [
+    // ── Production ──
     {
         id: 'llama-3.3-70b-versatile',
         name: 'Llama 3.3 70B',
         tier: 'high',
         pricing: 'free',
         contextWindow: 128_000,
-        description: 'MMLU 86%. Strong generalist. 1K RPD, 12K TPM.',
+        description: 'MMLU 86%. Strong generalist. 1K RPD.',
     },
     {
-        id: 'llama-4-maverick-17b-128e-instruct',
-        name: 'Llama 4 Maverick',
+        id: 'openai/gpt-oss-120b',
+        name: 'GPT-OSS 120B',
         tier: 'high',
         pricing: 'free',
         contextWindow: 128_000,
-        description: 'MoE 128 experts. 1K RPD, 6K TPM.',
+        description: 'OpenAI flagship open-weight. ~500 tps.',
     },
     {
-        id: 'llama-4-scout-17b-16e-instruct',
-        name: 'Llama 4 Scout',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 512_000,
-        description: 'MoE 16 experts, huge context. 1K RPD, 30K TPM.',
-    },
-    {
-        id: 'qwen-qwq-32b',
-        name: 'Qwen QWQ 32B',
+        id: 'openai/gpt-oss-20b',
+        name: 'GPT-OSS 20B',
         tier: 'medium',
         pricing: 'free',
         contextWindow: 128_000,
-        description: 'Reasoning-focused. 1K RPD.',
+        description: 'OpenAI lightweight open-weight.',
     },
     {
         id: 'llama-3.1-8b-instant',
@@ -46,6 +40,23 @@ export const GROQ_MODELS: ModelInfo[] = [
         pricing: 'free',
         contextWindow: 128_000,
         description: 'Fastest, lightest. 14.4K RPD, 6K TPM.',
+    },
+    // ── Preview ──
+    {
+        id: 'meta-llama/llama-4-scout-17b-16e-instruct',
+        name: 'Llama 4 Scout',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 512_000,
+        description: 'Preview. MoE 16 experts, huge context.',
+    },
+    {
+        id: 'qwen/qwen3-32b',
+        name: 'Qwen3 32B',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Preview. Strong multilingual.',
     },
 ];
 

--- a/packages/core/src/llm/providers/groq/models.ts
+++ b/packages/core/src/llm/providers/groq/models.ts
@@ -1,0 +1,53 @@
+import type { ModelInfo } from '../types';
+
+/**
+ * Groq model catalog — GroqCloud (LPU inference)
+ *
+ * Free tier, no credit card. Ultra-fast inference.
+ * Base URL: https://api.groq.com/openai
+ */
+export const GROQ_MODELS: ModelInfo[] = [
+    {
+        id: 'llama-3.3-70b-versatile',
+        name: 'Llama 3.3 70B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'MMLU 86%. Strong generalist. 1K RPD, 12K TPM.',
+    },
+    {
+        id: 'llama-4-maverick-17b-128e-instruct',
+        name: 'Llama 4 Maverick',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'MoE 128 experts. 1K RPD, 6K TPM.',
+    },
+    {
+        id: 'llama-4-scout-17b-16e-instruct',
+        name: 'Llama 4 Scout',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 512_000,
+        description: 'MoE 16 experts, huge context. 1K RPD, 30K TPM.',
+    },
+    {
+        id: 'qwen-qwq-32b',
+        name: 'Qwen QWQ 32B',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Reasoning-focused. 1K RPD.',
+    },
+    {
+        id: 'llama-3.1-8b-instant',
+        name: 'Llama 3.1 8B',
+        tier: 'low',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Fastest, lightest. 14.4K RPD, 6K TPM.',
+    },
+];
+
+export const GROQ_DEFAULT_MODEL = 'llama-3.3-70b-versatile';
+export const GROQ_BASE_URL = 'https://api.groq.com/openai';

--- a/packages/core/src/llm/providers/index.ts
+++ b/packages/core/src/llm/providers/index.ts
@@ -1,8 +1,27 @@
-export {
-    BaseLLMProvider,
-    type LLMMessage,
-    type LLMRequest,
-    type LLMResponse,
-    type LLMUsage,
-} from './base-provider';
-export { GeminiProvider } from './gemini-provider';
+// ── Types ─────────────────────────────────────────────────────────────
+export type {
+    LLMMessage,
+    LLMRequest,
+    LLMResponse,
+    LLMUsage,
+    ModelTier,
+    ModelPricing,
+    ModelInfo,
+} from './types';
+
+// ── Base ─────────────────────────────────────────────────────────────
+export { BaseLLMProvider } from './base-provider';
+
+// ── Providers ────────────────────────────────────────────────────────
+export { GeminiProvider } from './gemini/gemini-provider';
+export { GroqProvider } from './groq/groq-provider';
+export { OpenRouterProvider } from './openrouter/openrouter-provider';
+export { CerebrasProvider } from './cerebras/cerebras-provider';
+export { MistralProvider } from './mistral/mistral-provider';
+
+// ── Model catalogs ──────────────────────────────────────────────────
+export { GEMINI_MODELS } from './gemini/models';
+export { GROQ_MODELS } from './groq/models';
+export { OPENROUTER_MODELS } from './openrouter/models';
+export { CEREBRAS_MODELS } from './cerebras/models';
+export { MISTRAL_MODELS } from './mistral/models';

--- a/packages/core/src/llm/providers/index.ts
+++ b/packages/core/src/llm/providers/index.ts
@@ -3,6 +3,7 @@ export type {
     LLMMessage,
     LLMRequest,
     LLMResponse,
+    LLMStreamEvent,
     LLMUsage,
     ModelTier,
     ModelPricing,

--- a/packages/core/src/llm/providers/mistral/mistral-provider.ts
+++ b/packages/core/src/llm/providers/mistral/mistral-provider.ts
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from '../base-provider';
-import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, ModelInfo } from '../types';
+import { parseOpenAIStream } from '../stream-parser';
 import { MISTRAL_MODELS, MISTRAL_DEFAULT_MODEL, MISTRAL_BASE_URL } from './models';
 
 /**
@@ -64,6 +65,33 @@ export class MistralProvider extends BaseLLMProvider {
             },
             latencyMs,
         };
+    }
+
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+                stream: true,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[MistralProvider] API error ${response.status}: ${error}`);
+        }
+
+        yield* parseOpenAIStream(response, this.providerName, modelName, startTime);
     }
 
     async listModels(): Promise<string[]> {

--- a/packages/core/src/llm/providers/mistral/mistral-provider.ts
+++ b/packages/core/src/llm/providers/mistral/mistral-provider.ts
@@ -1,0 +1,78 @@
+import { BaseLLMProvider } from '../base-provider';
+import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import { MISTRAL_MODELS, MISTRAL_DEFAULT_MODEL, MISTRAL_BASE_URL } from './models';
+
+/**
+ * Mistral LLM Provider — La Plateforme
+ *
+ * Free "Experiment" tier via OpenAI-compatible API.
+ * Global: 1 req/sec. Standard pool: 50K TPM, 4M tokens/month.
+ */
+export class MistralProvider extends BaseLLMProvider {
+    private _defaultModel: string;
+    private baseUrl: string;
+
+    constructor(apiKey: string) {
+        super(apiKey);
+        this._defaultModel = process.env.LLM_MODEL || MISTRAL_DEFAULT_MODEL;
+        this.baseUrl = MISTRAL_BASE_URL;
+        console.log(`[MistralProvider] Initialized with model: ${this._defaultModel}`);
+    }
+
+    get defaultModel(): string {
+        return this._defaultModel;
+    }
+
+    get providerName(): string {
+        return 'mistral';
+    }
+
+    async generate(request: LLMRequest): Promise<LLMResponse> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[MistralProvider] API error ${response.status}: ${error}`);
+        }
+
+        const data = await response.json();
+        const latencyMs = Date.now() - startTime;
+
+        return {
+            content: data.choices?.[0]?.message?.content ?? '',
+            model: data.model ?? modelName,
+            provider: this.providerName,
+            usage: {
+                inputTokens: data.usage?.prompt_tokens ?? 0,
+                outputTokens: data.usage?.completion_tokens ?? 0,
+                totalTokens: data.usage?.total_tokens ?? 0,
+            },
+            latencyMs,
+        };
+    }
+
+    async listModels(): Promise<string[]> {
+        return MISTRAL_MODELS.map((m) => m.id);
+    }
+
+    listModelCatalog(): ModelInfo[] {
+        return MISTRAL_MODELS;
+    }
+}
+
+export default MistralProvider;

--- a/packages/core/src/llm/providers/mistral/models.ts
+++ b/packages/core/src/llm/providers/mistral/models.ts
@@ -1,0 +1,62 @@
+import type { ModelInfo } from '../types';
+
+/**
+ * Mistral model catalog — La Plateforme
+ *
+ * Free "Experiment" tier. 1 req/sec, 50K TPM, 4M tokens/month (standard pool).
+ * mistral-large has its own pool with much higher quota.
+ * Base URL: https://api.mistral.ai
+ */
+export const MISTRAL_MODELS: ModelInfo[] = [
+    {
+        id: 'mistral-large-latest',
+        name: 'Mistral Large',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Flagship. Own pool with huge monthly quota.',
+    },
+    {
+        id: 'codestral-latest',
+        name: 'Codestral',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 256_000,
+        description: 'Code-specialized. 256K context. Standard pool.',
+    },
+    {
+        id: 'mistral-small-latest',
+        name: 'Mistral Small',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Efficient generalist. Standard pool.',
+    },
+    {
+        id: 'devstral-small-latest',
+        name: 'Devstral Small',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Agentic coding. Standard pool.',
+    },
+    {
+        id: 'open-mistral-nemo',
+        name: 'Mistral Nemo',
+        tier: 'low',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Lightweight open model. Standard pool.',
+    },
+    {
+        id: 'pixtral-large-latest',
+        name: 'Pixtral Large',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Vision + text. Standard pool.',
+    },
+];
+
+export const MISTRAL_DEFAULT_MODEL = 'mistral-small-latest';
+export const MISTRAL_BASE_URL = 'https://api.mistral.ai';

--- a/packages/core/src/llm/providers/openrouter/models.ts
+++ b/packages/core/src/llm/providers/openrouter/models.ts
@@ -1,0 +1,94 @@
+import type { ModelInfo } from '../types';
+
+/**
+ * OpenRouter model catalog — Aggregator (24+ free models)
+ *
+ * Free tier: 50 RPD (no credits) / 1K RPD (with $10 deposit, not consumed).
+ * Use `:free` suffix on model IDs. Or `openrouter/free` auto-router.
+ * Base URL: https://openrouter.ai/api
+ */
+export const OPENROUTER_MODELS: ModelInfo[] = [
+    {
+        id: 'meta-llama/llama-3.3-70b-instruct:free',
+        name: 'Llama 3.3 70B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'MMLU 86%. Strong generalist via Meta.',
+    },
+    {
+        id: 'qwen/qwen3-coder-480b-a35b:free',
+        name: 'Qwen3 Coder 480B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Top coding model. 480B MoE, 35B active.',
+    },
+    {
+        id: 'deepseek/deepseek-r1-zero:free',
+        name: 'DeepSeek R1 Zero',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Strong reasoning via pure RL training.',
+    },
+    {
+        id: 'openai/gpt-oss-120b:free',
+        name: 'GPT-OSS 120B',
+        tier: 'high',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'OpenAI open-weight. MMLU-Pro 90%, MoE 5.1B active.',
+    },
+    {
+        id: 'mistralai/devstral-2512:free',
+        name: 'Devstral 2',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: '123B agentic coding model from Mistral.',
+    },
+    {
+        id: 'qwen/qwq-32b:free',
+        name: 'QWQ 32B',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Reasoning-focused Qwen variant.',
+    },
+    {
+        id: 'google/gemini-2.0-flash-exp:free',
+        name: 'Gemini 2.0 Flash',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 1_000_000,
+        description: 'Google experimental. 1M context.',
+    },
+    {
+        id: 'google/gemma-3-27b-it:free',
+        name: 'Gemma 3 27B',
+        tier: 'medium',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Google open-weight, solid generalist.',
+    },
+    {
+        id: 'nvidia/llama-3.1-nemotron-nano-12b-v2:free',
+        name: 'Nemotron Nano 12B',
+        tier: 'low',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'NVIDIA edge-optimized, very fast.',
+    },
+    {
+        id: 'google/gemma-3-4b-it:free',
+        name: 'Gemma 3 4B',
+        tier: 'low',
+        pricing: 'free',
+        contextWindow: 128_000,
+        description: 'Tiny, ultra-fast for simple tasks.',
+    },
+];
+
+export const OPENROUTER_DEFAULT_MODEL = 'meta-llama/llama-3.3-70b-instruct:free';
+export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api';

--- a/packages/core/src/llm/providers/openrouter/models.ts
+++ b/packages/core/src/llm/providers/openrouter/models.ts
@@ -1,10 +1,11 @@
 import type { ModelInfo } from '../types';
 
 /**
- * OpenRouter model catalog — Aggregator (24+ free models)
+ * OpenRouter model catalog — Aggregator (free :free models)
  *
  * Free tier: 50 RPD (no credits) / 1K RPD (with $10 deposit, not consumed).
- * Use `:free` suffix on model IDs. Or `openrouter/free` auto-router.
+ * Use `:free` suffix on model IDs.
+ * Docs: https://openrouter.ai/models/?q=free
  * Base URL: https://openrouter.ai/api
  */
 export const OPENROUTER_MODELS: ModelInfo[] = [
@@ -14,23 +15,7 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
         tier: 'high',
         pricing: 'free',
         contextWindow: 128_000,
-        description: 'MMLU 86%. Strong generalist via Meta.',
-    },
-    {
-        id: 'qwen/qwen3-coder-480b-a35b:free',
-        name: 'Qwen3 Coder 480B',
-        tier: 'high',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: 'Top coding model. 480B MoE, 35B active.',
-    },
-    {
-        id: 'deepseek/deepseek-r1-zero:free',
-        name: 'DeepSeek R1 Zero',
-        tier: 'high',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: 'Strong reasoning via pure RL training.',
+        description: 'MMLU 86%. Strong generalist.',
     },
     {
         id: 'openai/gpt-oss-120b:free',
@@ -38,15 +23,7 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
         tier: 'high',
         pricing: 'free',
         contextWindow: 128_000,
-        description: 'OpenAI open-weight. MMLU-Pro 90%, MoE 5.1B active.',
-    },
-    {
-        id: 'mistralai/devstral-2512:free',
-        name: 'Devstral 2',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: '123B agentic coding model from Mistral.',
+        description: 'OpenAI open-weight. MoE 5.1B active.',
     },
     {
         id: 'qwen/qwq-32b:free',
@@ -73,12 +50,12 @@ export const OPENROUTER_MODELS: ModelInfo[] = [
         description: 'Google open-weight, solid generalist.',
     },
     {
-        id: 'nvidia/llama-3.1-nemotron-nano-12b-v2:free',
-        name: 'Nemotron Nano 12B',
-        tier: 'low',
+        id: 'mistralai/devstral-2512:free',
+        name: 'Devstral 2',
+        tier: 'medium',
         pricing: 'free',
         contextWindow: 128_000,
-        description: 'NVIDIA edge-optimized, very fast.',
+        description: '123B agentic coding model.',
     },
     {
         id: 'google/gemma-3-4b-it:free',

--- a/packages/core/src/llm/providers/openrouter/openrouter-provider.ts
+++ b/packages/core/src/llm/providers/openrouter/openrouter-provider.ts
@@ -1,0 +1,79 @@
+import { BaseLLMProvider } from '../base-provider';
+import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import { OPENROUTER_MODELS, OPENROUTER_DEFAULT_MODEL, OPENROUTER_BASE_URL } from './models';
+
+/**
+ * OpenRouter LLM Provider
+ *
+ * Aggregator with 24+ free models via OpenAI-compatible API.
+ * Append `:free` to model IDs for free tier.
+ */
+export class OpenRouterProvider extends BaseLLMProvider {
+    private _defaultModel: string;
+    private baseUrl: string;
+
+    constructor(apiKey: string) {
+        super(apiKey);
+        this._defaultModel = process.env.LLM_MODEL || OPENROUTER_DEFAULT_MODEL;
+        this.baseUrl = OPENROUTER_BASE_URL;
+        console.log(`[OpenRouterProvider] Initialized with model: ${this._defaultModel}`);
+    }
+
+    get defaultModel(): string {
+        return this._defaultModel;
+    }
+
+    get providerName(): string {
+        return 'openrouter';
+    }
+
+    async generate(request: LLMRequest): Promise<LLMResponse> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+                'HTTP-Referer': 'https://github.com/flow-sample',
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[OpenRouterProvider] API error ${response.status}: ${error}`);
+        }
+
+        const data = await response.json();
+        const latencyMs = Date.now() - startTime;
+
+        return {
+            content: data.choices?.[0]?.message?.content ?? '',
+            model: data.model ?? modelName,
+            provider: this.providerName,
+            usage: {
+                inputTokens: data.usage?.prompt_tokens ?? 0,
+                outputTokens: data.usage?.completion_tokens ?? 0,
+                totalTokens: data.usage?.total_tokens ?? 0,
+            },
+            latencyMs,
+        };
+    }
+
+    async listModels(): Promise<string[]> {
+        return OPENROUTER_MODELS.map((m) => m.id);
+    }
+
+    listModelCatalog(): ModelInfo[] {
+        return OPENROUTER_MODELS;
+    }
+}
+
+export default OpenRouterProvider;

--- a/packages/core/src/llm/providers/openrouter/openrouter-provider.ts
+++ b/packages/core/src/llm/providers/openrouter/openrouter-provider.ts
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from '../base-provider';
-import type { LLMRequest, LLMResponse, ModelInfo } from '../types';
+import type { LLMRequest, LLMResponse, LLMStreamEvent, ModelInfo } from '../types';
+import { parseOpenAIStream } from '../stream-parser';
 import { OPENROUTER_MODELS, OPENROUTER_DEFAULT_MODEL, OPENROUTER_BASE_URL } from './models';
 
 /**
@@ -65,6 +66,34 @@ export class OpenRouterProvider extends BaseLLMProvider {
             },
             latencyMs,
         };
+    }
+
+    async *generateStream(request: LLMRequest): AsyncGenerator<LLMStreamEvent> {
+        const startTime = Date.now();
+        const modelName = request.model || this.defaultModel;
+
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+                'HTTP-Referer': 'https://github.com/flow-sample',
+            },
+            body: JSON.stringify({
+                model: modelName,
+                messages: request.messages,
+                temperature: request.temperature ?? 0.5,
+                max_tokens: request.maxTokens ?? 1024,
+                stream: true,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`[OpenRouterProvider] API error ${response.status}: ${error}`);
+        }
+
+        yield* parseOpenAIStream(response, this.providerName, modelName, startTime);
     }
 
     async listModels(): Promise<string[]> {

--- a/packages/core/src/llm/providers/stream-parser.ts
+++ b/packages/core/src/llm/providers/stream-parser.ts
@@ -1,0 +1,82 @@
+import type { LLMStreamEvent, LLMResponse } from './types';
+
+/**
+ * Parse an OpenAI-compatible SSE stream (used by Groq, OpenRouter, Cerebras, Mistral).
+ *
+ * Reads `data: {...}` lines from a fetch Response, yields text deltas,
+ * then yields a final `done` event with the assembled LLMResponse.
+ */
+export async function* parseOpenAIStream(
+    fetchResponse: Response,
+    providerName: string,
+    modelName: string,
+    startTime: number,
+): AsyncGenerator<LLMStreamEvent> {
+    const reader = fetchResponse.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullContent = '';
+    let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    let responseModel = modelName;
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+
+            // Process complete lines
+            const lines = buffer.split('\n');
+            buffer = lines.pop()!; // Keep incomplete line in buffer
+
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith(':')) continue; // Skip comments and empty lines
+
+                if (trimmed === 'data: [DONE]') continue;
+
+                if (trimmed.startsWith('data: ')) {
+                    try {
+                        const json = JSON.parse(trimmed.slice(6));
+                        const delta = json.choices?.[0]?.delta?.content ?? '';
+
+                        // Capture usage if present (some providers send it on the last chunk)
+                        if (json.usage) {
+                            usage = {
+                                inputTokens: json.usage.prompt_tokens ?? 0,
+                                outputTokens: json.usage.completion_tokens ?? 0,
+                                totalTokens: json.usage.total_tokens ?? 0,
+                            };
+                        }
+
+                        if (json.model) {
+                            responseModel = json.model;
+                        }
+
+                        if (delta) {
+                            fullContent += delta;
+                            yield { delta, done: false };
+                        }
+                    } catch {
+                        // Skip malformed JSON lines
+                    }
+                }
+            }
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    // Final event with full response
+    const latencyMs = Date.now() - startTime;
+    const finalResponse: LLMResponse = {
+        content: fullContent,
+        model: responseModel,
+        provider: providerName,
+        usage,
+        latencyMs,
+    };
+
+    yield { delta: '', done: true, response: finalResponse };
+}

--- a/packages/core/src/llm/providers/types.ts
+++ b/packages/core/src/llm/providers/types.ts
@@ -1,0 +1,45 @@
+/**
+ * LLM Types — Shared types for all LLM providers
+ */
+
+// ── Message & Request/Response ───────────────────────────────────────
+
+export interface LLMMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+}
+
+export interface LLMRequest {
+    messages: LLMMessage[];
+    temperature?: number;
+    maxTokens?: number;
+    model?: string; // Optional override for default model
+}
+
+export interface LLMUsage {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+}
+
+export interface LLMResponse {
+    content: string;
+    model: string;
+    provider: string;
+    usage: LLMUsage;
+    latencyMs: number;
+}
+
+// ── Model catalog ────────────────────────────────────────────────────
+
+export type ModelTier = 'very_high' | 'high' | 'medium' | 'low';
+export type ModelPricing = 'free' | 'paid';
+
+export interface ModelInfo {
+    id: string;
+    name: string;
+    tier: ModelTier;
+    pricing: ModelPricing;
+    contextWindow: number;
+    description?: string;
+}

--- a/packages/core/src/llm/providers/types.ts
+++ b/packages/core/src/llm/providers/types.ts
@@ -14,6 +14,7 @@ export interface LLMRequest {
     temperature?: number;
     maxTokens?: number;
     model?: string; // Optional override for default model
+    streaming?: boolean; // Whether to stream the response
 }
 
 export interface LLMUsage {
@@ -28,6 +29,16 @@ export interface LLMResponse {
     provider: string;
     usage: LLMUsage;
     latencyMs: number;
+}
+
+/** A single chunk yielded during streaming. */
+export interface LLMStreamEvent {
+    /** Text delta for this chunk (empty on final event). */
+    delta: string;
+    /** Whether this is the final event. */
+    done: boolean;
+    /** Full response, only present on the final event. */
+    response?: LLMResponse;
 }
 
 // ── Model catalog ────────────────────────────────────────────────────

--- a/packages/flows/chat/src/backend/database.ts
+++ b/packages/flows/chat/src/backend/database.ts
@@ -29,6 +29,7 @@ export class ChatDatabase {
                 role TEXT NOT NULL,
                 content TEXT NOT NULL,
                 model_used TEXT NOT NULL,
+                provider_used TEXT DEFAULT '',
                 created_at INTEGER NOT NULL,
                 FOREIGN KEY(conversation_id) REFERENCES chat_conversations(id) ON DELETE CASCADE
             );
@@ -80,8 +81,8 @@ export class ChatDatabase {
 
     addMessage(message: ChatMessage): void {
         const stmt = this.db.prepare(`
-            INSERT INTO chat_messages (id, conversation_id, role, content, model_used, created_at)
-            VALUES (@id, @conversationId, @role, @content, @modelUsed, @createdAt)
+            INSERT INTO chat_messages (id, conversation_id, role, content, model_used, provider_used, created_at)
+            VALUES (@id, @conversationId, @role, @content, @modelUsed, @providerUsed, @createdAt)
         `);
         stmt.run({
             id: message.id,
@@ -89,7 +90,8 @@ export class ChatDatabase {
             role: message.role,
             content: message.content,
             modelUsed: message.modelUsed,
-            createdAt: message.createdAt
+            providerUsed: message.providerUsed || '',
+            createdAt: message.createdAt,
         });
 
         // Bump conversation updated_at
@@ -104,6 +106,7 @@ export class ChatDatabase {
                 role, 
                 content, 
                 model_used as modelUsed, 
+                provider_used as providerUsed,
                 created_at as createdAt 
             FROM chat_messages 
             WHERE conversation_id = ? 

--- a/packages/flows/chat/src/backend/routes.ts
+++ b/packages/flows/chat/src/backend/routes.ts
@@ -7,38 +7,56 @@ const chatService = new ChatService();
  * Chat Flow API Routes
  */
 export const chatRoutes = new Elysia({ prefix: '/chat' })
-    // Models Support
-    .get('/models', async () => {
-        return await chatService.getModels();
+    // Model catalog (grouped by provider)
+    .get('/models', () => {
+        return chatService.getModelCatalog();
     })
 
     // Conversation Management
     .get('/conversations', () => {
         return chatService.getConversations();
     })
-    .get('/conversations/:id', ({ params }) => {
-        return chatService.getMessages(params.id);
-    }, {
-        params: t.Object({
-            id: t.String()
-        })
-    })
-    .delete('/conversations/:id', ({ params }) => {
-        chatService.deleteConversation(params.id);
-        return { success: true };
-    }, {
-        params: t.Object({
-            id: t.String()
-        })
-    })
+    .get(
+        '/conversations/:id',
+        ({ params }) => {
+            return chatService.getMessages(params.id);
+        },
+        {
+            params: t.Object({
+                id: t.String(),
+            }),
+        },
+    )
+    .delete(
+        '/conversations/:id',
+        ({ params }) => {
+            chatService.deleteConversation(params.id);
+            return { success: true };
+        },
+        {
+            params: t.Object({
+                id: t.String(),
+            }),
+        },
+    )
 
     // Interaction
-    .post('/message', async ({ body }) => {
-        return await chatService.sendMessage(body.conversationId, body.message, body.model);
-    }, {
-        body: t.Object({
-            conversationId: t.String(),
-            message: t.String(),
-            model: t.Optional(t.String())
-        })
-    });
+    .post(
+        '/message',
+        async ({ body }) => {
+            return await chatService.sendMessage(
+                body.conversationId,
+                body.message,
+                body.mode,
+                body.model,
+            );
+        },
+        {
+            body: t.Object({
+                conversationId: t.String(),
+                message: t.String(),
+                mode: t.Optional(t.Union([t.Literal('rotation'), t.Literal('specific')])),
+                model: t.Optional(t.String()),
+            }),
+        },
+    );

--- a/packages/flows/chat/src/backend/routes.ts
+++ b/packages/flows/chat/src/backend/routes.ts
@@ -40,7 +40,7 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
         },
     )
 
-    // Interaction
+    // Non-streaming message (fallback)
     .post(
         '/message',
         async ({ body }) => {
@@ -50,6 +50,54 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
                 body.mode,
                 body.model,
             );
+        },
+        {
+            body: t.Object({
+                conversationId: t.String(),
+                message: t.String(),
+                mode: t.Optional(t.Union([t.Literal('rotation'), t.Literal('specific')])),
+                model: t.Optional(t.String()),
+            }),
+        },
+    )
+
+    // Streaming message (SSE)
+    .post(
+        '/message/stream',
+        async ({ body }) => {
+            const stream = chatService.sendMessageStream(
+                body.conversationId,
+                body.message,
+                body.mode,
+                body.model,
+            );
+
+            const readable = new ReadableStream({
+                async start(controller) {
+                    try {
+                        for await (const chunk of stream) {
+                            controller.enqueue(new TextEncoder().encode(chunk));
+                        }
+                    } catch (error) {
+                        const errMsg = error instanceof Error ? error.message : String(error);
+                        controller.enqueue(
+                            new TextEncoder().encode(
+                                `data: ${JSON.stringify({ type: 'error', error: errMsg })}\n\n`,
+                            ),
+                        );
+                    } finally {
+                        controller.close();
+                    }
+                },
+            });
+
+            return new Response(readable, {
+                headers: {
+                    'Content-Type': 'text/event-stream',
+                    'Cache-Control': 'no-cache',
+                    Connection: 'keep-alive',
+                },
+            });
         },
         {
             body: t.Object({

--- a/packages/flows/chat/src/backend/services/chat.service.ts
+++ b/packages/flows/chat/src/backend/services/chat.service.ts
@@ -1,37 +1,32 @@
 import { randomUUID } from 'crypto';
-import { createLLMClient } from '@flows/core';
-import type { ChatConversation, ChatMessage, ChatProviderOption } from '@flows/shared';
+import { LLMClient } from '@flows/core';
+import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
 import { chatDb } from '../database';
 
 export class ChatService {
-    private llmClient;
-
-    constructor() {
-        this.llmClient = createLLMClient();
-    }
+    private rotationClient: LLMClient | null = null;
 
     /**
-     * Get available models dynamically from the connected LLM provider
+     * Get model catalog grouped by provider (for the provider/model selector).
      */
-    async getModels(): Promise<ChatProviderOption[]> {
-        try {
-            const models = await this.llmClient.listModels();
-            return models.map(id => {
-                // Formatting name nicely e.g. gemini-2.5-flash -> Gemini 2.5 Flash
-                let name = id.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
-                return { id, name, provider: this.llmClient.providerName };
-            });
-        } catch (e) {
-            console.error('[ChatService] Failed to list models:', e);
-            return [];
-        }
+    getModelCatalog(): ChatProviderGroup[] {
+        return LLMClient.getModelCatalogGrouped().map((g) => ({
+            provider: g.provider,
+            models: g.models.map((m) => ({
+                id: m.id,
+                name: m.name,
+                tier: m.tier,
+                pricing: m.pricing,
+                contextWindow: m.contextWindow,
+                description: m.description,
+            })),
+        }));
     }
 
     /**
      * Fetch all conversations.
      */
     getConversations(): ChatConversation[] {
-        console.log('[ChatService] Fetching all conversations...');
         return chatDb.getConversations();
     }
 
@@ -46,32 +41,32 @@ export class ChatService {
      * Fetch messages for a conversation.
      */
     getMessages(conversationId: string): ChatMessage[] {
-        console.log(`[ChatService] Fetching messages for conversation: ${conversationId}`);
         return chatDb.getMessages(conversationId);
     }
 
     /**
      * Send a message and get an AI response.
+     *
+     * @param mode — 'rotation' cycles free providers, 'specific' uses the given model
+     * @param model — 'provider:model' format for specific mode (e.g. "groq:llama-3.3-70b-versatile")
      */
-    async sendMessage(conversationId: string, content: string, requestedModel?: string): Promise<{ userMessage: ChatMessage, assistantMessage: ChatMessage }> {
-        console.log(`[ChatService] Sending message to ${conversationId} using model ${requestedModel || this.llmClient.defaultModel}...`);
+    async sendMessage(
+        conversationId: string,
+        content: string,
+        mode: ChatMode = 'specific',
+        model?: string,
+    ): Promise<{ userMessage: ChatMessage; assistantMessage: ChatMessage }> {
+        console.log(`[ChatService] mode=${mode} model=${model || 'auto'} conv=${conversationId}`);
 
         // 1. Create or ensure conversation exists
-        let isNew = false;
-        try {
-            const existing = chatDb.getConversations().find(c => c.id === conversationId);
-            if (!existing) {
-                isNew = true;
-                chatDb.createConversation({
-                    id: conversationId,
-                    title: content.slice(0, 30) + (content.length > 30 ? '...' : ''), // Auto-title from first msg
-                    createdAt: Date.now(),
-                    updatedAt: Date.now()
-                });
-            }
-        } catch (e) {
-            console.error("Error creating conversation", e);
-            throw e;
+        const existing = chatDb.getConversations().find((c) => c.id === conversationId);
+        if (!existing) {
+            chatDb.createConversation({
+                id: conversationId,
+                title: content.slice(0, 30) + (content.length > 30 ? '...' : ''),
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
         }
 
         // 2. Save user message
@@ -80,30 +75,34 @@ export class ChatService {
             conversationId,
             role: 'user',
             content,
-            modelUsed: '', // User messages don't use models
-            createdAt: Date.now()
+            modelUsed: '',
+            createdAt: Date.now(),
         };
         chatDb.addMessage(userMsg);
 
-        // 3. Build context from previous messages + system prompt
+        // 3. Build context
         const history = chatDb.getMessages(conversationId);
-
         const llmMessages = [
-            { role: 'system' as const, content: 'You are a helpful AI assistant. Format your replies using standard Markdown.' },
-            ...history.map(msg => ({
-                role: msg.role === 'system' ? 'system' as const : msg.role === 'user' ? 'user' as const : 'assistant' as const,
-                content: msg.content
-            }))
+            {
+                role: 'system' as const,
+                content: 'You are a helpful AI assistant. Format your replies using standard Markdown.',
+            },
+            ...history.map((msg) => ({
+                role: msg.role === 'user' ? ('user' as const) : ('assistant' as const),
+                content: msg.content,
+            })),
         ];
 
-        // 4. Generate LLM response
-        console.log(`[ChatService] Calling LLM API (${llmMessages.length} messages in context)...`);
+        // 4. Generate based on mode
         try {
-            const response = await this.llmClient.generate({
-                messages: llmMessages,
-                model: requestedModel || this.llmClient.defaultModel
-            });
-            console.log(`[ChatService] LLM API responded in ${response.latencyMs}ms (${response.usage.totalTokens} tokens)`);
+            const response =
+                mode === 'rotation'
+                    ? await this.getRotationClient().generate({ messages: llmMessages })
+                    : await LLMClient.generateForProvider(model!, { messages: llmMessages });
+
+            console.log(
+                `[ChatService] ${response.provider}/${response.model} responded in ${response.latencyMs}ms (${response.usage.totalTokens} tokens)`,
+            );
 
             // 5. Save assistant message
             const assistantMsg: ChatMessage = {
@@ -112,14 +111,24 @@ export class ChatService {
                 role: 'assistant',
                 content: response.content,
                 modelUsed: response.model,
-                createdAt: Date.now()
+                providerUsed: response.provider,
+                createdAt: Date.now(),
             };
             chatDb.addMessage(assistantMsg);
 
             return { userMessage: userMsg, assistantMessage: assistantMsg };
         } catch (error) {
-            console.error('[ChatService] Error generating LLM response:', error);
+            console.error('[ChatService] LLM error:', error);
             throw error;
         }
+    }
+
+    // ── Private ──────────────────────────────────────────────────────
+
+    private getRotationClient(): LLMClient {
+        if (!this.rotationClient) {
+            this.rotationClient = LLMClient.createRotation();
+        }
+        return this.rotationClient;
     }
 }

--- a/packages/flows/chat/src/backend/services/chat.service.ts
+++ b/packages/flows/chat/src/backend/services/chat.service.ts
@@ -45,10 +45,7 @@ export class ChatService {
     }
 
     /**
-     * Send a message and get an AI response.
-     *
-     * @param mode — 'rotation' cycles free providers, 'specific' uses the given model
-     * @param model — 'provider:model' format for specific mode (e.g. "groq:llama-3.3-70b-versatile")
+     * Send a message and get an AI response (non-streaming).
      */
     async sendMessage(
         conversationId: string,
@@ -58,7 +55,97 @@ export class ChatService {
     ): Promise<{ userMessage: ChatMessage; assistantMessage: ChatMessage }> {
         console.log(`[ChatService] mode=${mode} model=${model || 'auto'} conv=${conversationId}`);
 
-        // 1. Create or ensure conversation exists
+        this.ensureConversation(conversationId, content);
+
+        // Save user message
+        const userMsg = this.createUserMessage(conversationId, content);
+        chatDb.addMessage(userMsg);
+
+        // Build context and generate
+        const llmMessages = this.buildLLMMessages(conversationId);
+
+        const response =
+            mode === 'rotation'
+                ? await this.getRotationClient().generate({ messages: llmMessages })
+                : await LLMClient.generateForProvider(model!, { messages: llmMessages });
+
+        console.log(
+            `[ChatService] ${response.provider}/${response.model} responded in ${response.latencyMs}ms (${response.usage.totalTokens} tokens)`,
+        );
+
+        const assistantMsg: ChatMessage = {
+            id: randomUUID(),
+            conversationId,
+            role: 'assistant',
+            content: response.content,
+            modelUsed: response.model,
+            providerUsed: response.provider,
+            createdAt: Date.now(),
+        };
+        chatDb.addMessage(assistantMsg);
+
+        return { userMessage: userMsg, assistantMessage: assistantMsg };
+    }
+
+    /**
+     * Streaming version of sendMessage.
+     * Yields SSE `data: {...}\n\n` lines which the route writes to the response stream.
+     */
+    async *sendMessageStream(
+        conversationId: string,
+        content: string,
+        mode: ChatMode = 'specific',
+        model?: string,
+    ): AsyncGenerator<string> {
+        console.log(`[ChatService] STREAM mode=${mode} model=${model || 'auto'} conv=${conversationId}`);
+
+        this.ensureConversation(conversationId, content);
+
+        // Save user message
+        const userMsg = this.createUserMessage(conversationId, content);
+        chatDb.addMessage(userMsg);
+        yield `data: ${JSON.stringify({ type: 'user_message', message: userMsg })}\n\n`;
+
+        // Build context and stream
+        const llmMessages = this.buildLLMMessages(conversationId);
+        const stream =
+            mode === 'rotation'
+                ? this.getRotationClient().generateStream({ messages: llmMessages })
+                : LLMClient.generateStreamForProvider(model!, { messages: llmMessages });
+
+        let fullContent = '';
+        let providerUsed = '';
+        let modelUsed = '';
+
+        for await (const event of stream) {
+            if (event.done && event.response) {
+                providerUsed = event.response.provider;
+                modelUsed = event.response.model;
+            } else if (event.delta) {
+                fullContent += event.delta;
+                yield `data: ${JSON.stringify({ type: 'delta', delta: event.delta })}\n\n`;
+            }
+        }
+
+        // Save assistant message
+        const assistantMsg: ChatMessage = {
+            id: randomUUID(),
+            conversationId,
+            role: 'assistant',
+            content: fullContent,
+            modelUsed,
+            providerUsed,
+            createdAt: Date.now(),
+        };
+        chatDb.addMessage(assistantMsg);
+
+        console.log(`[ChatService] STREAM complete ${providerUsed}/${modelUsed} (${fullContent.length} chars)`);
+        yield `data: ${JSON.stringify({ type: 'done', message: assistantMsg })}\n\n`;
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────
+
+    private ensureConversation(conversationId: string, content: string): void {
         const existing = chatDb.getConversations().find((c) => c.id === conversationId);
         if (!existing) {
             chatDb.createConversation({
@@ -68,9 +155,10 @@ export class ChatService {
                 updatedAt: Date.now(),
             });
         }
+    }
 
-        // 2. Save user message
-        const userMsg: ChatMessage = {
+    private createUserMessage(conversationId: string, content: string): ChatMessage {
+        return {
             id: randomUUID(),
             conversationId,
             role: 'user',
@@ -78,11 +166,11 @@ export class ChatService {
             modelUsed: '',
             createdAt: Date.now(),
         };
-        chatDb.addMessage(userMsg);
+    }
 
-        // 3. Build context
+    private buildLLMMessages(conversationId: string) {
         const history = chatDb.getMessages(conversationId);
-        const llmMessages = [
+        return [
             {
                 role: 'system' as const,
                 content:
@@ -94,38 +182,7 @@ export class ChatService {
                 content: msg.content,
             })),
         ];
-
-        // 4. Generate based on mode
-        try {
-            const response =
-                mode === 'rotation'
-                    ? await this.getRotationClient().generate({ messages: llmMessages })
-                    : await LLMClient.generateForProvider(model!, { messages: llmMessages });
-
-            console.log(
-                `[ChatService] ${response.provider}/${response.model} responded in ${response.latencyMs}ms (${response.usage.totalTokens} tokens)`,
-            );
-
-            // 5. Save assistant message
-            const assistantMsg: ChatMessage = {
-                id: randomUUID(),
-                conversationId,
-                role: 'assistant',
-                content: response.content,
-                modelUsed: response.model,
-                providerUsed: response.provider,
-                createdAt: Date.now(),
-            };
-            chatDb.addMessage(assistantMsg);
-
-            return { userMessage: userMsg, assistantMessage: assistantMsg };
-        } catch (error) {
-            console.error('[ChatService] LLM error:', error);
-            throw error;
-        }
     }
-
-    // ── Private ──────────────────────────────────────────────────────
 
     private getRotationClient(): LLMClient {
         if (!this.rotationClient) {

--- a/packages/flows/chat/src/backend/services/chat.service.ts
+++ b/packages/flows/chat/src/backend/services/chat.service.ts
@@ -85,7 +85,9 @@ export class ChatService {
         const llmMessages = [
             {
                 role: 'system' as const,
-                content: 'You are a helpful AI assistant. Format your replies using standard Markdown.',
+                content:
+                    'You are a helpful AI assistant. Format your replies using standard Markdown. ' +
+                    'Never start your reply with a heading (# or ## or ###). Begin with normal text.',
             },
             ...history.map((msg) => ({
                 role: msg.role === 'user' ? ('user' as const) : ('assistant' as const),

--- a/packages/flows/lyrics/src/backend/repository.ts
+++ b/packages/flows/lyrics/src/backend/repository.ts
@@ -10,6 +10,7 @@ interface LyricsRow {
   synced_lyrics: string | null;
   status: LyricsStatus;
   fetched_at: string | null;
+  interpretation: string | null;
 }
 
 export interface LyricsData {
@@ -23,16 +24,27 @@ export interface LyricsRecord {
   syncedLyrics: string | null;
   status: LyricsStatus;
   fetchedAt: string | null;
+  interpretation: string | null;
 }
 
 export class SQLiteLyricsRepository {
+  constructor() {
+    // Migration: add interpretation column if missing
+    try {
+      musicDb.exec(`ALTER TABLE lyrics ADD COLUMN interpretation TEXT DEFAULT NULL`);
+      log.info('Added interpretation column to lyrics table');
+    } catch {
+      // Column already exists — expected after first run
+    }
+  }
+
   /**
    * Find lyrics by track ID
    */
   async findByTrackId(trackId: string): Promise<LyricsRecord | null> {
     const row = musicDb
       .prepare(
-        `SELECT track_id, plain_lyrics, synced_lyrics, status, fetched_at 
+        `SELECT track_id, plain_lyrics, synced_lyrics, status, fetched_at, interpretation 
          FROM lyrics WHERE track_id = ?`,
       )
       .get(trackId) as LyricsRow | undefined;
@@ -184,6 +196,26 @@ export class SQLiteLyricsRepository {
     }));
   }
 
+  /**
+   * Get cached interpretation for a track
+   */
+  async getInterpretation(trackId: string): Promise<string | null> {
+    const row = musicDb
+      .prepare(`SELECT interpretation FROM lyrics WHERE track_id = ?`)
+      .get(trackId) as { interpretation: string | null } | undefined;
+    return row?.interpretation ?? null;
+  }
+
+  /**
+   * Save AI-generated interpretation for a track
+   */
+  async saveInterpretation(trackId: string, interpretation: string): Promise<void> {
+    musicDb
+      .prepare(`UPDATE lyrics SET interpretation = ? WHERE track_id = ?`)
+      .run(interpretation, trackId);
+    log.debug({ trackId }, 'Saved interpretation');
+  }
+
   private hydrate(row: LyricsRow): LyricsRecord {
     return {
       trackId: row.track_id,
@@ -191,6 +223,7 @@ export class SQLiteLyricsRepository {
       syncedLyrics: row.synced_lyrics,
       status: row.status,
       fetchedAt: row.fetched_at,
+      interpretation: row.interpretation,
     };
   }
 }

--- a/packages/flows/lyrics/src/backend/routes.ts
+++ b/packages/flows/lyrics/src/backend/routes.ts
@@ -2,7 +2,7 @@ import { Elysia, t } from 'elysia';
 import { LrcLibAdapter } from './adapter';
 import { SQLiteLyricsRepository } from './repository';
 import { SQLiteTrackRepository } from '@flows/spotify/src/backend/repository';
-import { logger } from '@flows/core';
+import { logger, LLMClient } from '@flows/core';
 import type { LyricsStatus } from '@flows/shared';
 
 const log = logger.child({ module: 'LyricsRoutes' });
@@ -164,5 +164,93 @@ export function createLyricsRoutes() {
       .get('/stats', async ({ lyricsRepository }) => {
         return lyricsRepository.getStats();
       })
+
+      // ── AI Interpretation (SSE) ────────────────────────────────────
+      .post(
+        '/:trackId/interpret',
+        async ({ params, lyricsRepository, trackRepository }) => {
+          const { trackId } = params;
+
+          // Check if we already have a cached interpretation
+          const cached = await lyricsRepository.getInterpretation(trackId);
+          if (cached) {
+            log.debug({ trackId }, 'Returning cached interpretation');
+            const encoder = new TextEncoder();
+            return new Response(
+              new ReadableStream({
+                start(controller) {
+                  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'cached', interpretation: cached })}\n\n`));
+                  controller.close();
+                },
+              }),
+              { headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' } },
+            );
+          }
+
+          // Need lyrics + track info
+          const lyrics = await lyricsRepository.findByTrackId(trackId);
+          if (!lyrics || lyrics.status !== 'found' || !lyrics.plainLyrics) {
+            return new Response(JSON.stringify({ error: 'Lyrics not found for this track' }), { status: 404 });
+          }
+
+          const track = await trackRepository.findById(trackId);
+          const artist = track?.artists?.[0]?.name || 'Unknown Artist';
+          const title = track?.title || 'Unknown Song';
+
+          log.info({ trackId, artist, title }, 'Generating AI interpretation');
+
+          const client = LLMClient.createRotation();
+          const stream = client.generateStream({
+            messages: [
+              {
+                role: 'system',
+                content:
+                  'You are a music analyst. Analyze the following song lyrics. ' +
+                  'Explain what the song is about, its themes, emotions, and any notable metaphors or references. ' +
+                  'Write in the same language as the lyrics. Be concise but insightful. ' +
+                  'Use Markdown formatting for structure.',
+              },
+              {
+                role: 'user',
+                content: `Song: "${title}" by ${artist}\n\nLyrics:\n${lyrics.plainLyrics}`,
+              },
+            ],
+          });
+
+          const readable = new ReadableStream({
+            async start(controller) {
+              const encoder = new TextEncoder();
+              let fullText = '';
+              try {
+                for await (const event of stream) {
+                  if (event.done && event.response) {
+                    // Save to DB
+                    await lyricsRepository.saveInterpretation(trackId, fullText);
+                    controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'done' })}\n\n`));
+                  } else if (event.delta) {
+                    fullText += event.delta;
+                    controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'delta', delta: event.delta })}\n\n`));
+                  }
+                }
+              } catch (error) {
+                const errMsg = error instanceof Error ? error.message : String(error);
+                log.error({ trackId, error: errMsg }, 'Interpretation stream error');
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'error', error: errMsg })}\n\n`));
+              } finally {
+                controller.close();
+              }
+            },
+          });
+
+          return new Response(readable, {
+            headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' },
+          });
+        },
+        {
+          params: t.Object({
+            trackId: t.String(),
+          }),
+        },
+      )
   );
 }

--- a/packages/flows/spotify/package.json
+++ b/packages/flows/spotify/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "build": "tsc",
         "dev": "tsc --watch",
+        "test": "vitest run",
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {

--- a/packages/flows/spotify/src/backend/adapter/adapter.ts
+++ b/packages/flows/spotify/src/backend/adapter/adapter.ts
@@ -7,9 +7,10 @@ import type {
   SpotifySavedTrack,
   SpotifyPaging,
   SpotifyTokenResponse,
-  SpotifyArtistsResponse,
+  SpotifyArtistFull,
 } from './types.js';
 import { logger } from '@flows/core';
+import { ArtistCacheRepository } from '../artist-cache.repository';
 
 const log = logger.child({ module: 'SpotifyApiAdapter' });
 
@@ -25,12 +26,14 @@ export class SpotifyApiAdapter implements SourcePort {
   private client: AxiosInstance;
   private accessToken: string | null = null;
   private tokenRepository?: SQLiteTokenRepository;
+  private artistCache: ArtistCacheRepository;
 
   constructor(
     private config: SpotifyConfig,
     tokenRepository?: SQLiteTokenRepository,
   ) {
     this.tokenRepository = tokenRepository;
+    this.artistCache = new ArtistCacheRepository();
     this.client = axios.create({
       baseURL: 'https://api.spotify.com/v1',
     });
@@ -244,7 +247,6 @@ export class SpotifyApiAdapter implements SourcePort {
       },
       addedAt: item.added_at,
       durationMs: t.duration_ms || 0,
-      popularity: t.popularity,
       previewUrl: t.preview_url || undefined,
       spotifyUrl: t.id ? `https://open.spotify.com/track/${t.id}` : undefined,
     };
@@ -252,8 +254,8 @@ export class SpotifyApiAdapter implements SourcePort {
 
   /**
    * Fetch genres and images for a list of artist IDs.
-   * Spotify API allows up to 50 artists per request.
-   * Returns a Map of artistId -> { genres: string[], imageUrl?: string }
+   * Uses SQLite cache first, then fetches misses individually via GET /artists/{id}.
+   * (Feb 2026 migration: batch GET /artists was removed)
    */
   async fetchArtistDetails(
     artistIds: string[],
@@ -263,39 +265,54 @@ export class SpotifyApiAdapter implements SourcePort {
     const detailsMap = new Map<string, { genres: string[]; imageUrl?: string }>();
     const uniqueIds = [...new Set(artistIds)];
 
-    log.info({ artistCount: uniqueIds.length }, 'Fetching artist details from Spotify');
+    // 1. Check cache first
+    const { cached, misses } = this.artistCache.getMany(uniqueIds);
+    for (const [id, entry] of cached) {
+      detailsMap.set(id, { genres: entry.genres, imageUrl: entry.imageUrl });
+    }
 
-    // Batch in chunks of 50 (Spotify limit)
-    const batchSize = 50;
-    for (let i = 0; i < uniqueIds.length; i += batchSize) {
-      const batch = uniqueIds.slice(i, i + batchSize);
-      const ids = batch.join(',');
+    if (misses.length === 0) {
+      log.info({ artistCount: uniqueIds.length, allCached: true }, 'All artist details from cache');
+      return detailsMap;
+    }
 
-      try {
-        const response: AxiosResponse<SpotifyArtistsResponse> = await this.client.get(
-          `/artists?ids=${ids}`,
-        );
+    log.info(
+      { total: uniqueIds.length, cached: cached.size, toFetch: misses.length },
+      'Fetching uncached artist details individually',
+    );
 
-        if (!response.data?.artists) {
-          continue;
+    // 2. Fetch misses individually in controlled batches of 5
+    const concurrency = 5;
+    for (let i = 0; i < misses.length; i += concurrency) {
+      const batch = misses.slice(i, i + concurrency);
+
+      const results = await Promise.allSettled(
+        batch.map(async (id) => {
+          const response: AxiosResponse<SpotifyArtistFull> = await this.client.get(
+            `/artists/${id}`,
+          );
+          return response.data;
+        }),
+      );
+
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value) {
+          const artist = result.value;
+          const image =
+            artist.images?.find((img) => img.width === 160) || artist.images?.[0];
+          const genres = artist.genres || [];
+          const imageUrl = image?.url;
+
+          detailsMap.set(artist.id, { genres, imageUrl });
+
+          // Save to cache
+          this.artistCache.set(artist.id, genres, imageUrl);
         }
+      }
 
-        for (const artist of response.data.artists) {
-          if (artist) {
-            // Get small image (160px) for artist avatar
-            const image = artist.images?.find((img) => img.width === 160) || artist.images?.[0];
-            detailsMap.set(artist.id, {
-              genres: artist.genres || [],
-              imageUrl: image?.url,
-            });
-          }
-        }
-      } catch (error) {
-        // Log but don't fail the whole operation
-        log.error(
-          { batchStart: i, error: error instanceof Error ? error.message : 'Unknown' },
-          'Failed to fetch artist details batch',
-        );
+      // Small delay between batches to respect rate limits
+      if (i + concurrency < misses.length) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
     }
 

--- a/packages/flows/spotify/src/backend/adapter/adapter.ts
+++ b/packages/flows/spotify/src/backend/adapter/adapter.ts
@@ -281,8 +281,12 @@ export class SpotifyApiAdapter implements SourcePort {
       'Fetching uncached artist details individually',
     );
 
-    // 2. Fetch misses individually in controlled batches of 5
-    const concurrency = 5;
+    // 2. Fetch misses individually — conservative to avoid 429s
+    //    First sync is slow (~10 min for 2000+ artists) but subsequent syncs are instant from cache.
+    const concurrency = 2;
+    const delayMs = 500;
+    let fetched = 0;
+
     for (let i = 0; i < misses.length; i += concurrency) {
       const batch = misses.slice(i, i + concurrency);
 
@@ -304,15 +308,22 @@ export class SpotifyApiAdapter implements SourcePort {
           const imageUrl = image?.url;
 
           detailsMap.set(artist.id, { genres, imageUrl });
-
-          // Save to cache
           this.artistCache.set(artist.id, genres, imageUrl);
+          fetched++;
         }
       }
 
-      // Small delay between batches to respect rate limits
+      // Progress logging every 50 artists
+      if (fetched % 50 < concurrency && fetched > 0) {
+        log.info(
+          { fetched, total: misses.length, pct: Math.round((fetched / misses.length) * 100) },
+          'Artist fetch progress',
+        );
+      }
+
+      // Respectful delay between requests
       if (i + concurrency < misses.length) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }
 

--- a/packages/flows/spotify/src/backend/adapter/types.ts
+++ b/packages/flows/spotify/src/backend/adapter/types.ts
@@ -24,7 +24,6 @@ export interface SpotifyTrack {
   name: string;
   uri: string;
   duration_ms: number;
-  popularity: number;
   preview_url: string | null;
   album: SpotifyAlbumSimple;
   artists: SpotifyArtistSimple[];
@@ -57,8 +56,6 @@ export interface SpotifyArtistFull {
   id: string;
   name: string;
   genres: string[];
-  popularity: number;
-  followers: { total: number };
   images: SpotifyImage[];
 }
 

--- a/packages/flows/spotify/src/backend/adapter/types.ts
+++ b/packages/flows/spotify/src/backend/adapter/types.ts
@@ -58,7 +58,3 @@ export interface SpotifyArtistFull {
   genres: string[];
   images: SpotifyImage[];
 }
-
-export interface SpotifyArtistsResponse {
-  artists: SpotifyArtistFull[];
-}

--- a/packages/flows/spotify/src/backend/artist-cache.repository.ts
+++ b/packages/flows/spotify/src/backend/artist-cache.repository.ts
@@ -1,0 +1,58 @@
+import { musicDb } from './database';
+import { logger } from '@flows/core';
+
+const log = logger.child({ module: 'ArtistCacheRepository' });
+
+export interface CachedArtist {
+    id: string;
+    genres: string[];
+    imageUrl?: string;
+    cachedAt: number;
+}
+
+export class ArtistCacheRepository {
+    /**
+     * Get multiple artists from cache. Returns a map of found entries
+     * and an array of IDs that were not in the cache.
+     */
+    getMany(ids: string[]): { cached: Map<string, CachedArtist>; misses: string[] } {
+        const cached = new Map<string, CachedArtist>();
+        const misses: string[] = [];
+
+        const stmt = musicDb.prepare(
+            'SELECT id, genres, image_url, cached_at FROM artist_cache WHERE id = ?',
+        );
+
+        for (const id of ids) {
+            const row = stmt.get(id) as
+                | { id: string; genres: string | null; image_url: string | null; cached_at: number }
+                | undefined;
+
+            if (row) {
+                cached.set(row.id, {
+                    id: row.id,
+                    genres: row.genres ? JSON.parse(row.genres) : [],
+                    imageUrl: row.image_url ?? undefined,
+                    cachedAt: row.cached_at,
+                });
+            } else {
+                misses.push(id);
+            }
+        }
+
+        log.debug({ cached: cached.size, misses: misses.length }, 'Artist cache lookup');
+        return { cached, misses };
+    }
+
+    /**
+     * Upsert a single artist into the cache.
+     */
+    set(id: string, genres: string[], imageUrl?: string): void {
+        musicDb
+            .prepare(
+                `INSERT OR REPLACE INTO artist_cache (id, genres, image_url, cached_at)
+         VALUES (?, ?, ?, ?)`,
+            )
+            .run(id, JSON.stringify(genres), imageUrl ?? null, Date.now());
+    }
+}

--- a/packages/flows/spotify/src/backend/database.ts
+++ b/packages/flows/spotify/src/backend/database.ts
@@ -15,7 +15,6 @@ musicDb.exec(`
     title TEXT NOT NULL,
     added_at TEXT,
     duration_ms INTEGER,
-    popularity INTEGER,
     album_id TEXT,
     album_name TEXT,
     album_release_date TEXT,
@@ -48,10 +47,17 @@ musicDb.exec(`
 
   -- Indexes for common queries
   CREATE INDEX IF NOT EXISTS idx_tracks_added_at ON tracks(added_at DESC);
-  CREATE INDEX IF NOT EXISTS idx_tracks_popularity ON tracks(popularity DESC);
   CREATE INDEX IF NOT EXISTS idx_tracks_album_year ON tracks(album_release_year DESC);
   CREATE INDEX IF NOT EXISTS idx_artists_name ON artists(name);
   CREATE INDEX IF NOT EXISTS idx_artist_genres_genre ON artist_genres(genre);
+
+  -- Artist cache for individual Spotify API lookups (Feb 2026 migration)
+  CREATE TABLE IF NOT EXISTS artist_cache (
+    id TEXT PRIMARY KEY,
+    genres TEXT,
+    image_url TEXT,
+    cached_at INTEGER
+  );
 
   -- Token cache for Spotify access tokens
   CREATE TABLE IF NOT EXISTS token_cache (

--- a/packages/flows/spotify/src/backend/repository.ts
+++ b/packages/flows/spotify/src/backend/repository.ts
@@ -69,18 +69,21 @@ export class SQLiteTrackRepository implements TrackRepository {
     `);
 
     const insertArtist = musicDb.prepare(`
-      INSERT OR REPLACE INTO artists (id, name, image_url)
+      INSERT INTO artists (id, name, image_url)
       VALUES (@id, @name, @imageUrl)
+      ON CONFLICT(id) DO UPDATE SET 
+        name = excluded.name,
+        image_url = excluded.image_url
     `);
 
     const deleteTrackArtists = musicDb.prepare(`DELETE FROM track_artists WHERE track_id = ?`);
     const insertTrackArtist = musicDb.prepare(`
-      INSERT OR REPLACE INTO track_artists (track_id, artist_id)
+      INSERT OR IGNORE INTO track_artists (track_id, artist_id)
       VALUES (?, ?)
     `);
 
     const insertGenre = musicDb.prepare(`
-      INSERT OR REPLACE INTO artist_genres (artist_id, genre)
+      INSERT OR IGNORE INTO artist_genres (artist_id, genre)
       VALUES (?, ?)
     `);
 

--- a/packages/flows/spotify/src/backend/repository.ts
+++ b/packages/flows/spotify/src/backend/repository.ts
@@ -21,7 +21,6 @@ interface TrackRow {
   title: string;
   added_at: string | null;
   duration_ms: number | null;
-  popularity: number | null;
   album_id: string | null;
   album_name: string | null;
   album_release_date: string | null;
@@ -50,8 +49,7 @@ export interface SearchOptions extends PaginationOptions {
   query?: string;
   genre?: string;
   year?: number;
-  minPopularity?: number;
-  sortBy?: 'added_at' | 'popularity' | 'title';
+  sortBy?: 'added_at' | 'title';
   sortOrder?: 'asc' | 'desc';
 }
 
@@ -66,8 +64,8 @@ export interface PaginatedResult<T> {
 export class SQLiteTrackRepository implements TrackRepository {
   async save(tracks: Track[]): Promise<void> {
     const insertTrack = musicDb.prepare(`
-      INSERT OR REPLACE INTO tracks (id, title, added_at, duration_ms, popularity, album_id, album_name, album_release_date, album_release_year, album_image_url, preview_url, spotify_url)
-      VALUES (@id, @title, @addedAt, @durationMs, @popularity, @albumId, @albumName, @releaseDate, @releaseYear, @imageUrl, @previewUrl, @spotifyUrl)
+      INSERT OR REPLACE INTO tracks (id, title, added_at, duration_ms, album_id, album_name, album_release_date, album_release_year, album_image_url, preview_url, spotify_url)
+      VALUES (@id, @title, @addedAt, @durationMs, @albumId, @albumName, @releaseDate, @releaseYear, @imageUrl, @previewUrl, @spotifyUrl)
     `);
 
     const insertArtist = musicDb.prepare(`
@@ -94,7 +92,6 @@ export class SQLiteTrackRepository implements TrackRepository {
           title: track.title || 'Unknown Title',
           addedAt: track.addedAt,
           durationMs: track.durationMs,
-          popularity: track.popularity ?? null,
           albumId: track.album.id,
           albumName: track.album.name || 'Unknown Album',
           releaseDate: track.album.releaseDate,
@@ -173,12 +170,6 @@ export class SQLiteTrackRepository implements TrackRepository {
       params.push(options.year);
     }
 
-    // Min popularity
-    if (options.minPopularity) {
-      conditions.push(`t.popularity >= ?`);
-      params.push(options.minPopularity);
-    }
-
     if (conditions.length > 0) {
       whereClause = `WHERE ${conditions.join(' AND ')}`;
     }
@@ -188,9 +179,6 @@ export class SQLiteTrackRepository implements TrackRepository {
     if (options.sortBy) {
       const dir = options.sortOrder === 'asc' ? 'ASC' : 'DESC';
       switch (options.sortBy) {
-        case 'popularity':
-          orderClause = `ORDER BY t.popularity ${dir}`;
-          break;
         case 'title':
           orderClause = `ORDER BY t.title ${dir}`;
           break;
@@ -312,7 +300,6 @@ export class SQLiteTrackRepository implements TrackRepository {
       },
       addedAt: row.added_at || '',
       durationMs: row.duration_ms || 0,
-      popularity: row.popularity ?? undefined,
       previewUrl: row.preview_url ?? undefined,
       spotifyUrl: row.spotify_url ?? undefined,
     };

--- a/packages/flows/spotify/src/backend/routes.ts
+++ b/packages/flows/spotify/src/backend/routes.ts
@@ -127,8 +127,7 @@ export function createSpotifyRoutes(config: SpotifyRoutesConfig) {
             query: query.q,
             genre: query.genre,
             year: query.year,
-            minPopularity: query.minPopularity,
-            sortBy: query.sortBy as 'added_at' | 'popularity' | 'title' | undefined,
+            sortBy: query.sortBy as 'added_at' | 'title' | undefined,
             sortOrder: query.sortOrder as 'asc' | 'desc' | undefined,
           });
         },
@@ -139,7 +138,6 @@ export function createSpotifyRoutes(config: SpotifyRoutesConfig) {
             q: t.Optional(t.String()),
             genre: t.Optional(t.String()),
             year: t.Optional(t.Numeric()),
-            minPopularity: t.Optional(t.Numeric()),
             sortBy: t.Optional(t.String()),
             sortOrder: t.Optional(t.String()),
           }),

--- a/packages/flows/spotify/tests/backend/artist-cache.test.ts
+++ b/packages/flows/spotify/tests/backend/artist-cache.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { ArtistCacheRepository } from '../../src/backend/artist-cache.repository';
+
+// We need to mock the musicDb used inside ArtistCacheRepository.
+// The repository imports from './database', so we mock that module.
+import { vi } from 'vitest';
+
+// Create an in-memory SQLite database for testing
+let testDb: Database.Database;
+
+vi.mock('../../src/backend/database', () => {
+    return {
+        musicDb: (() => {
+            const db = new Database(':memory:');
+            db.exec(`
+        CREATE TABLE IF NOT EXISTS artist_cache (
+          id TEXT PRIMARY KEY,
+          genres TEXT,
+          image_url TEXT,
+          cached_at INTEGER
+        );
+      `);
+            return db;
+        })(),
+    };
+});
+
+describe('ArtistCacheRepository', () => {
+    let repo: ArtistCacheRepository;
+
+    beforeEach(async () => {
+        // Import the mocked musicDb and clear it
+        const { musicDb } = await import('../../src/backend/database');
+        testDb = musicDb as unknown as Database.Database;
+        testDb.exec('DELETE FROM artist_cache');
+
+        repo = new ArtistCacheRepository();
+    });
+
+    describe('set', () => {
+        it('should insert a new artist into the cache', () => {
+            repo.set('artist-1', ['rock', 'indie'], 'https://img.example.com/1.jpg');
+
+            const row = testDb.prepare('SELECT * FROM artist_cache WHERE id = ?').get('artist-1') as {
+                id: string;
+                genres: string;
+                image_url: string;
+                cached_at: number;
+            };
+
+            expect(row).toBeDefined();
+            expect(row.id).toBe('artist-1');
+            expect(JSON.parse(row.genres)).toEqual(['rock', 'indie']);
+            expect(row.image_url).toBe('https://img.example.com/1.jpg');
+            expect(row.cached_at).toBeGreaterThan(0);
+        });
+
+        it('should upsert (overwrite) existing artist data', () => {
+            repo.set('artist-1', ['rock'], 'https://img.example.com/old.jpg');
+            repo.set('artist-1', ['pop', 'electronic'], 'https://img.example.com/new.jpg');
+
+            const row = testDb.prepare('SELECT * FROM artist_cache WHERE id = ?').get('artist-1') as {
+                genres: string;
+                image_url: string;
+            };
+
+            expect(JSON.parse(row.genres)).toEqual(['pop', 'electronic']);
+            expect(row.image_url).toBe('https://img.example.com/new.jpg');
+        });
+
+        it('should handle artist with no image', () => {
+            repo.set('artist-no-img', ['jazz']);
+
+            const row = testDb.prepare('SELECT * FROM artist_cache WHERE id = ?').get('artist-no-img') as {
+                image_url: string | null;
+            };
+
+            expect(row.image_url).toBeNull();
+        });
+    });
+
+    describe('getMany', () => {
+        it('should return cached entries and report misses', () => {
+            repo.set('a1', ['rock'], 'https://img/a1.jpg');
+            repo.set('a2', ['pop'], 'https://img/a2.jpg');
+
+            const { cached, misses } = repo.getMany(['a1', 'a2', 'a3', 'a4']);
+
+            expect(cached.size).toBe(2);
+            expect(cached.get('a1')!.genres).toEqual(['rock']);
+            expect(cached.get('a1')!.imageUrl).toBe('https://img/a1.jpg');
+            expect(cached.get('a2')!.genres).toEqual(['pop']);
+            expect(misses).toEqual(['a3', 'a4']);
+        });
+
+        it('should return all misses when cache is empty', () => {
+            const { cached, misses } = repo.getMany(['x1', 'x2']);
+
+            expect(cached.size).toBe(0);
+            expect(misses).toEqual(['x1', 'x2']);
+        });
+
+        it('should return all cached when every ID hits', () => {
+            repo.set('b1', ['classical']);
+            repo.set('b2', ['blues']);
+
+            const { cached, misses } = repo.getMany(['b1', 'b2']);
+
+            expect(cached.size).toBe(2);
+            expect(misses).toHaveLength(0);
+        });
+
+        it('should handle empty input array', () => {
+            const { cached, misses } = repo.getMany([]);
+
+            expect(cached.size).toBe(0);
+            expect(misses).toHaveLength(0);
+        });
+    });
+});

--- a/packages/flows/spotify/vitest.config.ts
+++ b/packages/flows/spotify/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['tests/**/*.test.ts'],
+    },
+    resolve: {
+        alias: {
+            '@flows/core': path.resolve(__dirname, '../../core/src/index.ts'),
+            '@flows/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+        },
+    },
+});

--- a/packages/shared/src/chat.types.ts
+++ b/packages/shared/src/chat.types.ts
@@ -15,8 +15,11 @@ export interface ChatMessage {
     role: 'user' | 'assistant' | 'system';
     content: string;
     modelUsed: string;
+    providerUsed?: string;
     createdAt: number;
 }
+
+// ── Model selector types ─────────────────────────────────────────────
 
 export interface ChatProviderOption {
     id: string;
@@ -24,8 +27,25 @@ export interface ChatProviderOption {
     provider: string;
 }
 
+export interface ChatModelCatalogEntry {
+    id: string;
+    name: string;
+    tier: string;
+    pricing: string;
+    contextWindow: number;
+    description?: string;
+}
+
+export interface ChatProviderGroup {
+    provider: string;
+    models: ChatModelCatalogEntry[];
+}
+
+export type ChatMode = 'rotation' | 'specific';
+
 export interface ChatRequest {
     conversationId: string;
     message: string;
-    model: string;
+    model?: string;
+    mode?: ChatMode;
 }

--- a/packages/shared/src/common.types.ts
+++ b/packages/shared/src/common.types.ts
@@ -17,8 +17,7 @@ export interface SearchOptions {
     q?: string;
     genre?: string;
     year?: number;
-    minPopularity?: number;
-    sortBy?: 'added_at' | 'popularity' | 'title';
+    sortBy?: 'added_at' | 'title';
     sortOrder?: 'asc' | 'desc';
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -48,5 +48,8 @@ export type {
     ChatConversation,
     ChatMessage,
     ChatProviderOption,
+    ChatModelCatalogEntry,
+    ChatProviderGroup,
+    ChatMode,
     ChatRequest,
 } from './chat.types';

--- a/packages/shared/src/lyrics.types.ts
+++ b/packages/shared/src/lyrics.types.ts
@@ -10,6 +10,7 @@ export interface Lyrics {
     syncedLyrics: string | null;
     status: LyricsStatus;
     fetchedAt: string | null;
+    interpretation?: string | null;
 }
 
 export interface LyricsStats {

--- a/packages/shared/src/spotify.types.ts
+++ b/packages/shared/src/spotify.types.ts
@@ -24,7 +24,6 @@ export interface Track {
     album: Album;
     addedAt: string;
     durationMs: number;
-    popularity?: number;
     previewUrl?: string;
     spotifyUrl?: string;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/postcss": "^4.1.17",
     "@tailwindcss/vite": "^4.1.17",
     "@tsconfig/svelte": "^5.0.6",
+    "@types/dompurify": "^3.2.0",
     "@types/node": "^24.10.1",
     "@typescript-eslint/eslint-plugin": "^8.48.1",
     "@typescript-eslint/parser": "^8.48.1",
@@ -47,7 +48,9 @@
     "@flows/spotify": "workspace:*",
     "@flows/trading": "workspace:*",
     "chart.js": "^4.5.1",
+    "dompurify": "^3.3.2",
     "lightweight-charts": "^5.1.0",
+    "marked": "^17.0.4",
     "svelte-5-french-toast": "^2.0.6",
     "svelte-lightweight-charts": "^2.2.0"
   }

--- a/packages/ui/src/lib/flows/chat/ChatFlow.svelte
+++ b/packages/ui/src/lib/flows/chat/ChatFlow.svelte
@@ -3,7 +3,6 @@
   import MessageList from './components/MessageList.svelte';
   import ChatInput from './components/ChatInput.svelte';
   import ModelSelector from './components/ModelSelector.svelte';
-  import { chatStore } from './stores';
   import FlowLayout from '../../components/layout/FlowLayout.svelte';
 
   let isMobileMenuOpen = false;
@@ -51,30 +50,6 @@
 
         <ModelSelector />
       </header>
-
-      <!-- Error Banner -->
-      {#if $chatStore.error}
-        <div
-          class="bg-red-500/10 border-l-4 border-red-500 p-3 mx-4 mt-4 shadow-md rounded-r-md shrink-0"
-        >
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                <path
-                  fill-rule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-red-300">
-                {$chatStore.error}
-              </p>
-            </div>
-          </div>
-        </div>
-      {/if}
 
       <MessageList />
       <ChatInput />

--- a/packages/ui/src/lib/flows/chat/api.ts
+++ b/packages/ui/src/lib/flows/chat/api.ts
@@ -46,6 +46,7 @@ export async function deleteConversation(conversationId: string): Promise<void> 
   if (error) throw extractError(error);
 }
 
+/** Non-streaming message send (fallback). */
 export async function sendMessage(
   conversationId: string,
   message: string,
@@ -60,4 +61,59 @@ export async function sendMessage(
   });
   if (error) throw extractError(error);
   return data as { userMessage: ChatMessage; assistantMessage: ChatMessage };
+}
+
+/** SSE event types from the backend. */
+export type StreamEvent =
+  | { type: 'user_message'; message: ChatMessage }
+  | { type: 'delta'; delta: string }
+  | { type: 'done'; message: ChatMessage }
+  | { type: 'error'; error: string };
+
+/**
+ * Streaming message send via SSE.
+ * Calls a callback for each event as it arrives.
+ */
+export async function sendMessageStream(
+  conversationId: string,
+  message: string,
+  mode: ChatMode,
+  model: string | undefined,
+  onEvent: (event: StreamEvent) => void
+): Promise<void> {
+  const response = await fetch('http://localhost:4173/chat/message/stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ conversationId, message, mode, model }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Stream error ${response.status}: ${text}`);
+  }
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n\n');
+    buffer = lines.pop()!;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data: ')) continue;
+
+      try {
+        const event = JSON.parse(trimmed.slice(6)) as StreamEvent;
+        onEvent(event);
+      } catch {
+        // skip malformed SSE
+      }
+    }
+  }
 }

--- a/packages/ui/src/lib/flows/chat/api.ts
+++ b/packages/ui/src/lib/flows/chat/api.ts
@@ -1,10 +1,5 @@
 import { api } from '@lib/client';
-import type {
-  ChatConversation,
-  ChatMessage,
-  ChatProviderGroup,
-  ChatMode,
-} from '@flows/shared';
+import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
 
 // Typed Eden client for the chat routes
 const chatApi = api.chat;
@@ -55,7 +50,7 @@ export async function sendMessage(
   conversationId: string,
   message: string,
   mode: ChatMode,
-  model?: string,
+  model?: string
 ): Promise<{ userMessage: ChatMessage; assistantMessage: ChatMessage }> {
   const { data, error } = await chatApi.message.post({
     conversationId,

--- a/packages/ui/src/lib/flows/chat/api.ts
+++ b/packages/ui/src/lib/flows/chat/api.ts
@@ -1,5 +1,10 @@
 import { api } from '@lib/client';
-import type { ChatConversation, ChatMessage, ChatProviderOption } from '@flows/shared';
+import type {
+  ChatConversation,
+  ChatMessage,
+  ChatProviderGroup,
+  ChatMode,
+} from '@flows/shared';
 
 // Typed Eden client for the chat routes
 const chatApi = api.chat;
@@ -10,9 +15,7 @@ const chatApi = api.chat;
 function extractError(error: unknown): Error {
   if (!error) return new Error('Unknown API Error');
 
-  // Convert to a generic object to safely check properties
   const errObj = error as Record<string, unknown>;
-
   const valueObj = errObj?.value as Record<string, unknown> | undefined;
 
   const msg =
@@ -25,10 +28,10 @@ function extractError(error: unknown): Error {
   return new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
 }
 
-export async function fetchModels(): Promise<ChatProviderOption[]> {
+export async function fetchModelCatalog(): Promise<ChatProviderGroup[]> {
   const { data, error } = await chatApi.models.get();
   if (error) throw extractError(error);
-  return data as ChatProviderOption[];
+  return data as ChatProviderGroup[];
 }
 
 export async function fetchConversations(): Promise<ChatConversation[]> {
@@ -51,11 +54,13 @@ export async function deleteConversation(conversationId: string): Promise<void> 
 export async function sendMessage(
   conversationId: string,
   message: string,
-  model?: string
+  mode: ChatMode,
+  model?: string,
 ): Promise<{ userMessage: ChatMessage; assistantMessage: ChatMessage }> {
   const { data, error } = await chatApi.message.post({
     conversationId,
     message,
+    mode,
     model,
   });
   if (error) throw extractError(error);

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
@@ -64,9 +64,7 @@
       </svg>
     </button>
   </div>
-  <div class="text-center mt-2">
-    <span class="text-[11px] text-slate-500"
-      >AI can make mistakes. Consider verifying important information.</span
-    >
-  </div>
+  <p class="text-center mt-2 text-[11px] text-slate-500 cursor-default select-none">
+    AI can make mistakes. Consider verifying important information.
+  </p>
 </div>

--- a/packages/ui/src/lib/flows/chat/components/MessageList.svelte
+++ b/packages/ui/src/lib/flows/chat/components/MessageList.svelte
@@ -21,8 +21,19 @@
 
   /** Render markdown → sanitized HTML. */
   function renderMarkdown(text: string): string {
-    const rawHtml = marked.parse(text, { async: false }) as string;
-    return DOMPurify.sanitize(rawHtml);
+    // Transform <think> tags into a collapsible details block
+    const processedText = text
+      .replace(
+        /<think>/g,
+        '\n<details class="mb-3 border border-slate-700 rounded-md bg-slate-800/40 overflow-hidden"><summary class="px-3 py-2 cursor-pointer text-[10px] uppercase tracking-wider font-semibold text-slate-400 hover:text-slate-300 bg-slate-800/80 select-none flex items-center gap-2"><svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg> Thought Process</summary><div class="px-4 py-3 text-sm text-slate-400 border-t border-slate-700/50 italic">\n\n'
+      )
+      .replace(/<\/think>/g, '\n\n</div></details>\n');
+
+    const rawHtml = marked.parse(processedText, { async: false }) as string;
+    return DOMPurify.sanitize(rawHtml, {
+      ADD_TAGS: ['details', 'summary'],
+      ADD_ATTR: ['class'],
+    });
   }
 
   function getModelDisplayName(msg: { modelUsed?: string; providerUsed?: string }): string {

--- a/packages/ui/src/lib/flows/chat/components/MessageList.svelte
+++ b/packages/ui/src/lib/flows/chat/components/MessageList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { chatStore } from '../stores';
   import { afterUpdate } from 'svelte';
+  import { marked } from 'marked';
+  import DOMPurify from 'dompurify';
 
   let listContainer: HTMLDivElement;
 
@@ -11,30 +13,39 @@
     }
   });
 
-  // Helper to format basic markdown (bold, code segments) - very simple version
-  function formatText(text: string) {
-    // Prevent XSS mostly by escaping < and >
-    let safe = text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  // Configure marked for clean output
+  marked.setOptions({
+    breaks: true,
+    gfm: true,
+  });
 
-    // Bold **text**
-    safe = safe.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+  /** Render markdown → sanitized HTML. */
+  function renderMarkdown(text: string): string {
+    const rawHtml = marked.parse(text, { async: false }) as string;
+    return DOMPurify.sanitize(rawHtml);
+  }
 
-    // Code `text`
-    safe = safe.replace(
-      /`([^`]+)`/g,
-      '<code class="bg-black/30 px-1 py-0.5 rounded text-cosmic-300 font-mono text-sm">$1</code>'
-    );
+  function getModelDisplayName(msg: { modelUsed?: string; providerUsed?: string }): string {
+    if (!msg.modelUsed) return '';
+    const provider = msg.providerUsed || '';
+    const model = msg.modelUsed || '';
 
-    // Code blocks ```text```
-    safe = safe.replace(
-      /```(\w*)\n([\s\S]*?)```/g,
-      '<pre class="bg-slate-900 border border-slate-700 p-3 rounded-md my-2 overflow-x-auto text-sm font-mono text-slate-300"><code>$2</code></pre>'
-    );
+    // Try to find human-readable name from catalog
+    for (const group of $chatStore.catalog) {
+      if (group.provider === provider) {
+        const found = group.models.find((m) => m.id === model);
+        if (found) return `${provider} / ${found.name}`;
+      }
+    }
+    // Fallback: clean ID
+    const cleaned = model
+      .replace(/:free$/, '')
+      .split(/[-/]/)
+      .filter((w) => w !== '')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
 
-    // Newlines to <br>
-    safe = safe.replace(/\n/g, '<br/>');
-
-    return safe;
+    return provider ? `${provider} / ${cleaned}` : cleaned;
   }
 </script>
 
@@ -42,7 +53,7 @@
   bind:this={listContainer}
   class="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 scrollbar-thin scroll-smooth"
 >
-  {#if $chatStore.messages.length === 0}
+  {#if $chatStore.messages.length === 0 && !$chatStore.isStreaming}
     <div class="h-full flex flex-col items-center justify-center text-slate-500 space-y-4">
       <div
         class="w-16 h-16 rounded-full bg-cosmic-900/50 flex items-center justify-center border border-cosmic-500/30"
@@ -63,7 +74,19 @@
         <div
           class="w-8 h-8 rounded-full bg-cosmic-700 flex-shrink-0 flex items-center justify-center mr-3 mt-1 shadow-glow-sm"
         >
-          <span class="text-xs">🤖</span>
+          <svg
+            class="w-4 h-4 text-cosmic-300"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
+            />
+          </svg>
         </div>
       {/if}
 
@@ -74,44 +97,76 @@
             : 'bg-transparent border border-cosmic-800 text-slate-200 rounded-tl-sm shadow-sm'
         }`}
       >
-        <div class="prose prose-invert prose-sm max-w-none leading-relaxed prose-p:my-1">
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-          {@html formatText(msg.content)}
-        </div>
+        {#if msg.role === 'user'}
+          <p class="text-sm leading-relaxed whitespace-pre-wrap">{msg.content}</p>
+        {:else}
+          <div
+            class="prose prose-invert prose-sm max-w-none leading-relaxed prose-p:my-1 prose-pre:bg-slate-900 prose-pre:border prose-pre:border-slate-700 prose-code:text-cosmic-300 prose-code:before:content-[''] prose-code:after:content-['']"
+          >
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html renderMarkdown(msg.content)}
+          </div>
+        {/if}
 
         {#if msg.role === 'assistant' && msg.modelUsed}
           <div class="mt-2 text-[10px] text-slate-500 flex justify-end">
-            <span class="bg-slate-800 px-2 py-0.5 rounded-full border border-slate-700"
-              >{msg.modelUsed}</span
-            >
+            <span class="bg-slate-800 px-2 py-0.5 rounded-full border border-slate-700 capitalize">
+              {getModelDisplayName(msg)}
+            </span>
           </div>
         {/if}
       </div>
     </div>
   {/each}
 
-  {#if $chatStore.isLoading}
+  <!-- Streaming message (in progress) -->
+  {#if $chatStore.isStreaming}
     <div class="flex w-full justify-start">
       <div
-        class="w-8 h-8 rounded-full bg-cosmic-700 flex-shrink-0 flex items-center justify-center mr-3 shadow-glow-sm"
+        class="w-8 h-8 rounded-full bg-cosmic-700 flex-shrink-0 flex items-center justify-center mr-3 mt-1 shadow-glow-sm"
       >
-        <span class="text-xs">🤖</span>
+        <svg
+          class="w-4 h-4 text-cosmic-300 animate-pulse"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.5"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
+          />
+        </svg>
       </div>
       <div
-        class="bg-transparent border border-cosmic-800 rounded-2xl rounded-tl-sm px-5 py-4 flex items-center gap-1"
+        class="max-w-[85%] md:max-w-[75%] bg-transparent border border-cosmic-800 rounded-2xl rounded-tl-sm px-5 py-3 shadow-sm"
       >
-        <div
-          class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
-          style="animation-delay: 0ms"
-        ></div>
-        <div
-          class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
-          style="animation-delay: 150ms"
-        ></div>
-        <div
-          class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
-          style="animation-delay: 300ms"
-        ></div>
+        {#if $chatStore.streamingContent}
+          <div
+            class="prose prose-invert prose-sm max-w-none leading-relaxed prose-p:my-1 prose-pre:bg-slate-900 prose-pre:border prose-pre:border-slate-700 prose-code:text-cosmic-300 prose-code:before:content-[''] prose-code:after:content-['']"
+          >
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html renderMarkdown($chatStore.streamingContent)}
+          </div>
+          <span class="inline-block w-0.5 h-4 bg-cosmic-400 animate-pulse ml-0.5 align-text-bottom"
+          ></span>
+        {:else}
+          <div class="flex items-center gap-1.5 py-1">
+            <div
+              class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
+              style="animation-delay: 0ms"
+            ></div>
+            <div
+              class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
+              style="animation-delay: 150ms"
+            ></div>
+            <div
+              class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
+              style="animation-delay: 300ms"
+            ></div>
+          </div>
+        {/if}
       </div>
     </div>
   {/if}

--- a/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
@@ -22,7 +22,6 @@
     }
   }
 
-  // Close dropdown on click outside
   function handleClickOutside(e: MouseEvent) {
     const target = e.target as HTMLElement;
     if (!target.closest('.model-selector-container')) {
@@ -30,7 +29,6 @@
     }
   }
 
-  // Parse "provider:model" into display parts
   function parseSelected(sel: string): { provider: string; model: string } {
     const idx = sel.indexOf(':');
     if (idx === -1) return { provider: '', model: sel };
@@ -42,9 +40,9 @@
       const found = group.models.find((m) => m.id === modelId);
       if (found) return found.name;
     }
-    // Fallback: format the raw ID nicely
     return modelId
-      .split('-')
+      .split(/[-/]/)
+      .filter((w) => w !== 'free' && w !== '')
       .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
       .join(' ');
   }
@@ -52,15 +50,15 @@
   function tierColor(tier: string): string {
     switch (tier) {
       case 'very_high':
-        return 'text-amber-400 bg-amber-400/10';
+        return 'text-amber-400 bg-amber-400/10 border-amber-400/20';
       case 'high':
-        return 'text-emerald-400 bg-emerald-400/10';
+        return 'text-emerald-400 bg-emerald-400/10 border-emerald-400/20';
       case 'medium':
-        return 'text-blue-400 bg-blue-400/10';
+        return 'text-blue-400 bg-blue-400/10 border-blue-400/20';
       case 'low':
-        return 'text-slate-400 bg-slate-400/10';
+        return 'text-slate-400 bg-slate-400/10 border-slate-400/20';
       default:
-        return 'text-slate-500 bg-slate-500/10';
+        return 'text-slate-500 bg-slate-500/10 border-slate-500/20';
     }
   }
 
@@ -86,47 +84,76 @@
 <svelte:window on:click={handleClickOutside} />
 
 <div class="model-selector-container relative flex items-center gap-1.5">
-  <!-- Mode Toggle -->
-  <div class="flex bg-slate-800 rounded-lg border border-slate-700 overflow-hidden">
+  <!-- Mode Toggle (labeled) -->
+  <div
+    class="flex bg-slate-800 rounded-lg border border-slate-700 overflow-hidden text-xs font-medium"
+  >
     <button
-      class="px-2.5 py-1.5 text-xs font-medium transition-colors"
+      class="flex items-center gap-1 px-3 py-1.5 transition-all"
       class:bg-cosmic-600={$chatStore.chatMode === 'rotation'}
       class:text-white={$chatStore.chatMode === 'rotation'}
       class:text-slate-400={$chatStore.chatMode !== 'rotation'}
       class:hover:text-slate-200={$chatStore.chatMode !== 'rotation'}
       on:click={() => setMode('rotation')}
-      title="Rotate through free providers"
+      title="Round-robin across free providers"
     >
-      🔄
+      <svg
+        class="w-3.5 h-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
+      </svg>
+      <span class="hidden sm:inline">Rotate</span>
     </button>
     <button
-      class="px-2.5 py-1.5 text-xs font-medium transition-colors"
+      class="flex items-center gap-1 px-3 py-1.5 transition-all"
       class:bg-cosmic-600={$chatStore.chatMode === 'specific'}
       class:text-white={$chatStore.chatMode === 'specific'}
       class:text-slate-400={$chatStore.chatMode !== 'specific'}
       class:hover:text-slate-200={$chatStore.chatMode !== 'specific'}
       on:click={() => setMode('specific')}
-      title="Choose a specific model"
+      title="Choose a specific provider and model"
     >
-      🎯
+      <svg
+        class="w-3.5 h-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"
+        />
+      </svg>
+      <span class="hidden sm:inline">Specific</span>
     </button>
   </div>
 
-  <!-- Current Selection / Badge -->
+  <!-- Badge / Selector -->
   {#if $chatStore.chatMode === 'rotation'}
     <div
       class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800/50 rounded-lg border border-slate-700/50 text-xs"
     >
       {#if $chatStore.lastProvider}
-        <span class="text-cosmic-400 font-medium">{$chatStore.lastProvider}</span>
+        <span class="text-cosmic-400 font-medium capitalize">{$chatStore.lastProvider}</span>
         <span class="text-slate-600">/</span>
-        <span class="text-slate-300 truncate max-w-[120px]">{$chatStore.lastModel}</span>
+        <span class="text-slate-300 truncate max-w-[140px]">
+          {getModelDisplayName($chatStore.lastModel, $chatStore.catalog)}
+        </span>
       {:else}
-        <span class="text-slate-400">Auto-rotate</span>
+        <span class="text-slate-400 italic">Auto-rotate</span>
       {/if}
     </div>
   {:else}
-    <!-- Specific: Clickable selector -->
     <button
       class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800 rounded-lg border border-slate-700 hover:border-cosmic-600 transition-colors text-xs cursor-pointer"
       on:click={toggleDropdown}
@@ -147,7 +174,7 @@
     </button>
   {/if}
 
-  <!-- Dropdown: Grouped by Provider -->
+  <!-- Dropdown -->
   {#if dropdownOpen}
     <div
       transition:slide={{ duration: 150 }}
@@ -156,7 +183,6 @@
       <div class="max-h-[360px] overflow-y-auto scrollbar-thin">
         {#each $chatStore.catalog as group (group.provider)}
           {#if group.models.length > 0}
-            <!-- Provider Header -->
             <div
               class="sticky top-0 px-3 py-2 bg-slate-800/95 backdrop-blur-sm border-b border-slate-700/50"
             >
@@ -165,7 +191,6 @@
               >
             </div>
 
-            <!-- Models -->
             {#each group.models as model (model.id)}
               {@const fullId = `${group.provider}:${model.id}`}
               {@const isSelected = $chatStore.selectedModel === fullId}
@@ -175,14 +200,12 @@
                   : ''}"
                 on:click={() => selectModel(group.provider, model.id)}
               >
-                <!-- Selection indicator -->
                 <span
-                  class="w-1.5 h-1.5 rounded-full shrink-0"
-                  class:bg-cosmic-500={isSelected}
-                  class:bg-transparent={!isSelected}
+                  class="w-1.5 h-1.5 rounded-full shrink-0 {isSelected
+                    ? 'bg-cosmic-500'
+                    : 'bg-transparent'}"
                 ></span>
 
-                <!-- Model info -->
                 <div class="flex-1 min-w-0">
                   <div class="text-sm text-slate-200 truncate">{model.name}</div>
                   {#if model.description}
@@ -190,9 +213,8 @@
                   {/if}
                 </div>
 
-                <!-- Tier badge -->
                 <span
-                  class="text-[10px] font-bold px-1.5 py-0.5 rounded {tierColor(model.tier)}"
+                  class="text-[10px] font-bold px-1.5 py-0.5 rounded border {tierColor(model.tier)}"
                   title={model.tier}
                 >
                   {tierLabel(model.tier)}

--- a/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
@@ -1,26 +1,207 @@
 <script lang="ts">
   import { chatStore } from '../stores';
+  import { slide } from 'svelte/transition';
 
-  function handleSelect(e: Event) {
-    const target = e.target as HTMLSelectElement;
-    chatStore.setModel(target.value);
+  let dropdownOpen = false;
+
+  function setMode(mode: 'rotation' | 'specific') {
+    chatStore.setMode(mode);
+    if (mode === 'rotation') {
+      dropdownOpen = false;
+    }
   }
+
+  function selectModel(provider: string, modelId: string) {
+    chatStore.setModel(`${provider}:${modelId}`);
+    dropdownOpen = false;
+  }
+
+  function toggleDropdown() {
+    if ($chatStore.chatMode === 'specific') {
+      dropdownOpen = !dropdownOpen;
+    }
+  }
+
+  // Close dropdown on click outside
+  function handleClickOutside(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    if (!target.closest('.model-selector-container')) {
+      dropdownOpen = false;
+    }
+  }
+
+  // Parse "provider:model" into display parts
+  function parseSelected(sel: string): { provider: string; model: string } {
+    const idx = sel.indexOf(':');
+    if (idx === -1) return { provider: '', model: sel };
+    return { provider: sel.slice(0, idx), model: sel.slice(idx + 1) };
+  }
+
+  function getModelDisplayName(modelId: string, catalog: typeof $chatStore.catalog): string {
+    for (const group of catalog) {
+      const found = group.models.find((m) => m.id === modelId);
+      if (found) return found.name;
+    }
+    // Fallback: format the raw ID nicely
+    return modelId
+      .split('-')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
+  }
+
+  function tierColor(tier: string): string {
+    switch (tier) {
+      case 'very_high':
+        return 'text-amber-400 bg-amber-400/10';
+      case 'high':
+        return 'text-emerald-400 bg-emerald-400/10';
+      case 'medium':
+        return 'text-blue-400 bg-blue-400/10';
+      case 'low':
+        return 'text-slate-400 bg-slate-400/10';
+      default:
+        return 'text-slate-500 bg-slate-500/10';
+    }
+  }
+
+  function tierLabel(tier: string): string {
+    switch (tier) {
+      case 'very_high':
+        return '★';
+      case 'high':
+        return 'H';
+      case 'medium':
+        return 'M';
+      case 'low':
+        return 'L';
+      default:
+        return '?';
+    }
+  }
+
+  $: selected = parseSelected($chatStore.selectedModel);
+  $: selectedDisplayName = getModelDisplayName(selected.model, $chatStore.catalog);
 </script>
 
-<div class="flex items-center gap-2">
-  <label for="model-select" class="text-sm text-slate-400 hidden sm:block">Model:</label>
-  <select
-    id="model-select"
-    value={$chatStore.selectedModel}
-    on:change={handleSelect}
-    class="bg-slate-800 border border-cosmic-700 text-slate-200 text-sm rounded-lg focus:ring-cosmic-500 focus:border-cosmic-500 block w-full p-2 outline-none appearance-none pr-8 cursor-pointer relative"
-    style="background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M7%2010L12%2015L17%2010%22%20stroke%3D%22%2394a3b8%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; background-position: right 0.5rem center; background-size: 1.25rem"
-  >
-    {#if $chatStore.models.length === 0}
-      <option value="" disabled>Loading models...</option>
-    {/if}
-    {#each $chatStore.models as model (model.id)}
-      <option value={model.id}>{model.name}</option>
-    {/each}
-  </select>
+<svelte:window on:click={handleClickOutside} />
+
+<div class="model-selector-container relative flex items-center gap-1.5">
+  <!-- Mode Toggle -->
+  <div class="flex bg-slate-800 rounded-lg border border-slate-700 overflow-hidden">
+    <button
+      class="px-2.5 py-1.5 text-xs font-medium transition-colors"
+      class:bg-cosmic-600={$chatStore.chatMode === 'rotation'}
+      class:text-white={$chatStore.chatMode === 'rotation'}
+      class:text-slate-400={$chatStore.chatMode !== 'rotation'}
+      class:hover:text-slate-200={$chatStore.chatMode !== 'rotation'}
+      on:click={() => setMode('rotation')}
+      title="Rotate through free providers"
+    >
+      🔄
+    </button>
+    <button
+      class="px-2.5 py-1.5 text-xs font-medium transition-colors"
+      class:bg-cosmic-600={$chatStore.chatMode === 'specific'}
+      class:text-white={$chatStore.chatMode === 'specific'}
+      class:text-slate-400={$chatStore.chatMode !== 'specific'}
+      class:hover:text-slate-200={$chatStore.chatMode !== 'specific'}
+      on:click={() => setMode('specific')}
+      title="Choose a specific model"
+    >
+      🎯
+    </button>
+  </div>
+
+  <!-- Current Selection / Badge -->
+  {#if $chatStore.chatMode === 'rotation'}
+    <div
+      class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800/50 rounded-lg border border-slate-700/50 text-xs"
+    >
+      {#if $chatStore.lastProvider}
+        <span class="text-cosmic-400 font-medium">{$chatStore.lastProvider}</span>
+        <span class="text-slate-600">/</span>
+        <span class="text-slate-300 truncate max-w-[120px]">{$chatStore.lastModel}</span>
+      {:else}
+        <span class="text-slate-400">Auto-rotate</span>
+      {/if}
+    </div>
+  {:else}
+    <!-- Specific: Clickable selector -->
+    <button
+      class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800 rounded-lg border border-slate-700 hover:border-cosmic-600 transition-colors text-xs cursor-pointer"
+      on:click={toggleDropdown}
+    >
+      <span class="text-cosmic-400 font-medium capitalize">{selected.provider}</span>
+      <span class="text-slate-600">/</span>
+      <span class="text-slate-200 truncate max-w-[140px]">{selectedDisplayName}</span>
+      <svg
+        class="w-3 h-3 text-slate-400 ml-0.5 transition-transform"
+        class:rotate-180={dropdownOpen}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+  {/if}
+
+  <!-- Dropdown: Grouped by Provider -->
+  {#if dropdownOpen}
+    <div
+      transition:slide={{ duration: 150 }}
+      class="absolute top-full right-0 mt-1.5 w-72 bg-slate-800 border border-slate-700 rounded-xl shadow-2xl shadow-black/40 z-50 overflow-hidden"
+    >
+      <div class="max-h-[360px] overflow-y-auto scrollbar-thin">
+        {#each $chatStore.catalog as group (group.provider)}
+          {#if group.models.length > 0}
+            <!-- Provider Header -->
+            <div
+              class="sticky top-0 px-3 py-2 bg-slate-800/95 backdrop-blur-sm border-b border-slate-700/50"
+            >
+              <span class="text-xs font-semibold text-slate-400 uppercase tracking-wider"
+                >{group.provider}</span
+              >
+            </div>
+
+            <!-- Models -->
+            {#each group.models as model (model.id)}
+              {@const fullId = `${group.provider}:${model.id}`}
+              {@const isSelected = $chatStore.selectedModel === fullId}
+              <button
+                class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-slate-700/50 transition-colors {isSelected
+                  ? 'bg-cosmic-600/10'
+                  : ''}"
+                on:click={() => selectModel(group.provider, model.id)}
+              >
+                <!-- Selection indicator -->
+                <span
+                  class="w-1.5 h-1.5 rounded-full shrink-0"
+                  class:bg-cosmic-500={isSelected}
+                  class:bg-transparent={!isSelected}
+                ></span>
+
+                <!-- Model info -->
+                <div class="flex-1 min-w-0">
+                  <div class="text-sm text-slate-200 truncate">{model.name}</div>
+                  {#if model.description}
+                    <div class="text-[10px] text-slate-500 truncate">{model.description}</div>
+                  {/if}
+                </div>
+
+                <!-- Tier badge -->
+                <span
+                  class="text-[10px] font-bold px-1.5 py-0.5 rounded {tierColor(model.tier)}"
+                  title={model.tier}
+                >
+                  {tierLabel(model.tier)}
+                </span>
+              </button>
+            {/each}
+          {/if}
+        {/each}
+      </div>
+    </div>
+  {/if}
 </div>

--- a/packages/ui/src/lib/flows/chat/components/Sidebar.svelte
+++ b/packages/ui/src/lib/flows/chat/components/Sidebar.svelte
@@ -18,6 +18,25 @@
     chatStore.startNewConversation();
     isMobileMenuOpen = false;
   }
+
+  function handleDelete(e: Event, id: string) {
+    e.stopPropagation();
+    chatStore.deleteConversation(id);
+  }
+
+  function formatRelativeTime(timestamp: number): string {
+    const diff = Date.now() - timestamp;
+    const seconds = Math.floor(diff / 1000);
+
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days}d ago`;
+    return new Date(timestamp).toLocaleDateString();
+  }
 </script>
 
 <div
@@ -28,7 +47,10 @@
       on:click={newChat}
       class="w-full flex items-center justify-center gap-2 bg-cosmic-600 hover:bg-cosmic-500 text-white py-2 px-4 rounded-lg transition-colors shadow-glow"
     >
-      <span class="text-xl">+</span> New Chat
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+      </svg>
+      New Chat
     </button>
   </div>
 
@@ -39,20 +61,62 @@
       </div>
     {/if}
 
-    <ul class="space-y-1">
+    <ul class="space-y-0.5">
       {#each $chatStore.conversations as conv (conv.id)}
-        <li>
-          <button
+        <li class="group">
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <div
             on:click={() => selectConversation(conv.id)}
-            class={`w-full text-left px-3 py-2 rounded-md text-sm truncate transition-colors ${
+            class={`w-full text-left px-3 py-2.5 rounded-lg text-sm flex items-center gap-2 transition-all cursor-pointer ${
               $chatStore.activeConversationId === conv.id
-                ? 'bg-cosmic-800 text-white'
-                : 'text-slate-300 hover:bg-slate-800'
+                ? 'bg-cosmic-800/70 text-white border border-cosmic-600/30'
+                : 'text-slate-300 hover:bg-slate-800/70'
             }`}
             title={conv.title}
           >
-            {conv.title}
-          </button>
+            <svg
+              class="w-3.5 h-3.5 shrink-0 text-slate-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.068.157 2.148.279 3.238.364.466.037.893.281 1.153.671L12 21l2.652-3.978c.26-.39.687-.634 1.153-.671 1.09-.085 2.17-.207 3.238-.364 1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"
+              />
+            </svg>
+
+            <div class="min-w-0 flex-1">
+              <div class="truncate">{conv.title}</div>
+              <div class="text-[10px] text-slate-500 mt-0.5">
+                {formatRelativeTime(conv.updatedAt)}
+              </div>
+            </div>
+
+            <!-- Delete button (visible on hover) -->
+            <button
+              class="shrink-0 opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-slate-500 transition-all"
+              on:click={(e) => handleDelete(e, conv.id)}
+              title="Delete conversation"
+            >
+              <svg
+                class="w-3.5 h-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                />
+              </svg>
+            </button>
+          </div>
         </li>
       {/each}
     </ul>

--- a/packages/ui/src/lib/flows/chat/stores.ts
+++ b/packages/ui/src/lib/flows/chat/stores.ts
@@ -142,9 +142,7 @@ function createChatStore() {
               // Replace temp user message with server version
               update((s) => ({
                 ...s,
-                messages: s.messages.map((m) =>
-                  m.id === tempUserMsg.id ? event.message : m
-                ),
+                messages: s.messages.map((m) => (m.id === tempUserMsg.id ? event.message : m)),
               }));
               break;
 
@@ -172,6 +170,7 @@ function createChatStore() {
               break;
 
             case 'error':
+              console.error('[ChatStore] Stream error:', event.error);
               showError(event.error);
               update((s) => ({
                 ...s,

--- a/packages/ui/src/lib/flows/chat/stores.ts
+++ b/packages/ui/src/lib/flows/chat/stores.ts
@@ -14,6 +14,8 @@ function createChatStore() {
     activeConversationId: string | null;
     messages: ChatMessage[];
     isLoading: boolean;
+    isStreaming: boolean;
+    streamingContent: string; // partial content being streamed
   }>({
     catalog: [],
     selectedModel: '',
@@ -24,6 +26,8 @@ function createChatStore() {
     activeConversationId: null,
     messages: [],
     isLoading: false,
+    isStreaming: false,
+    streamingContent: '',
   });
 
   return {
@@ -113,7 +117,7 @@ function createChatStore() {
       const mode = currentState.chatMode;
       const model = mode === 'specific' ? currentState.selectedModel : undefined;
 
-      // Optimistic update
+      // Optimistic user message
       const tempUserMsg: ChatMessage = {
         id: 'temp-' + Date.now(),
         conversationId: convId,
@@ -127,29 +131,56 @@ function createChatStore() {
         ...s,
         messages: [...s.messages, tempUserMsg],
         isLoading: true,
+        isStreaming: true,
+        streamingContent: '',
       }));
 
       try {
-        const { userMessage, assistantMessage } = await api.sendMessage(
-          convId,
-          content,
-          mode,
-          model
-        );
+        await api.sendMessageStream(convId, content, mode, model, (event) => {
+          switch (event.type) {
+            case 'user_message':
+              // Replace temp user message with server version
+              update((s) => ({
+                ...s,
+                messages: s.messages.map((m) =>
+                  m.id === tempUserMsg.id ? event.message : m
+                ),
+              }));
+              break;
 
-        update((s) => {
-          const msgs = s.messages.filter((m) => m.id !== tempUserMsg.id);
-          api.fetchConversations().then((conversations) => {
-            update((inner) => ({ ...inner, conversations }));
-          });
+            case 'delta':
+              update((s) => ({
+                ...s,
+                streamingContent: s.streamingContent + event.delta,
+              }));
+              break;
 
-          return {
-            ...s,
-            messages: [...msgs, userMessage, assistantMessage],
-            lastProvider: assistantMessage.providerUsed || '',
-            lastModel: assistantMessage.modelUsed || '',
-            isLoading: false,
-          };
+            case 'done':
+              update((s) => ({
+                ...s,
+                messages: [...s.messages, event.message],
+                lastProvider: event.message.providerUsed || '',
+                lastModel: event.message.modelUsed || '',
+                isLoading: false,
+                isStreaming: false,
+                streamingContent: '',
+              }));
+              // Refresh conversation list in background
+              api.fetchConversations().then((conversations) => {
+                update((inner) => ({ ...inner, conversations }));
+              });
+              break;
+
+            case 'error':
+              showError(event.error);
+              update((s) => ({
+                ...s,
+                isLoading: false,
+                isStreaming: false,
+                streamingContent: '',
+              }));
+              break;
+          }
         });
       } catch (e: unknown) {
         update((s) => {
@@ -158,6 +189,8 @@ function createChatStore() {
             ...s,
             messages: msgs,
             isLoading: false,
+            isStreaming: false,
+            streamingContent: '',
           };
         });
         showError(e instanceof Error ? e.message : String(e));

--- a/packages/ui/src/lib/flows/chat/stores.ts
+++ b/packages/ui/src/lib/flows/chat/stores.ts
@@ -1,19 +1,30 @@
 import { writable, get } from 'svelte/store';
-import type { ChatConversation, ChatMessage, ChatProviderOption } from '@flows/shared';
+import type {
+  ChatConversation,
+  ChatMessage,
+  ChatProviderGroup,
+  ChatMode,
+} from '@flows/shared';
 import * as api from './api';
 
 function createChatStore() {
   const { subscribe, update } = writable<{
-    models: ChatProviderOption[];
-    selectedModel: string;
+    catalog: ChatProviderGroup[];
+    selectedModel: string; // "provider:modelId" format
+    chatMode: ChatMode;
+    lastProvider: string; // provider that answered last (for rotation badge)
+    lastModel: string; // model that answered last
     conversations: ChatConversation[];
     activeConversationId: string | null;
     messages: ChatMessage[];
     isLoading: boolean;
     error: string | null;
   }>({
-    models: [],
+    catalog: [],
     selectedModel: '',
+    chatMode: 'specific',
+    lastProvider: '',
+    lastModel: '',
     conversations: [],
     activeConversationId: null,
     messages: [],
@@ -26,19 +37,20 @@ function createChatStore() {
 
     async init() {
       try {
-        const [models, conversations] = await Promise.all([
-          api.fetchModels(),
+        const [catalog, conversations] = await Promise.all([
+          api.fetchModelCatalog(),
           api.fetchConversations(),
         ]);
 
+        // Default: first model of first provider
         let defaultModel = '';
-        if (models.length > 0) {
-          defaultModel = models[0].id; // default to first
+        if (catalog.length > 0 && catalog[0].models.length > 0) {
+          defaultModel = `${catalog[0].provider}:${catalog[0].models[0].id}`;
         }
 
         update((s) => ({
           ...s,
-          models,
+          catalog,
           selectedModel: defaultModel,
           conversations,
         }));
@@ -47,8 +59,12 @@ function createChatStore() {
       }
     },
 
-    setModel(modelId: string) {
-      update((s) => ({ ...s, selectedModel: modelId }));
+    setModel(providerAndModel: string) {
+      update((s) => ({ ...s, selectedModel: providerAndModel }));
+    },
+
+    setMode(mode: ChatMode) {
+      update((s) => ({ ...s, chatMode: mode }));
     },
 
     async loadConversation(id: string) {
@@ -72,7 +88,6 @@ function createChatStore() {
     },
 
     startNewConversation() {
-      // we don't save to DB until first message, just reset UI
       const newId = crypto.randomUUID();
       update((s) => ({
         ...s,
@@ -103,12 +118,12 @@ function createChatStore() {
         this.startNewConversation();
       }
 
-      // get updated state
       const currentState = get(this);
       const convId = currentState.activeConversationId!;
-      const model = currentState.selectedModel;
+      const mode = currentState.chatMode;
+      const model = mode === 'specific' ? currentState.selectedModel : undefined;
 
-      // Optimistic update for user message
+      // Optimistic update
       const tempUserMsg: ChatMessage = {
         id: 'temp-' + Date.now(),
         conversationId: convId,
@@ -125,13 +140,15 @@ function createChatStore() {
       }));
 
       try {
-        const { userMessage, assistantMessage } = await api.sendMessage(convId, content, model);
+        const { userMessage, assistantMessage } = await api.sendMessage(
+          convId,
+          content,
+          mode,
+          model,
+        );
 
-        // Real update
         update((s) => {
-          // Update messages: replace temp with real user msg, add assistant msg
           const msgs = s.messages.filter((m) => m.id !== tempUserMsg.id);
-          // Also refresh conversations (title might have changed or it's new)
           api.fetchConversations().then((conversations) => {
             update((inner) => ({ ...inner, conversations }));
           });
@@ -139,12 +156,13 @@ function createChatStore() {
           return {
             ...s,
             messages: [...msgs, userMessage, assistantMessage],
+            lastProvider: assistantMessage.providerUsed || '',
+            lastModel: assistantMessage.modelUsed || '',
             isLoading: false,
           };
         });
       } catch (e: unknown) {
         update((s) => {
-          // Remove temp on failure
           const msgs = s.messages.filter((m) => m.id !== tempUserMsg.id);
           return {
             ...s,

--- a/packages/ui/src/lib/flows/chat/stores.ts
+++ b/packages/ui/src/lib/flows/chat/stores.ts
@@ -1,5 +1,6 @@
 import { writable, get } from 'svelte/store';
 import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
+import { showError } from '@lib/toast';
 import * as api from './api';
 
 function createChatStore() {
@@ -13,7 +14,6 @@ function createChatStore() {
     activeConversationId: string | null;
     messages: ChatMessage[];
     isLoading: boolean;
-    error: string | null;
   }>({
     catalog: [],
     selectedModel: '',
@@ -24,7 +24,6 @@ function createChatStore() {
     activeConversationId: null,
     messages: [],
     isLoading: false,
-    error: null,
   });
 
   return {
@@ -50,7 +49,7 @@ function createChatStore() {
           conversations,
         }));
       } catch (e: unknown) {
-        update((s) => ({ ...s, error: e instanceof Error ? e.message : String(e) }));
+        showError(e instanceof Error ? e.message : String(e));
       }
     },
 
@@ -68,17 +67,13 @@ function createChatStore() {
         isLoading: true,
         activeConversationId: id,
         messages: [],
-        error: null,
       }));
       try {
         const messages = await api.fetchMessages(id);
         update((s) => ({ ...s, messages, isLoading: false }));
       } catch (e: unknown) {
-        update((s) => ({
-          ...s,
-          error: e instanceof Error ? e.message : String(e),
-          isLoading: false,
-        }));
+        showError(e instanceof Error ? e.message : String(e));
+        update((s) => ({ ...s, isLoading: false }));
       }
     },
 
@@ -103,7 +98,7 @@ function createChatStore() {
           return { ...s, conversations, activeConversationId, messages };
         });
       } catch (e: unknown) {
-        update((s) => ({ ...s, error: e instanceof Error ? e.message : String(e) }));
+        showError(e instanceof Error ? e.message : String(e));
       }
     },
 
@@ -162,10 +157,10 @@ function createChatStore() {
           return {
             ...s,
             messages: msgs,
-            error: e instanceof Error ? e.message : String(e),
             isLoading: false,
           };
         });
+        showError(e instanceof Error ? e.message : String(e));
       }
     },
   };

--- a/packages/ui/src/lib/flows/chat/stores.ts
+++ b/packages/ui/src/lib/flows/chat/stores.ts
@@ -1,10 +1,5 @@
 import { writable, get } from 'svelte/store';
-import type {
-  ChatConversation,
-  ChatMessage,
-  ChatProviderGroup,
-  ChatMode,
-} from '@flows/shared';
+import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
 import * as api from './api';
 
 function createChatStore() {
@@ -144,7 +139,7 @@ function createChatStore() {
           convId,
           content,
           mode,
-          model,
+          model
         );
 
         update((s) => {

--- a/packages/ui/src/lib/flows/lyrics/api.ts
+++ b/packages/ui/src/lib/flows/lyrics/api.ts
@@ -79,3 +79,54 @@ export async function getLyricsLibrary(
     status: LyricsStatus;
   }>;
 }
+
+/** SSE event types from the interpret endpoint. */
+export type InterpretEvent =
+  | { type: 'cached'; interpretation: string }
+  | { type: 'delta'; delta: string }
+  | { type: 'done' }
+  | { type: 'error'; error: string };
+
+/**
+ * Stream an AI interpretation for a track's lyrics.
+ * Calls a callback for each SSE event as it arrives.
+ */
+export async function interpretLyrics(
+  trackId: string,
+  onEvent: (event: InterpretEvent) => void
+): Promise<void> {
+  const response = await fetch(`/api/lyrics/${trackId}/interpret`, {
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Interpret error ${response.status}: ${text}`);
+  }
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n\n');
+    buffer = lines.pop()!;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data: ')) continue;
+
+      try {
+        const event = JSON.parse(trimmed.slice(6)) as InterpretEvent;
+        onEvent(event);
+      } catch {
+        // skip malformed SSE
+      }
+    }
+  }
+}
+

--- a/packages/ui/src/lib/flows/lyrics/api.ts
+++ b/packages/ui/src/lib/flows/lyrics/api.ts
@@ -129,4 +129,3 @@ export async function interpretLyrics(
     }
   }
 }
-

--- a/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
+++ b/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import type { Track, Lyrics } from '@flows/shared';
-  import { getLyrics } from '../api';
+  import type { Track } from '@flows/shared';
+  import { getLyrics, interpretLyrics } from '../api';
+  import { marked } from 'marked';
+  import DOMPurify from 'dompurify';
 
   interface Props {
     track: Track;
@@ -9,16 +11,39 @@
 
   let { track, onclose }: Props = $props();
 
-  let lyrics = $state<Lyrics | null>(null);
+  let lyrics = $state<{ plainLyrics: string | null; status: string; interpretation?: string | null } | null>(null);
   let loading = $state(true);
   let error = $state<string | null>(null);
+
+  // Interpretation state
+  let isInterpreting = $state(false);
+  let interpretContent = $state('');
+  let interpretDone = $state(false);
+  let interpretError = $state<string | null>(null);
+  let showInterpretation = $state(false);
+
+  // Configure marked
+  marked.setOptions({ breaks: true, gfm: true });
+
+  function renderMarkdown(text: string): string {
+    const rawHtml = marked.parse(text, { async: false }) as string;
+    return DOMPurify.sanitize(rawHtml);
+  }
 
   async function fetchLyrics(force = false) {
     loading = true;
     error = null;
 
     try {
-      lyrics = await getLyrics(track.id, { force });
+      const result = await getLyrics(track.id, { force });
+      lyrics = result;
+
+      // If we have a cached interpretation, show it
+      if (result.interpretation) {
+        interpretContent = result.interpretation;
+        interpretDone = true;
+        showInterpretation = true;
+      }
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to fetch lyrics';
     } finally {
@@ -30,6 +55,49 @@
   $effect(() => {
     fetchLyrics();
   });
+
+  async function handleInterpret() {
+    if (isInterpreting) return;
+
+    isInterpreting = true;
+    interpretContent = '';
+    interpretDone = false;
+    interpretError = null;
+    showInterpretation = true;
+
+    try {
+      await interpretLyrics(track.id, (event) => {
+        switch (event.type) {
+          case 'cached':
+            interpretContent = event.interpretation;
+            interpretDone = true;
+            isInterpreting = false;
+            break;
+          case 'delta':
+            interpretContent += event.delta;
+            break;
+          case 'done':
+            interpretDone = true;
+            isInterpreting = false;
+            break;
+          case 'error':
+            interpretError = event.error;
+            isInterpreting = false;
+            break;
+        }
+      });
+    } catch (e) {
+      interpretError = e instanceof Error ? e.message : 'Interpretation failed';
+      isInterpreting = false;
+    }
+  }
+
+  function handleRegenerate() {
+    // Clear cached state and re-interpret
+    interpretContent = '';
+    interpretDone = false;
+    handleInterpret();
+  }
 
   function handleBackdropClick(event: MouseEvent) {
     if (event.target === event.currentTarget) {
@@ -58,7 +126,7 @@
 >
   <!-- Modal -->
   <div
-    class="glass rounded-2xl max-w-2xl w-full max-h-[80vh] flex flex-col overflow-hidden shadow-2xl shadow-aurora/20"
+    class="glass rounded-2xl max-w-2xl w-full max-h-[85vh] flex flex-col overflow-hidden shadow-2xl shadow-aurora/20"
   >
     <!-- Header -->
     <div class="p-4 border-b border-white/10 flex items-center gap-4">
@@ -77,24 +145,43 @@
           {track.artists.map((a) => a.name).join(', ')}
         </p>
       </div>
-      <button
-        class="p-2 hover:bg-white/10 rounded-lg transition-colors text-pulsar hover:text-cosmic"
-        onclick={onclose}
-        aria-label="Close"
-      >
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M6 18L18 6M6 6l12 12"
-          />
-        </svg>
-      </button>
+
+      <div class="flex items-center gap-2">
+        <!-- Interpret Button -->
+        {#if lyrics?.plainLyrics && !showInterpretation}
+          <button
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all
+                   bg-aurora/10 hover:bg-aurora/20 text-aurora border border-aurora/30
+                   hover:shadow-lg hover:shadow-aurora/10 active:scale-95"
+            onclick={handleInterpret}
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+            </svg>
+            Interpret
+          </button>
+        {/if}
+
+        <!-- Close Button -->
+        <button
+          class="p-2 hover:bg-white/10 rounded-lg transition-colors text-pulsar hover:text-cosmic"
+          onclick={onclose}
+          aria-label="Close"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
 
     <!-- Content -->
-    <div class="flex-grow overflow-y-auto p-6">
+    <div class="flex-grow overflow-y-auto p-6 space-y-6">
       {#if loading}
         <div class="flex flex-col items-center justify-center py-12 text-pulsar">
           <div
@@ -128,8 +215,58 @@
           </button>
         </div>
       {:else if lyrics?.plainLyrics}
+        <!-- Lyrics -->
         <pre
           class="whitespace-pre-wrap font-sans text-cosmic/90 leading-relaxed">{lyrics.plainLyrics}</pre>
+
+        <!-- AI Interpretation Panel -->
+        {#if showInterpretation}
+          <div class="border-t border-white/10 pt-4">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <svg class="w-4 h-4 text-aurora" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+                </svg>
+                <h3 class="text-sm font-semibold text-aurora uppercase tracking-wider">AI Interpretation</h3>
+                {#if isInterpreting}
+                  <div class="w-3 h-3 border-2 border-aurora border-t-transparent rounded-full animate-spin"></div>
+                {/if}
+              </div>
+              {#if interpretDone}
+                <button
+                  class="text-[10px] text-pulsar hover:text-cosmic transition-colors px-2 py-0.5 rounded border border-white/10 hover:bg-white/5"
+                  onclick={handleRegenerate}
+                >
+                  Regenerate
+                </button>
+              {/if}
+            </div>
+
+            {#if interpretError}
+              <div class="text-red-400 text-sm bg-red-400/10 p-3 rounded-lg border border-red-400/20">
+                {interpretError}
+              </div>
+            {:else if interpretContent}
+              <div class="prose prose-invert prose-sm max-w-none leading-relaxed
+                          prose-p:my-1.5 prose-pre:bg-black/30 prose-pre:border prose-pre:border-white/10
+                          prose-code:text-aurora prose-code:before:content-[''] prose-code:after:content-['']
+                          prose-headings:text-cosmic prose-strong:text-cosmic/90
+                          bg-white/[0.02] rounded-xl p-4 border border-white/5">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                {@html renderMarkdown(interpretContent)}
+                {#if isInterpreting}
+                  <span class="inline-block w-0.5 h-4 bg-aurora animate-pulse ml-0.5 align-text-bottom"></span>
+                {/if}
+              </div>
+            {:else if isInterpreting}
+              <div class="flex items-center gap-1.5 py-4 justify-center">
+                <div class="w-2 h-2 bg-aurora rounded-full animate-bounce" style="animation-delay: 0ms"></div>
+                <div class="w-2 h-2 bg-aurora rounded-full animate-bounce" style="animation-delay: 150ms"></div>
+                <div class="w-2 h-2 bg-aurora rounded-full animate-bounce" style="animation-delay: 300ms"></div>
+              </div>
+            {/if}
+          </div>
+        {/if}
       {:else}
         <p class="text-pulsar text-center py-12">No lyrics content available.</p>
       {/if}

--- a/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
+++ b/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
@@ -11,7 +11,11 @@
 
   let { track, onclose }: Props = $props();
 
-  let lyrics = $state<{ plainLyrics: string | null; status: string; interpretation?: string | null } | null>(null);
+  let lyrics = $state<{
+    plainLyrics: string | null;
+    status: string;
+    interpretation?: string | null;
+  } | null>(null);
   let loading = $state(true);
   let error = $state<string | null>(null);
 
@@ -155,8 +159,18 @@
                    hover:shadow-lg hover:shadow-aurora/10 active:scale-95"
             onclick={handleInterpret}
           >
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+              />
             </svg>
             Interpret
           </button>
@@ -224,12 +238,26 @@
           <div class="border-t border-white/10 pt-4">
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-2">
-                <svg class="w-4 h-4 text-aurora" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+                <svg
+                  class="w-4 h-4 text-aurora"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+                  />
                 </svg>
-                <h3 class="text-sm font-semibold text-aurora uppercase tracking-wider">AI Interpretation</h3>
+                <h3 class="text-sm font-semibold text-aurora uppercase tracking-wider">
+                  AI Interpretation
+                </h3>
                 {#if isInterpreting}
-                  <div class="w-3 h-3 border-2 border-aurora border-t-transparent rounded-full animate-spin"></div>
+                  <div
+                    class="w-3 h-3 border-2 border-aurora border-t-transparent rounded-full animate-spin"
+                  ></div>
                 {/if}
               </div>
               {#if interpretDone}
@@ -243,26 +271,41 @@
             </div>
 
             {#if interpretError}
-              <div class="text-red-400 text-sm bg-red-400/10 p-3 rounded-lg border border-red-400/20">
+              <div
+                class="text-red-400 text-sm bg-red-400/10 p-3 rounded-lg border border-red-400/20"
+              >
                 {interpretError}
               </div>
             {:else if interpretContent}
-              <div class="prose prose-invert prose-sm max-w-none leading-relaxed
+              <div
+                class="prose prose-invert prose-sm max-w-none leading-relaxed
                           prose-p:my-1.5 prose-pre:bg-black/30 prose-pre:border prose-pre:border-white/10
                           prose-code:text-aurora prose-code:before:content-[''] prose-code:after:content-['']
                           prose-headings:text-cosmic prose-strong:text-cosmic/90
-                          bg-white/[0.02] rounded-xl p-4 border border-white/5">
+                          bg-white/[0.02] rounded-xl p-4 border border-white/5"
+              >
                 <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                 {@html renderMarkdown(interpretContent)}
                 {#if isInterpreting}
-                  <span class="inline-block w-0.5 h-4 bg-aurora animate-pulse ml-0.5 align-text-bottom"></span>
+                  <span
+                    class="inline-block w-0.5 h-4 bg-aurora animate-pulse ml-0.5 align-text-bottom"
+                  ></span>
                 {/if}
               </div>
             {:else if isInterpreting}
               <div class="flex items-center gap-1.5 py-4 justify-center">
-                <div class="w-2 h-2 bg-aurora rounded-full animate-bounce" style="animation-delay: 0ms"></div>
-                <div class="w-2 h-2 bg-aurora rounded-full animate-bounce" style="animation-delay: 150ms"></div>
-                <div class="w-2 h-2 bg-aurora rounded-full animate-bounce" style="animation-delay: 300ms"></div>
+                <div
+                  class="w-2 h-2 bg-aurora rounded-full animate-bounce"
+                  style="animation-delay: 0ms"
+                ></div>
+                <div
+                  class="w-2 h-2 bg-aurora rounded-full animate-bounce"
+                  style="animation-delay: 150ms"
+                ></div>
+                <div
+                  class="w-2 h-2 bg-aurora rounded-full animate-bounce"
+                  style="animation-delay: 300ms"
+                ></div>
               </div>
             {/if}
           </div>

--- a/packages/ui/src/lib/flows/spotify/api.ts
+++ b/packages/ui/src/lib/flows/spotify/api.ts
@@ -30,7 +30,6 @@ export async function loadTracks(
         q: newOptions.q,
         genre: newOptions.genre,
         year: newOptions.year,
-        minPopularity: newOptions.minPopularity,
         sortBy: newOptions.sortBy,
         sortOrder: newOptions.sortOrder,
       },

--- a/packages/ui/src/lib/flows/spotify/components/FilterPanel.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/FilterPanel.svelte
@@ -13,7 +13,6 @@
   // Local filter values (synced with store)
   let selectedGenre = $state($searchOptions.genre || '');
   let selectedYear = $state($searchOptions.year?.toString() || '');
-  let minPopularity = $state($searchOptions.minPopularity || 0);
   let sortBy = $state($searchOptions.sortBy || 'added_at');
   let sortOrder = $state($searchOptions.sortOrder || 'desc');
 
@@ -21,7 +20,6 @@
   let activeFilterCount = $derived(
     (selectedGenre ? 1 : 0) +
       (selectedYear ? 1 : 0) +
-      (minPopularity > 0 ? 1 : 0) +
       (sortBy !== 'added_at' || sortOrder !== 'desc' ? 1 : 0)
   );
 
@@ -42,8 +40,7 @@
     loadTracks({
       genre: selectedGenre || undefined,
       year: selectedYear ? parseInt(selectedYear) : undefined,
-      minPopularity: minPopularity > 0 ? minPopularity : undefined,
-      sortBy: sortBy as 'added_at' | 'popularity' | 'title',
+      sortBy: sortBy as 'added_at' | 'title',
       sortOrder: sortOrder as 'asc' | 'desc',
       page: 1,
     });
@@ -53,11 +50,9 @@
   function clearFilters() {
     selectedGenre = '';
     selectedYear = '';
-    minPopularity = 0;
     sortBy = 'added_at';
     sortOrder = 'desc';
     loadTracks({ page: 1 });
-    // isOpen = false; // Keep panel open for better UX
   }
 
   function togglePanel() {
@@ -141,7 +136,6 @@
           bind:value={sortBy}
         >
           <option value="added_at" class="bg-void">Date Added</option>
-          <option value="popularity" class="bg-void">Popularity</option>
           <option value="title" class="bg-void">Title</option>
         </select>
       </div>
@@ -157,22 +151,6 @@
           <option value="desc" class="bg-void">Descending</option>
           <option value="asc" class="bg-void">Ascending</option>
         </select>
-      </div>
-
-      <!-- Min Popularity -->
-      <div class="flex flex-col gap-1">
-        <label for="filter-popularity" class="text-xs text-pulsar uppercase tracking-wide"
-          >Min Popularity: {minPopularity}</label
-        >
-        <input
-          id="filter-popularity"
-          type="range"
-          min="0"
-          max="100"
-          step="10"
-          bind:value={minPopularity}
-          class="w-full accent-aurora"
-        />
       </div>
     </div>
 

--- a/packages/ui/src/lib/flows/spotify/components/TrackCard.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/TrackCard.svelte
@@ -73,19 +73,6 @@
 
     <!-- Footer Stats -->
     <div class="flex justify-between items-center mt-auto pt-3">
-      <!-- Popularity Bar -->
-      {#if track.popularity !== undefined}
-        <div class="flex items-center gap-2 flex-grow" title="Popularity: {track.popularity}%">
-          <div class="w-full max-w-[60px] h-1.5 bg-white/10 rounded-full overflow-hidden">
-            <div
-              class="h-full bg-gradient-to-r from-aurora to-cyan-400"
-              style="width: {track.popularity}%"
-            ></div>
-          </div>
-          <span class="text-[10px] text-pulsar font-medium">{track.popularity}</span>
-        </div>
-      {/if}
-
       <!-- Lyrics Button -->
       <button
         class="text-[10px] text-white/90 hover:text-aurora transition-colors px-2 py-1 bg-white/5 hover:bg-white/10 rounded font-medium"

--- a/packages/ui/src/lib/toast.ts
+++ b/packages/ui/src/lib/toast.ts
@@ -18,6 +18,7 @@ export const showError = (message: string) => {
   toast.error(message, {
     duration: 5000,
     position: 'bottom-right',
+    style: 'word-break: break-word; max-width: 450px;',
   });
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,9 +293,15 @@ importers:
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
+      dompurify:
+        specifier: ^3.3.2
+        version: 3.3.2
       lightweight-charts:
         specifier: ^5.1.0
         version: 5.1.0
+      marked:
+        specifier: ^17.0.4
+        version: 17.0.4
       svelte-5-french-toast:
         specifier: ^2.0.6
         version: 2.0.6(svelte@5.45.5)
@@ -321,6 +327,9 @@ importers:
       '@tsconfig/svelte':
         specifier: ^5.0.6
         version: 5.0.6
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -977,6 +986,10 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -991,6 +1004,9 @@ packages:
 
   '@types/node@6.14.13':
     resolution: {integrity: sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1343,6 +1359,10 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
@@ -1943,6 +1963,11 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  marked@17.0.4:
+    resolution: {integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3138,6 +3163,10 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.3.2
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3151,6 +3180,9 @@ snapshots:
       undici-types: 7.16.0
 
   '@types/node@6.14.13': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -3509,6 +3541,10 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dompurify@3.3.2:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.2.3: {}
 
@@ -4111,6 +4147,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   make-error@1.3.6: {}
+
+  marked@17.0.4: {}
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Pull Request

Closes #16

### What changed
- **LLM Core** (@flows/core/llm): 5-provider unified client with rotation, streaming, model catalogs
- **Chat Flow**: Complete conversational AI (backend + UI + persistence)
- **Lyrics Interpretation**: AI-powered song analysis with SSE streaming and SQLite caching
- **Spotify Sync Fix**: Replaced INSERT OR REPLACE with ON CONFLICT DO UPDATE to prevent cascade deletion of artist/genre data
- **Documentation**: Flow ideas backlog, Spotify adapter docs

### Testing
- ✅ svelte-check: 0 errors, 0 warnings
- ✅ 49 tests passing (42 trading + 7 spotify)
- ✅ All pre-push hooks pass

### 13 commits | Files changed across 6 packages