### PR TITLE
Complete Svelte 5 runes migration (#24)

### DIFF
--- a/packages/ui/src/lib/components/canvas/LayerToggle.svelte
+++ b/packages/ui/src/lib/components/canvas/LayerToggle.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import type { AnnotationLayer } from '@flows/shared';
-  import { createEventDispatcher } from 'svelte';
 
-  export let layers: AnnotationLayer[];
-  export let activeLayers: string[] = [];
-  export let disabled: boolean = false;
+  interface Props {
+    layers: AnnotationLayer[];
+    activeLayers?: string[];
+    disabled?: boolean;
+    /** Fired when a layer is toggled; replaces the old `toggle` event. */
+    ontoggle?: (detail: { layerId: string; active: boolean }) => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    toggle: { layerId: string; active: boolean };
-  }>();
+  let { layers, activeLayers = $bindable([]), disabled = false, ontoggle }: Props = $props();
 
   function toggleLayer(layerId: string) {
     if (disabled) return;
@@ -25,7 +26,7 @@
     // This makes the component controlled/uncontrolled hybrid for ease of use
     activeLayers = newActiveLayers;
 
-    dispatch('toggle', { layerId, active: !isActive });
+    ontoggle?.({ layerId, active: !isActive });
   }
 </script>
 
@@ -37,7 +38,7 @@
       class:active={isActive}
       style="--layer-color: {layer.color}"
       {disabled}
-      on:click={() => toggleLayer(layer.id)}
+      onclick={() => toggleLayer(layer.id)}
       title="Toggle {layer.name}"
     >
       <span class="icon">{layer.icon}</span>

--- a/packages/ui/src/lib/components/canvas/TokenRenderer.svelte
+++ b/packages/ui/src/lib/components/canvas/TokenRenderer.svelte
@@ -1,23 +1,26 @@
 <script lang="ts">
   import type { TokenAST, Annotation } from '@flows/shared';
-  import { createEventDispatcher } from 'svelte';
 
-  export let tokenAst: TokenAST;
-  export let annotations: Annotation[] = [];
-  export let activeLayers: string[] = [];
+  interface Props {
+    tokenAst: TokenAST;
+    annotations?: Annotation[];
+    activeLayers?: string[];
+    /** Fired with the hovered token (or null on leave); replaces the old `tokenhover` event. */
+    ontokenhover?: (detail: { tokenId: string; el: HTMLElement } | null) => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    tokenhover: { tokenId: string; el: HTMLElement } | null;
-  }>();
+  let { tokenAst, annotations = [], activeLayers = [], ontokenhover }: Props = $props();
 
   // Group annotations by token ID for O(1) lookup during render
-  $: annotationsByToken = annotations.reduce(
-    (acc, ann) => {
-      if (!acc[ann.tokenId]) acc[ann.tokenId] = [];
-      acc[ann.tokenId].push(ann);
-      return acc;
-    },
-    {} as Record<string, Annotation[]>
+  const annotationsByToken = $derived(
+    annotations.reduce(
+      (acc, ann) => {
+        if (!acc[ann.tokenId]) acc[ann.tokenId] = [];
+        acc[ann.tokenId].push(ann);
+        return acc;
+      },
+      {} as Record<string, Annotation[]>
+    )
   );
 
   // Filter annotations for a specific token that belong to active layers
@@ -31,7 +34,7 @@
   }
 
   // Line-level meaning highlight: track which line group is hovered
-  let hoveredLineId: string | null = null;
+  let hoveredLineId = $state<string | null>(null);
 
   function handleTokenMouseEnter(
     tokenId: string,
@@ -45,13 +48,13 @@
     }
 
     if (anns.length > 0) {
-      dispatch('tokenhover', { tokenId, el });
+      ontokenhover?.({ tokenId, el });
     }
   }
 
   function handleTokenMouseLeave() {
     hoveredLineId = null;
-    dispatch('tokenhover', null);
+    ontokenhover?.(null);
   }
 
   function abbreviateVocal(label: string): string {
@@ -86,15 +89,15 @@
               {@const displayAnns = activeAnns.filter((a) => a.layerId !== 'meaning')}
               {@const tokenHoverAnns = [...displayAnns, ...lineMeaningAnns]}
 
-              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
               <span
                 class="token"
                 class:annotated={displayAnns.length > 0}
                 class:has-meaning={lineHasMeaning}
                 data-id={token.id}
-                on:mouseenter={(e) =>
+                onmouseenter={(e) =>
                   handleTokenMouseEnter(token.id, tokenHoverAnns, e.currentTarget, lineId)}
-                on:mouseleave={handleTokenMouseLeave}
+                onmouseleave={handleTokenMouseLeave}
               >
                 <!-- All badges inline ABOVE the text -->
                 {#if displayAnns.length > 0}

--- a/packages/ui/src/lib/components/canvas/TokenTooltip.svelte
+++ b/packages/ui/src/lib/components/canvas/TokenTooltip.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import type { Annotation, AnnotationLayer } from '@flows/shared';
 
-  export let annotations: Annotation[] = [];
-  export let layers: AnnotationLayer[] = [];
-  export let x: number = 0;
-  export let y: number = 0;
-  export let visible: boolean = false;
+  interface Props {
+    annotations?: Annotation[];
+    layers?: AnnotationLayer[];
+    x?: number;
+    y?: number;
+    visible?: boolean;
+  }
+
+  let { annotations = [], layers = [], x = 0, y = 0, visible = false }: Props = $props();
 
   // Map layer info for display
   function getLayerInfo(layerId: string) {

--- a/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { canvasStore } from './stores.svelte';
 
-  let title = '';
-  let author = '';
-  let text = '';
+  let title = $state('');
+  let author = $state('');
+  let text = $state('');
 
   function handleSubmit() {
     if (!text.trim()) return;
@@ -50,7 +50,7 @@
     <div class="flex justify-end pt-2">
       <button
         class="px-6 py-3 bg-primary-600 hover:bg-primary-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors flex items-center gap-2 shadow-lg shadow-primary-900/20"
-        on:click={handleSubmit}
+        onclick={handleSubmit}
         disabled={!text.trim() || canvasStore.isAnalyzing}
       >
         {#if canvasStore.isAnalyzing}

--- a/packages/ui/src/lib/flows/canvas/CanvasFlow.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasFlow.svelte
@@ -31,8 +31,7 @@
     isMobileMenuOpen = !isMobileMenuOpen;
   }
 
-  function handleTokenHover(e: CustomEvent<{ tokenId: string; el: HTMLElement } | null>) {
-    const detail = e.detail;
+  function handleTokenHover(detail: { tokenId: string; el: HTMLElement } | null) {
     const analysis = canvasStore.activeCanvas;
 
     if (!detail || !analysis) {
@@ -76,7 +75,7 @@
           <button
             class="md:hidden text-slate-400 hover:text-white"
             aria-label="Toggle mobile menu"
-            on:click={toggleMobileMenu}
+            onclick={toggleMobileMenu}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -151,7 +150,7 @@
               tokenAst={canvasStore.activeCanvas.tokenAst}
               annotations={canvasStore.activeCanvas.annotations}
               {activeLayers}
-              on:tokenhover={handleTokenHover}
+              ontokenhover={handleTokenHover}
             />
 
             <TokenTooltip
@@ -169,11 +168,11 @@
 
     <!-- Overlay for mobile when sidebar is open -->
     {#if isMobileMenuOpen}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="fixed inset-0 bg-black/60 z-10 md:hidden"
-        on:click={() => (isMobileMenuOpen = false)}
+        onclick={() => (isMobileMenuOpen = false)}
       ></div>
     {/if}
   </div>

--- a/packages/ui/src/lib/flows/canvas/CanvasSidebar.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasSidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { canvasStore } from './stores.svelte';
 
-  export let isMobileMenuOpen = false;
+  let { isMobileMenuOpen = $bindable(false) }: { isMobileMenuOpen?: boolean } = $props();
 
   function handleSelect(id: string) {
     canvasStore.loadCanvas(id);
@@ -22,7 +22,7 @@
   <div class="p-4 border-b border-cosmic-800/50 flex-shrink-0">
     <button
       class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-500 text-white rounded-lg font-medium transition-colors"
-      on:click={handleNew}
+      onclick={handleNew}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -62,7 +62,7 @@
                                    {isActive
                 ? 'bg-primary-500/20 text-primary-300 font-medium'
                 : 'text-slate-300 hover:bg-slate-800 hover:text-white'}"
-              on:click={() => handleSelect(canvas.sourceId)}
+              onclick={() => handleSelect(canvas.sourceId)}
             >
               <div class="truncate text-sm font-medium">{canvas.meta?.title || 'Untitled'}</div>
               <div class="text-xs text-slate-500 truncate">{canvas.meta?.author || 'User'}</div>
@@ -71,7 +71,7 @@
             <button
               class="p-2 text-slate-500 hover:text-red-400 hover:bg-red-400/10 rounded-md opacity-0 group-hover:opacity-100 transition-all focus:opacity-100 flex-shrink-0"
               title="Delete Canvas"
-              on:click={() => canvasStore.deleteCanvas(canvas.sourceId)}
+              onclick={() => canvasStore.deleteCanvas(canvas.sourceId)}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte
+++ b/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte
@@ -9,27 +9,27 @@
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';
 
-  export let trackId: string;
+  let { trackId }: { trackId: string } = $props();
 
-  let loading = true;
-  let analyzing = false;
-  let error: string | null = null;
+  let loading = $state(true);
+  let analyzing = $state(false);
+  let error = $state<string | null>(null);
 
-  let analysis: CanvasAnalysis | null = null;
-  let statusInfo: CanvasStatusResponse['source'] | null = null;
+  let analysis = $state<CanvasAnalysis | null>(null);
+  let statusInfo = $state<CanvasStatusResponse['source'] | null>(null);
 
   // UI State
-  let activeLayers: string[] = ['chords', 'vocal', 'meaning'];
+  let activeLayers = $state<string[]>(['chords', 'vocal', 'meaning']);
 
   // Tooltip State
-  let tooltipX = 0;
-  let tooltipY = 0;
-  let tooltipVisible = false;
-  let tooltipAnnotations: Annotation[] = [];
+  let tooltipX = $state(0);
+  let tooltipY = $state(0);
+  let tooltipVisible = $state(false);
+  let tooltipAnnotations = $state<Annotation[]>([]);
 
   // Interpretation State
-  let interpretation: string | null = null;
-  let isInterpreting = false;
+  let interpretation = $state<string | null>(null);
+  let isInterpreting = $state(false);
 
   marked.setOptions({ breaks: true, gfm: true });
 
@@ -111,9 +111,7 @@
     }
   }
 
-  function handleTokenHover(e: CustomEvent<{ tokenId: string; el: HTMLElement } | null>) {
-    const detail = e.detail;
-
+  function handleTokenHover(detail: { tokenId: string; el: HTMLElement } | null) {
     if (!detail || !analysis) {
       tooltipVisible = false;
       return;
@@ -147,7 +145,7 @@
   {:else if error}
     <div class="center-state error">
       <p>{error}</p>
-      <button class="btn" on:click={loadData}>Retry</button>
+      <button class="btn" onclick={loadData}>Retry</button>
     </div>
   {:else if !analysis && statusInfo}
     <div class="center-state empty">
@@ -159,7 +157,7 @@
 
       <div class="actions">
         <p class="description">Generate a musical analysis for this track using AI.</p>
-        <button class="btn primary" on:click={handleAnalyze} disabled={analyzing}>
+        <button class="btn primary" onclick={handleAnalyze} disabled={analyzing}>
           {#if analyzing}
             <div class="spinner small"></div>
             Analyzing Lyrics... (This may take a minute)
@@ -193,7 +191,7 @@
           <LayerToggle layers={analysis.layers} bind:activeLayers />
           <button
             class="btn primary small"
-            on:click={handleAnalyze}
+            onclick={handleAnalyze}
             disabled={analyzing}
             title="Regenerate Analysis"
           >
@@ -221,7 +219,7 @@
           tokenAst={analysis.tokenAst}
           annotations={analysis.annotations}
           {activeLayers}
-          on:tokenhover={handleTokenHover}
+          ontokenhover={handleTokenHover}
         />
       </div>
 
@@ -246,7 +244,7 @@
               <p>No overarching meaning analysis found.</p>
               <button
                 class="btn small mt-4"
-                on:click={handleGenerateMeaning}
+                onclick={handleGenerateMeaning}
                 disabled={isInterpreting}
               >
                 {#if isInterpreting}

--- a/packages/ui/src/lib/flows/lyrics/__fixtures__/CanvasStub.svelte
+++ b/packages/ui/src/lib/flows/lyrics/__fixtures__/CanvasStub.svelte
@@ -2,7 +2,7 @@
   // Test stub standing in for LyricsCanvas. Renders its trackId so tests can
   // assert the flow handed the right id to the canvas branch, without driving
   // the real component's data edges.
-  export let trackId: string;
+  let { trackId }: { trackId: string } = $props();
 </script>
 
 <div data-testid="canvas-stub">{trackId}</div>

--- a/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
+++ b/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
@@ -116,7 +116,7 @@
   }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
 <!-- Backdrop -->
 <div


### PR DESCRIPTION
Migrates the remaining canvas + lyrics components off deprecated Svelte 4 syntax. **svelte-check now reports 0 errors and 0 warnings** (was 26 warnings).

## Changes
- `export let` → `$props()` with typed `Props` interfaces; bindable props use `$bindable` (`LayerToggle.activeLayers`, `CanvasSidebar.isMobileMenuOpen`)
- `createEventDispatcher` → **callback props**: `TokenRenderer`'s `tokenhover` and `LayerToggle`'s `toggle` become `ontokenhover` / `ontoggle`. Consumers (`CanvasFlow`, `LyricsCanvas`) pass plain functions and receive the detail directly instead of a `CustomEvent`.
- `on:event` → `onevent` across TokenRenderer, LayerToggle, CanvasEditor, CanvasSidebar, CanvasFlow, LyricsCanvas, LyricsModal
- local mutable state → `$state`; `$:` derived → `$derived`
- refreshed stale `svelte-ignore` a11y codes (`a11y-...` → `a11y_...`)

## Verification
No behavior change. **All 376 UI tests pass unmodified** — they assert DOM effects (classes, hover highlight) rather than the dispatched events, so the createEventDispatcher→callback swap is transparent to them. Full gate green: lint, svelte-check (0/0), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015raAFFekTRs65mGwxCMUzu)_