### PR TITLE
Chat flow overhaul: routing fix, hardening, runes & stop button (#25)

### DIFF
--- a/packages/flows/chat/src/backend/config.ts
+++ b/packages/flows/chat/src/backend/config.ts
@@ -1,0 +1,19 @@
+/**
+ * Chat flow configuration & constants.
+ *
+ * Centralizes the values that were previously inlined in the service, matching
+ * the convention used by the other flows (e.g. trading's `config.ts`).
+ */
+
+/**
+ * System prompt prepended to every conversation before the message history.
+ *
+ * Keeps replies in Markdown and avoids a leading heading, which renders poorly
+ * in the chat bubble.
+ */
+export const CHAT_SYSTEM_PROMPT =
+    'You are a helpful AI assistant. Format your replies using standard Markdown. ' +
+    'Never start your reply with a heading (# or ## or ###). Begin with normal text.';
+
+/** Mode used when the caller does not specify one. */
+export const DEFAULT_CHAT_MODE = 'specific' as const;

--- a/packages/flows/chat/src/backend/routes.ts
+++ b/packages/flows/chat/src/backend/routes.ts
@@ -6,7 +6,7 @@ const chatService = new ChatService();
 /**
  * Chat Flow API Routes
  */
-export const chatRoutes = new Elysia({ prefix: '/chat' })
+export const chatRoutes = new Elysia({ prefix: '/api/chat' })
     // Model catalog (grouped by provider)
     .get('/models', () => {
         return chatService.getModelCatalog();

--- a/packages/flows/chat/src/backend/services/chat.service.ts
+++ b/packages/flows/chat/src/backend/services/chat.service.ts
@@ -3,6 +3,8 @@ import { LLMClient, logger } from '@flows/core';
 import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
 import type { ChatRepository } from '../../domain/ports';
 import { deriveConversationTitle } from '../../domain/conversation';
+import { ChatError } from '../../domain/errors';
+import { CHAT_SYSTEM_PROMPT, DEFAULT_CHAT_MODE } from '../config';
 import { chatDb } from '../database';
 
 const log = logger.child({ module: 'ChatService' });
@@ -56,11 +58,12 @@ export class ChatService {
     async sendMessage(
         conversationId: string,
         content: string,
-        mode: ChatMode = 'specific',
+        mode: ChatMode = DEFAULT_CHAT_MODE,
         model?: string,
     ): Promise<{ userMessage: ChatMessage; assistantMessage: ChatMessage }> {
         log.info({ mode, model: model || 'auto', conversationId }, 'sendMessage');
 
+        this.assertModelForMode(mode, model);
         this.ensureConversation(conversationId, content);
 
         // Save user message
@@ -98,11 +101,12 @@ export class ChatService {
     async *sendMessageStream(
         conversationId: string,
         content: string,
-        mode: ChatMode = 'specific',
+        mode: ChatMode = DEFAULT_CHAT_MODE,
         model?: string,
     ): AsyncGenerator<string> {
         log.info({ mode, model: model || 'auto', conversationId }, 'sendMessageStream: start');
 
+        this.assertModelForMode(mode, model);
         this.ensureConversation(conversationId, content);
 
         // Save user message
@@ -149,6 +153,16 @@ export class ChatService {
 
     // ── Private helpers ──────────────────────────────────────────────
 
+    /**
+     * Guard: in "specific" mode a concrete `provider:model` must be selected.
+     * Rotation mode picks providers internally, so no model is required there.
+     */
+    private assertModelForMode(mode: ChatMode, model?: string): void {
+        if (mode === 'specific' && !model) {
+            throw new ChatError('A model must be selected in "specific" mode.');
+        }
+    }
+
     private ensureConversation(conversationId: string, content: string): void {
         const existing = this.repo.getConversations().find((c) => c.id === conversationId);
         if (!existing) {
@@ -177,9 +191,7 @@ export class ChatService {
         return [
             {
                 role: 'system' as const,
-                content:
-                    'You are a helpful AI assistant. Format your replies using standard Markdown. ' +
-                    'Never start your reply with a heading (# or ## or ###). Begin with normal text.',
+                content: CHAT_SYSTEM_PROMPT,
             },
             ...history.map((msg) => ({
                 role: msg.role === 'user' ? ('user' as const) : ('assistant' as const),

--- a/packages/flows/chat/tests/backend/services/chat.service.test.ts
+++ b/packages/flows/chat/tests/backend/services/chat.service.test.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3';
 import type { LLMRequest, LLMResponse, LLMStreamEvent } from '@flows/core';
 import type { ChatMessage, ChatMode } from '@flows/shared';
 import { ChatDatabase } from '../../../src/backend/database';
+import { ChatError } from '../../../src/domain/errors';
 
 // ── Spies live in a hoisted block (vi.mock factories run before imports) ──
 const spies = vi.hoisted(() => ({
@@ -366,6 +367,34 @@ describe('ChatService', () => {
             expect(stored).toHaveLength(1);
             expect(stored[0].role).toBe('user');
             expect(stored.find((m) => m.role === 'assistant')).toBeUndefined();
+        });
+    });
+
+    // ── model validation (specific mode) ──────────────────────────────
+    describe('specific-mode model validation', () => {
+        it('sendMessage throws ChatError when no model is given in specific mode', async () => {
+            await expect(service.sendMessage(CONV_ID, 'Hi', 'specific')).rejects.toBeInstanceOf(
+                ChatError,
+            );
+            expect(generateForProvider).not.toHaveBeenCalled();
+        });
+
+        it('sendMessage persists nothing when the model is missing', async () => {
+            await expect(service.sendMessage(CONV_ID, 'Hi', 'specific')).rejects.toThrow();
+            expect(service.getConversations()).toEqual([]);
+            expect(service.getMessages(CONV_ID)).toEqual([]);
+        });
+
+        it('sendMessageStream throws ChatError when no model is given in specific mode', async () => {
+            await expect(
+                collect(service.sendMessageStream(CONV_ID, 'Hi', 'specific')),
+            ).rejects.toBeInstanceOf(ChatError);
+            expect(generateStreamForProvider).not.toHaveBeenCalled();
+        });
+
+        it('rotation mode does not require a model', async () => {
+            rotationGenerate.mockResolvedValue(okResponse());
+            await expect(service.sendMessage(CONV_ID, 'Hi', 'rotation')).resolves.toBeDefined();
         });
     });
 

--- a/packages/ui/src/lib/flows/chat/ChatFlow.svelte
+++ b/packages/ui/src/lib/flows/chat/ChatFlow.svelte
@@ -37,7 +37,7 @@
           <button
             class="md:hidden text-slate-400 hover:text-white"
             aria-label="Toggle mobile menu"
-            on:click={toggleMobileMenu}
+            onclick={toggleMobileMenu}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -66,11 +66,11 @@
 
     <!-- Overlay for mobile when sidebar is open -->
     {#if isMobileMenuOpen}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="fixed inset-0 bg-black/60 z-10 md:hidden"
-        on:click={() => (isMobileMenuOpen = false)}
+        onclick={() => (isMobileMenuOpen = false)}
       ></div>
     {/if}
   </div>

--- a/packages/ui/src/lib/flows/chat/api.ts
+++ b/packages/ui/src/lib/flows/chat/api.ts
@@ -80,22 +80,38 @@ export type StreamEvent =
   | { type: 'done'; message: ChatMessage }
   | { type: 'error'; error: string };
 
+/** True when an error is the abort triggered by the caller's signal. */
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
+
 /**
  * Streaming message send via SSE.
- * Calls a callback for each event as it arrives.
+ *
+ * Calls `onEvent` for each event as it arrives. Pass an `AbortSignal` to cancel
+ * an in-flight response; on abort the function returns cleanly (no throw) so the
+ * caller can treat a user-initiated stop as a normal end of stream.
  */
 export async function sendMessageStream(
   conversationId: string,
   message: string,
   mode: ChatMode,
   model: string | undefined,
-  onEvent: (event: StreamEvent) => void
+  onEvent: (event: StreamEvent) => void,
+  signal?: AbortSignal
 ): Promise<void> {
-  const response = await fetch(STREAM_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ conversationId, message, mode, model }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(STREAM_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId, message, mode, model }),
+      signal,
+    });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    throw err;
+  }
 
   if (!response.ok) {
     const text = await response.text();
@@ -106,24 +122,30 @@ export async function sendMessageStream(
   const decoder = new TextDecoder();
   let buffer = '';
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n\n');
-    buffer = lines.pop()!;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n\n');
+      buffer = lines.pop()!;
 
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith('data: ')) continue;
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data: ')) continue;
 
-      try {
-        const event = JSON.parse(trimmed.slice(6)) as StreamEvent;
-        onEvent(event);
-      } catch {
-        // skip malformed SSE
+        try {
+          const event = JSON.parse(trimmed.slice(6)) as StreamEvent;
+          onEvent(event);
+        } catch {
+          // skip malformed SSE
+        }
       }
     }
+  } catch (err) {
+    // A caller-initiated abort is a normal stop, not an error.
+    if (isAbortError(err) || signal?.aborted) return;
+    throw err;
   }
 }

--- a/packages/ui/src/lib/flows/chat/api.ts
+++ b/packages/ui/src/lib/flows/chat/api.ts
@@ -1,8 +1,18 @@
 import { api } from '@lib/client';
 import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
 
-// Typed Eden client for the chat routes
-const chatApi = api.chat;
+// Typed Eden client for the chat routes (mounted under /api/chat, like every flow)
+const chatApi = api.api.chat;
+
+/**
+ * Relative URL for the SSE streaming endpoint.
+ *
+ * Eden Treaty doesn't model SSE responses, so the stream is consumed with a
+ * hand-rolled `fetch`. A relative path keeps it same-origin: in dev it's
+ * forwarded by the Vite proxy (`/api` → backend), in prod it hits the backend
+ * that serves the UI — no hardcoded host/port.
+ */
+const STREAM_URL = '/api/chat/message/stream';
 
 /**
  * Extracts a readable error message from Eden's error object
@@ -81,7 +91,7 @@ export async function sendMessageStream(
   model: string | undefined,
   onEvent: (event: StreamEvent) => void
 ): Promise<void> {
-  const response = await fetch('http://localhost:4173/chat/message/stream', {
+  const response = await fetch(STREAM_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ conversationId, message, mode, model }),

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
@@ -46,23 +46,42 @@
       disabled={chatStore.isLoading}
     ></textarea>
 
-    <button
-      onclick={submit}
-      disabled={!inputContent.trim() || chatStore.isLoading}
-      class="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-lg bg-cosmic-600 text-white disabled:opacity-50 disabled:bg-slate-700 disabled:cursor-not-allowed transition-colors hover:bg-cosmic-500"
-      title="Send message"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        class="w-4 h-4"
+    {#if chatStore.isStreaming}
+      <button
+        onclick={() => chatStore.stopStreaming()}
+        class="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-lg bg-slate-600 text-white transition-colors hover:bg-slate-500"
+        title="Stop generating"
+        aria-label="Stop generating"
       >
-        <path
-          d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z"
-        />
-      </svg>
-    </button>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-3.5 h-3.5"
+        >
+          <rect x="6" y="6" width="12" height="12" rx="1.5" />
+        </svg>
+      </button>
+    {:else}
+      <button
+        onclick={submit}
+        disabled={!inputContent.trim() || chatStore.isLoading}
+        class="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-lg bg-cosmic-600 text-white disabled:opacity-50 disabled:bg-slate-700 disabled:cursor-not-allowed transition-colors hover:bg-cosmic-500"
+        title="Send message"
+        aria-label="Send message"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-4 h-4"
+        >
+          <path
+            d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z"
+          />
+        </svg>
+      </button>
+    {/if}
   </div>
   <p class="text-center mt-2 text-[11px] text-slate-500 cursor-default select-none">
     AI can make mistakes. Consider verifying important information.

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
@@ -38,8 +38,8 @@
     <textarea
       bind:this={textareaEl}
       bind:value={inputContent}
-      on:input={handleInput}
-      on:keydown={handleKeydown}
+      oninput={handleInput}
+      onkeydown={handleKeydown}
       placeholder="Send a message..."
       class="w-full bg-transparent text-slate-200 resize-none outline-none py-3.5 pl-4 pr-12 max-h-[200px] overflow-y-auto scrollbar-thin text-sm leading-relaxed"
       rows="1"
@@ -47,7 +47,7 @@
     ></textarea>
 
     <button
-      on:click={submit}
+      onclick={submit}
       disabled={!inputContent.trim() || chatStore.isLoading}
       class="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-lg bg-cosmic-600 text-white disabled:opacity-50 disabled:bg-slate-700 disabled:cursor-not-allowed transition-colors hover:bg-cosmic-500"
       title="Send message"

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte.test.ts
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte.test.ts
@@ -100,7 +100,8 @@ describe('ChatInput', () => {
       'hi there',
       expect.any(String),
       expect.anything(),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(AbortSignal)
     );
     expect(textarea.value).toBe('');
   });
@@ -136,8 +137,8 @@ describe('ChatInput', () => {
     expect(sendMessageStream).not.toHaveBeenCalled();
   });
 
-  it('disables the textarea and button while a send is in flight (isLoading)', async () => {
-    // Hold the stream open so isLoading stays true.
+  it('disables the textarea and swaps in a Stop button while a send is in flight', async () => {
+    // Hold the stream open so isLoading/isStreaming stay true.
     let resolveStream: () => void = () => {};
     sendMessageStream.mockImplementationOnce(
       () =>
@@ -152,9 +153,35 @@ describe('ChatInput', () => {
     await fireEvent.click(screen.getByTitle('Send message'));
 
     expect(screen.getByPlaceholderText('Send a message...')).toBeDisabled();
-    expect(screen.getByTitle('Send message')).toBeDisabled();
+    // The send button is replaced by an (enabled) Stop button while streaming.
+    expect(screen.queryByTitle('Send message')).toBeNull();
+    expect(screen.getByTitle('Stop generating')).toBeEnabled();
 
     resolveStream();
+  });
+
+  it('clicking Stop aborts the in-flight stream', async () => {
+    let resolveStream: () => void = () => {};
+    sendMessageStream.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStream = resolve;
+        })
+    );
+    const stopSpy = vi.spyOn(chatStore, 'stopStreaming');
+
+    render(ChatInput);
+    const textarea = screen.getByPlaceholderText('Send a message...');
+    await fireEvent.input(textarea, { target: { value: 'stop me' } });
+    await fireEvent.click(screen.getByTitle('Send message'));
+
+    await fireEvent.click(screen.getByTitle('Stop generating'));
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(chatStore.isStreaming).toBe(false);
+
+    resolveStream();
+    stopSpy.mockRestore();
   });
 
   it('renders the AI disclaimer footer', () => {

--- a/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
@@ -82,7 +82,7 @@
   let selectedDisplayName = $derived(getModelDisplayName(selected.model, chatStore.catalog));
 </script>
 
-<svelte:window on:click={handleClickOutside} />
+<svelte:window onclick={handleClickOutside} />
 
 <div class="model-selector-container relative flex items-center gap-1.5">
   <!-- Mode Toggle (labeled) -->
@@ -95,7 +95,7 @@
       class:text-white={chatStore.chatMode === 'rotation'}
       class:text-slate-400={chatStore.chatMode !== 'rotation'}
       class:hover:text-slate-200={chatStore.chatMode !== 'rotation'}
-      on:click={() => setMode('rotation')}
+      onclick={() => setMode('rotation')}
       title="Round-robin across free providers"
     >
       <svg
@@ -119,7 +119,7 @@
       class:text-white={chatStore.chatMode === 'specific'}
       class:text-slate-400={chatStore.chatMode !== 'specific'}
       class:hover:text-slate-200={chatStore.chatMode !== 'specific'}
-      on:click={() => setMode('specific')}
+      onclick={() => setMode('specific')}
       title="Choose a specific provider and model"
     >
       <svg
@@ -157,7 +157,7 @@
   {:else}
     <button
       class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800 rounded-lg border border-slate-700 hover:border-cosmic-600 transition-colors text-xs cursor-pointer"
-      on:click={toggleDropdown}
+      onclick={toggleDropdown}
     >
       <span class="text-cosmic-400 font-medium capitalize">{selected.provider}</span>
       <span class="text-slate-600">/</span>
@@ -199,7 +199,7 @@
                 class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-slate-700/50 transition-colors {isSelected
                   ? 'bg-cosmic-600/10'
                   : ''}"
-                on:click={() => selectModel(group.provider, model.id)}
+                onclick={() => selectModel(group.provider, model.id)}
               >
                 <span
                   class="w-1.5 h-1.5 rounded-full shrink-0 {isSelected

--- a/packages/ui/src/lib/flows/chat/components/Sidebar.svelte
+++ b/packages/ui/src/lib/flows/chat/components/Sidebar.svelte
@@ -38,7 +38,7 @@
 >
   <div class="p-4 border-b border-cosmic-800">
     <button
-      on:click={newChat}
+      onclick={newChat}
       class="w-full flex items-center justify-center gap-2 bg-cosmic-600 hover:bg-cosmic-500 text-white py-2 px-4 rounded-lg transition-colors shadow-glow"
     >
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -58,10 +58,10 @@
     <ul class="space-y-0.5">
       {#each chatStore.conversations as conv (conv.id)}
         <li class="group">
-          <!-- svelte-ignore a11y-click-events-have-key-events -->
-          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
-            on:click={() => selectConversation(conv.id)}
+            onclick={() => selectConversation(conv.id)}
             class={`w-full text-left px-3 py-2.5 rounded-lg text-sm flex items-center gap-2 transition-all cursor-pointer ${
               chatStore.activeConversationId === conv.id
                 ? 'bg-cosmic-800/70 text-white border border-cosmic-600/30'
@@ -93,7 +93,7 @@
             <!-- Delete button (visible on hover) -->
             <button
               class="shrink-0 opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-slate-500 transition-all"
-              on:click={(e) => handleDelete(e, conv.id)}
+              onclick={(e) => handleDelete(e, conv.id)}
               title="Delete conversation"
             >
               <svg

--- a/packages/ui/src/lib/flows/chat/stores.svelte.ts
+++ b/packages/ui/src/lib/flows/chat/stores.svelte.ts
@@ -27,6 +27,9 @@ class ChatStore {
   isStreaming = $state(false);
   streamingContent = $state(''); // partial content being streamed
 
+  /** Aborts the in-flight streaming request, if any. Not reactive state. */
+  private streamController: AbortController | null = null;
+
   /** Seed the store from the route loader's data. Replaces the old `init()` fetch. */
   hydrate(data: ChatInitialData) {
     this.catalog = data.catalog;
@@ -98,48 +101,68 @@ class ChatStore {
     this.isLoading = true;
     this.isStreaming = true;
     this.streamingContent = '';
+    this.streamController = new AbortController();
 
     try {
-      await api.sendMessageStream(convId, content, mode, model, (event) => {
-        switch (event.type) {
-          case 'user_message':
-            // Replace temp user message with server version
-            this.messages = this.messages.map((m) => (m.id === tempUserMsg.id ? event.message : m));
-            break;
+      await api.sendMessageStream(
+        convId,
+        content,
+        mode,
+        model,
+        (event) => {
+          switch (event.type) {
+            case 'user_message':
+              // Replace temp user message with server version
+              this.messages = this.messages.map((m) =>
+                m.id === tempUserMsg.id ? event.message : m
+              );
+              break;
 
-          case 'delta':
-            this.streamingContent = this.streamingContent + event.delta;
-            break;
+            case 'delta':
+              this.streamingContent = this.streamingContent + event.delta;
+              break;
 
-          case 'done':
-            this.messages = [...this.messages, event.message];
-            this.lastProvider = event.message.providerUsed || '';
-            this.lastModel = event.message.modelUsed || '';
-            this.isLoading = false;
-            this.isStreaming = false;
-            this.streamingContent = '';
-            // Refresh conversation list in background
-            api.fetchConversations().then((conversations) => {
-              this.conversations = conversations;
-            });
-            break;
+            case 'done':
+              this.messages = [...this.messages, event.message];
+              this.lastProvider = event.message.providerUsed || '';
+              this.lastModel = event.message.modelUsed || '';
+              this.resetStreamingState();
+              // Refresh conversation list in background
+              api.fetchConversations().then((conversations) => {
+                this.conversations = conversations;
+              });
+              break;
 
-          case 'error':
-            console.error('[ChatStore] Stream error:', event.error);
-            showError(event.error);
-            this.isLoading = false;
-            this.isStreaming = false;
-            this.streamingContent = '';
-            break;
-        }
-      });
+            case 'error':
+              showError(event.error);
+              this.resetStreamingState();
+              break;
+          }
+        },
+        this.streamController.signal
+      );
     } catch (e: unknown) {
       this.messages = this.messages.filter((m) => m.id !== tempUserMsg.id);
-      this.isLoading = false;
-      this.isStreaming = false;
-      this.streamingContent = '';
+      this.resetStreamingState();
       showError(e instanceof Error ? e.message : String(e));
     }
+  }
+
+  /**
+   * Stop the in-flight streaming response. The user message stays (it was
+   * already persisted server-side); the partial assistant text is discarded.
+   */
+  stopStreaming() {
+    this.streamController?.abort();
+    this.resetStreamingState();
+  }
+
+  /** Clears the transient streaming flags and the abort controller. */
+  private resetStreamingState() {
+    this.isLoading = false;
+    this.isStreaming = false;
+    this.streamingContent = '';
+    this.streamController = null;
   }
 }
 

--- a/packages/ui/src/lib/flows/chat/stores.test.ts
+++ b/packages/ui/src/lib/flows/chat/stores.test.ts
@@ -255,7 +255,8 @@ describe('chatStore', () => {
         'specific msg',
         'specific',
         'openai:gpt-4o',
-        expect.any(Function)
+        expect.any(Function),
+        expect.any(AbortSignal)
       );
 
       chatStore.setMode('rotation');
@@ -269,8 +270,36 @@ describe('chatStore', () => {
         'rotation msg',
         'rotation',
         undefined,
-        expect.any(Function)
+        expect.any(Function),
+        expect.any(AbortSignal)
       );
+    });
+
+    it('stopStreaming aborts the request signal and resets streaming flags', async () => {
+      chatStore.startNewConversation();
+      let capturedSignal: AbortSignal | undefined;
+      // Hold the stream open until aborted; resolve on abort like the real
+      // api layer does (a user stop is a clean end of stream, not an error).
+      sendMessageStream.mockImplementationOnce(
+        (_c, _m, _mode, _model, _onEvent, signal?: AbortSignal) => {
+          capturedSignal = signal;
+          return new Promise<void>((resolve) => {
+            signal?.addEventListener('abort', () => resolve());
+          });
+        }
+      );
+
+      const pending = chatStore.sendMessage('long answer');
+      // streaming is in progress
+      expect(chatStore.isStreaming).toBe(true);
+
+      chatStore.stopStreaming();
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(chatStore.isStreaming).toBe(false);
+      expect(chatStore.isLoading).toBe(false);
+      expect(chatStore.streamingContent).toBe('');
+      await pending;
     });
 
     it('appends an optimistic user message immediately', async () => {

--- a/packages/ui/src/routes/chat/page.test.ts
+++ b/packages/ui/src/routes/chat/page.test.ts
@@ -11,11 +11,14 @@ const { modelsGet, conversationsGet } = vi.hoisted(() => ({
 
 vi.mock('@lib/client', () => ({
   api: {
-    chat: {
-      models: { get: modelsGet },
-      conversations: Object.assign(() => ({ get: vi.fn(), delete: vi.fn() }), {
-        get: conversationsGet,
-      }),
+    // Chat routes are mounted under /api/chat, so the Eden tree is api.api.chat
+    api: {
+      chat: {
+        models: { get: modelsGet },
+        conversations: Object.assign(() => ({ get: vi.fn(), delete: vi.fn() }), {
+          get: conversationsGet,
+        }),
+      },
     },
   },
 }));


### PR DESCRIPTION
Closes the rough edges in the Chat flow (#25) and improves the whole `@flows/chat` package. Four focused commits, each green on the full gate.

## 1. Routing fix (the actual bug)
Chat was the only flow mounted at `/chat` instead of `/api/<flow>`, and its SSE streaming endpoint was **hardcoded to `http://localhost:4173`** — bypassing the Vite dev proxy and breaking whenever the UI isn't served from that exact host/port (e.g. production, where the backend serves the UI).
- backend prefix `/chat` → `/api/chat` (matches every other flow)
- Eden client `api.chat` → `api.api.chat`
- SSE fetch now uses a relative `/api/chat/message/stream`

## 2. Backend hardening
- New `backend/config.ts` with `CHAT_SYSTEM_PROMPT` (was inlined) + `DEFAULT_CHAT_MODE`, matching the other flows' config convention
- Validate that "specific" mode has a selected model — throws the previously-**unused** `ChatError` instead of letting a non-null assertion blow up deep in the provider layer

## 3. Runes migration (part of #24)
- `on:click`/`on:input`/`on:keydown` → `onclick`/`oninput`/`onkeydown` across ChatFlow, ChatInput, ModelSelector, Sidebar (clears 12 deprecation warnings)
- Fixed stale `svelte-ignore` codes (`a11y-...` → `a11y_...`) so the a11y suppressions apply again

## 4. Stop button (UX)
- A streaming reply can now be cancelled mid-flight. `sendMessageStream` takes an `AbortSignal`; the store holds an `AbortController` and exposes `stopStreaming()`; the send button becomes a Stop button while streaming.

## Tests
+6 chat tests (backend validation, abort/reset, Stop-button swap & click). Full gate green: typecheck, lint, svelte-check (0 errors), **871 tests**, build.

## Notes / follow-ups
- Canvas has the same hardcoded-`localhost:4173` anti-pattern in its `api.ts` — noted for a follow-up.
- The Eden client base (`treaty<App>('localhost:4173')`) is global and still absolute; revisiting it for production is a separate, cross-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015raAFFekTRs65mGwxCMUzu)_