### PR TITLE
refactor: harden architecture and delivery workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
-<!-- Personal project: PRs are optional (you can push straight to main). Use this when a
-     change is big enough to want a checklist / the CI run. -->
+<!-- All non-trivial work goes through a short-lived branch and PR to main. -->
 
 ## What & why
 
@@ -11,7 +10,11 @@
 
 ## Checklist
 
-- [ ] `pnpm verify` is green locally (lint, typecheck, check, tests)
+- [ ] `pnpm lint` is green locally
+- [ ] `pnpm typecheck` is green locally
+- [ ] `pnpm check` is green locally
+- [ ] `pnpm test` is green locally
+- [ ] `pnpm build` is green locally when package entrypoints or build behavior changed
 - [ ] Follows [docs/conventions.md](../docs/conventions.md) (zero `any`, no magic strings, layering)
 - [ ] Tests added/updated for the change
 - [ ] Docs updated if behavior or architecture changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ Guidance for AI agents (and humans) working in this repo.
 ## What this is
 
 `flow-sample` — a pnpm-workspaces playground of vertical "flows" (spotify, lyrics, trading,
-chat, canvas) on an **ElysiaJS + better-sqlite3** backend (Node) and a **Svelte 5** frontend
-(migrating to SvelteKit), wired together with typed **Eden Treaty** RPC. Personal project:
-everything goes to `main`, minimal ceremony.
+chat, canvas) on an **ElysiaJS + better-sqlite3** backend (Node) and a **SvelteKit + Svelte 5**
+frontend, wired together with typed **Eden Treaty** RPC. Personal project with a
+lightweight PR workflow: short-lived branches merge back to `main`.
 
 ## Read first
 
@@ -29,7 +29,8 @@ pnpm check        # svelte-check (UI)
 ```
 
 Before pushing anything non-trivial run the full gate: `pnpm lint && pnpm typecheck &&
-pnpm check && pnpm test`.
+pnpm check && pnpm test`. Run `pnpm build` when entrypoints, package exports, or frontend
+build behavior changed.
 
 ## Working rules of thumb
 
@@ -38,4 +39,31 @@ pnpm check && pnpm test`.
 - After changing `@flows/shared` or `@flows/core`, **rebuild them** (`pnpm build:shared`, or
   `pnpm --filter @flows/core build`) — downstream packages typecheck against the compiled
   `dist`.
-- Conventional Commits in English. Commit each coherent step; push directly to `main`.
+- Conventional Commits in English. Commit each coherent step on a branch; never push
+  directly to `main`.
+
+## Git & delivery workflow
+
+Adapted from the `ccec` workflow, but simplified for this repo: there is no `develop`
+branch, so PRs target `main`.
+
+1. Start from updated `main`: `git switch main && git pull --ff-only`.
+2. Create a short-lived branch. Prefer `codex/<short-kebab-description>` for Codex work;
+   if the local ref layout cannot support slash branches, use a clear kebab name.
+3. Work in small coherent commits. Do not use `--no-verify`.
+4. Verify locally before pushing:
+   `pnpm lint && pnpm typecheck && pnpm check && pnpm test`.
+   Add `pnpm build` for non-trivial backend/frontend/package changes.
+5. Push the branch and open a PR to `main`.
+6. Fill the PR with:
+   - what changed and why
+   - user-visible impact
+   - files/areas touched
+   - how it was tested
+   - related issue or `Refs` note when applicable
+7. Check PR status before merging. Merge through GitHub, not by pushing to `main`.
+8. After merge, update local `main` and prune/delete the completed branch when practical.
+
+If the user explicitly asks to "merge it", the agent should complete the full delivery
+cycle in the same turn whenever possible: branch, commit, push, PR, checks, merge, and
+report the merged PR URL.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,9 +33,10 @@ Mostly done across the recent modernization (Fases 0–3):
 - [x] Tests + coverage: ~832 tests, per-package coverage (`pnpm test:coverage`)
 - [x] Tooling: Tailwind v4 (vite plugin, no config), pins, conventions doc, AGENTS/CLAUDE
 - [x] Frontend → **SvelteKit** (file routing, adapter-static SPA) + UI test suite
-- [ ] **3b** — data via `+page.ts` loaders (in progress)
-- [ ] **3c** — runes-only state, drop remaining `svelte/store` (in progress)
-- [ ] GitHub: light CI (gate on push/PR) + PR/issue templates + tidy the boards
+- [x] **3b** — data via `+page.ts` loaders
+- [x] **3c** — runes-only state, drop remaining `svelte/store`
+- [x] GitHub: light CI (gate on push/PR) + PR/issue templates
+- [ ] Refactor audit pass: architecture, frontend data access, backend layering, testing, and stale docs
 
 ---
 
@@ -79,7 +80,7 @@ obvious). This epic makes the LLM output genuinely useful.
 
 ### 5. Flow polish
 
-- **Chat flow**: it's currently broken — fix it; unify its components with the design system.
+- **Chat flow**: routing/streaming is fixed; continue UX and design-system polish.
 - **Trading flow**: tidy and improve; clarify its domain + docs.
 - Per flow: sharpen the domain model, the docs, and the high-level "what is this" framing.
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -18,27 +18,22 @@ packages/
     ├── spotify/        # Spotify Sync & Search Flow
     ├── lyrics/         # LrcLib Lyrics Fetcher Flow
     ├── trading/        # Binance real-time Trading & AI Advisor Flow
-    └── chat/           # Multi-provider LLM Chat Flow
+    ├── chat/           # Multi-provider LLM Chat Flow
+    └── canvas/         # Generic text analysis canvas
 ```
 
 ### Layout per Flow (current state)
 
-The flows are **not yet uniform** — two patterns coexist today. Unifying them is a
-B2 goal (see [refactor-proposals/B1-ordering.md](../refactor-proposals/B1-ordering.md)
-and GitHub issue #18); B1 keeps them in place.
+All five flows now follow the same high-level package shape: a `domain/` layer
+for pure concepts, ports, and typed errors, plus a `backend/` layer for Elysia
+routes, repositories, services, databases, and adapters. The remaining refactor
+work is about tightening boundaries inside that shape, not introducing it.
 
 ```text
-# Hexagonal (spotify, trading): a domain/ layer split from infrastructure
 flow-package/
 ├── src/
-│   ├── domain/             # Pure math, entities, ports, typed errors
-│   └── backend/            # Elysia routes, repositories, DB, services
-│       └── adapter/        # External API clients (trading: src/adapters/binance/)
-
-# Flat (lyrics, chat): routes + data access, no domain/ layer yet
-flow-package/
-├── src/
-│   └── backend/            # routes.ts, repository.ts / database.ts, adapter/
+│   ├── domain/             # Pure logic, ports, typed errors
+│   └── backend/            # Elysia routes, repositories, DB, services, adapters
 ```
 
 ## Shared Infrastructure

--- a/docs/architecture/server.md
+++ b/docs/architecture/server.md
@@ -4,109 +4,56 @@
 
 | Technology | Purpose |
 | ---------- | ------- |
-| **Elysia** | Web framework (TypeBox validation, plugin system) |
+| **Elysia** | HTTP composition, validation, plugin system |
 | **@elysiajs/node** | Node.js adapter |
-| **@elysiajs/static** | Static file serving |
-| **TypeScript** | Type safety |
+| **@elysiajs/static** | Static UI serving in production |
+| **Eden Treaty** | Type-safe client contract for the SvelteKit UI |
+| **better-sqlite3** | Local SQLite persistence inside flow repositories |
 
-## Why Elysia?
+## Host Shape
 
-- **Plugin system** — Dependency injection without decorators
-- **TypeBox validation** — Runtime validation with compile-time types
-- **Eden client** — Type-safe API client for frontend (future)
-- **Route groups** — Clean separation by domain
-- **Node.js adapter** — Works with existing Node.js ecosystem
-
-## Directory Structure
+The backend package is a thin host. Flow packages own their domain logic,
+repositories, adapters, and routes; `@flows/backend` only composes them.
 
 ```text
-src/api/
-├── app.ts              # Main Elysia server
-├── spotify.routes.ts   # Spotify route group
-├── config.ts           # Zod config loader
-└── index.ts            # Barrel exports
+packages/backend/src/api/
+├── app.ts      # import-safe createApp(config)
+├── config.ts   # env-to-config mapping
+└── server.ts   # process entrypoint, dotenv, listen()
 ```
 
-## API Endpoints
+`app.ts` must stay import-safe because UI Eden types and backend tests import it.
+Only `server.ts` may bind a port.
 
-| Method | Path | Description |
-| ------ | ---- | ----------- |
-| `GET` | `/api/status` | Health check |
-| `POST` | `/api/spotify/run` | Fetch tracks and save to SQLite |
-| `GET` | `/api/spotify/tracks` | Get all tracks from SQLite |
-| `GET` | `/api/spotify/count` | Get track count |
-| `GET` | `/outputs/*` | Serve output files |
-| `GET` | `/*` | Serve UI static files (production) |
+## Mounted Routes
 
-## Request/Response Examples
+| Prefix | Owner |
+| ------ | ----- |
+| `/api/health` | backend host |
+| `/api/spotify` | `@flows/spotify` |
+| `/api/lyrics` | `@flows/lyrics` |
+| `/api/trading` | `@flows/trading` |
+| `/api/chat` | `@flows/chat` |
+| `/api/canvas` | `@flows/canvas` |
 
-### Health Check
-
-```http
-GET /api/status
-
-{ "success": true, "message": "Server ready." }
-```
-
-### Run Spotify Flow
-
-```http
-POST /api/spotify/run
-Content-Type: application/json
-
-{ "limit": 50 }
-```
-
-Response:
-
-```json
-{
-  "success": true,
-  "message": "Flow completed.",
-  "count": 1247,
-  "output": "liked_songs.json"
-}
-```
-
-### Get All Tracks
-
-```http
-GET /api/spotify/tracks
-
-[
-  {
-    "id": "abc123",
-    "title": "Song Name",
-    "artists": [{ "id": "...", "name": "Artist" }],
-    "album": { "id": "...", "name": "Album", "releaseYear": 2024 },
-    ...
-  }
-]
-```
+In production-style builds, the host also serves the SvelteKit static output from
+`packages/ui/build` when it exists, with `index.html` fallback for SPA routing.
 
 ## Code Overview
 
 ```typescript
-import { Elysia } from 'elysia';
-import { node } from '@elysiajs/node';
-import { staticPlugin } from '@elysiajs/static';
-
-const app = new Elysia({ adapter: node() })
-  .get('/api/status', () => ({ success: true }))
+const app = createApp(config)
   .use(createSpotifyRoutes(config))
-  .use(staticPlugin({ assets: 'outputs', prefix: '/outputs' }))
-  .listen({ port: 4173 });
+  .use(createLyricsRoutes())
+  .use(createTradingRoutes())
+  .use(chatRoutes)
+  .use(canvasFlowRoutes);
 ```
 
-## Running the Server
+## Running
 
 ```bash
-# Development
-npm run server
-
-# The server will:
-# - Start on http://127.0.0.1:4173
-# - Create SQLite database at data/flow.db
-# - Serve API endpoints
-# - Serve UI from ui/dist (if built)
+pnpm --filter @flows/backend dev
 ```
+
+The root `pnpm dev` script runs all package dev scripts in parallel.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -148,16 +148,25 @@ from `lib/flows/<flow>/`. See [architecture/ui.md](architecture/ui.md).
 
 ---
 
-## 7. Git & quality gate (personal project — minimal ceremony)
+## 7. Git & delivery workflow
 
-- **Everything goes to `main`.** No `develop` branch, no mandatory PRs. Commit, push, merge
-  directly.
-- **Light hooks:** pre-commit formats/lints staged files; pre-push runs typecheck + fast
-  tests. Don't add multi-dev ceremony (branch protection, CI shards, PR templates as gates).
+This repo uses the lightweight PR discipline from `ccec`, adapted to a single permanent
+branch: **PRs target `main`**. There is no `develop` branch here.
+
+- **Never push directly to `main`.** Work on a short-lived branch, push it, open a PR, wait
+  for checks, and merge through GitHub.
+- **Branch naming:** prefer `codex/<short-kebab-description>` for Codex-created branches.
+  If a local ref layout blocks slash branches, use a clear kebab name such as
+  `housekeeping-audit-workflow`.
 - **Conventional Commits** in English: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`,
   `test:`, `ci:`.
-- The full local gate is `pnpm verify`-style: `pnpm lint && pnpm typecheck && pnpm check &&
-  pnpm test`. Run it before pushing anything non-trivial.
+- **Local gate before push:** `pnpm lint && pnpm typecheck && pnpm check && pnpm test`.
+  Add `pnpm build` when touching package entrypoints, generated artifacts, UI build output,
+  or backend startup/build behavior.
+- **PR description:** include what changed, why it matters, user-visible impact, technical
+  areas touched, test commands run, and related issue/refs if any.
+- **Merge discipline:** check PR status before merging. Prefer GitHub server-side merge
+  (`gh pr merge` or the GitHub UI) over local merges into `main`.
 
 ---
 

--- a/docs/refactor-proposals/architecture-audit-2026-07-09.md
+++ b/docs/refactor-proposals/architecture-audit-2026-07-09.md
@@ -1,0 +1,146 @@
+# Architecture Audit - 2026-07-09
+
+Scope: refactor/quality pass for `flow-sample`, excluding the product epics #27
+(Spotify x Lyrics x Canvas) and #23 (LLM depth / multi-agent).
+
+Reference baseline: `ccec` local repo, especially its backend flow layering,
+Eden data-access pattern, UI/a11y primitives, and testing docs. This repo should
+stay lighter than `ccec`, but the same boundaries apply: thin routes, explicit
+composition roots, typed RPC, server data through loaders, and tests that cover
+behavior rather than implementation.
+
+## Done in this pass
+
+- Updated local `main` to `origin/main` and confirmed a clean working tree before
+  edits.
+- Removed production-host hardcoding from the UI Eden client. The default base is
+  now same-origin; `VITE_API_URL` remains available for an explicit override.
+- Changed Canvas REST calls from `http://localhost:4173/api/canvas` to
+  `/api/canvas`.
+- Updated roadmap/backend/agent docs that still described completed migration
+  work as pending.
+- Removed one production `any` from the trading synthesizer return type.
+- Re-enabled `@typescript-eslint/no-explicit-any` for backend-managed TS lint and
+  expanded that lint surface to backend, core, shared, and all flow packages.
+- Split backend app construction (`createApp(config)`) from process startup
+  (`server.ts`) and added a health-route test that imports the app without
+  binding a port.
+- Moved Lyrics Canvas track/lyrics SQL into a repository, moved analysis
+  orchestration into a service, and left routes as HTTP mapping only.
+- Added focused tests for the Lyrics Canvas repository/service and tightened
+  LLM core test helpers so they no longer rely on explicit `any`.
+- Fixed backend static UI serving to point at SvelteKit's `packages/ui/build`
+  output.
+- Added `typecheck` to `@flows/shared` so root typecheck covers shared types.
+
+## High-priority refactor queue
+
+### 1. Enforce the conventions with tooling
+
+Status: done for TypeScript packages covered by backend lint. Remaining work is
+to extract this into a shared root ESLint config if the repo grows beyond this
+personal-workspace shape.
+
+### 2. Split backend app construction from process startup
+
+Status: done for the backend host. `app.ts` now exports `createApp(config)` and
+`server.ts` owns `.listen(...)`. Keep new route tests on `app.handle(...)` so
+importing backend types remains side-effect free.
+
+### 3. Move lyrics canvas SQL out of routes
+
+Status: done. The route now composes `SQLiteLyricsCanvasRepository` and
+`LyricsCanvasService`; SQL and orchestration have focused unit coverage.
+
+### 4. Normalize env/config ownership
+
+Current gap: some package-level modules still read `process.env` directly:
+
+- `@flows/core/llm` reads provider/model env.
+- Trading config/service reads `TRADING_*` and `ADVISOR_AUTO_START`.
+- Backend env reads now live in `config.ts` / `server.ts`, while `app.ts`
+  remains import-safe.
+
+This is workable for a personal project, but it weakens testability and makes
+runtime behavior implicit.
+
+Next step:
+
+- Keep env reads in package factories only when they are explicitly named as
+  composition helpers (`createLLMClientFromEnv`).
+- Prefer passing config into services/routes from the backend host.
+- Rename factories so env-reading behavior is visible.
+
+### 5. Finish UI data-access alignment
+
+Current gap: SvelteKit loaders exist, but several components still fetch API data
+from `onMount` or flow-local raw `fetch` wrappers.
+
+Acceptable exceptions:
+
+- Browser-only chart setup.
+- SSE streaming endpoints that Eden does not model cleanly.
+- IntersectionObserver / DOM-only behavior.
+
+Refactor targets:
+
+- Canvas CRUD should use Eden where the backend route is already typed.
+- Spotify filter options (`genres`, `years`) should move to a loader or a
+  documented shared loader/cache.
+- Add invalidation constants before adding more mutation-driven reloads.
+
+### 6. Turn #24 into an incremental design-system refactor
+
+Current gap: the UI has a theme file, but components still mix app tokens,
+Tailwind color literals, hardcoded hex values, and repeated async/empty/error
+states.
+
+Next step:
+
+- Create shared primitives first: `Button`, `IconButton`, `Field`, `Badge`,
+  `AsyncState`, `ModalShell`.
+- Keep cards at modest radius unless a flow has a deliberate reason.
+- Move the three palettes (galaxy/fire/organic) into named Tailwind v4 tokens.
+- Replace one flow at a time; start with Chat or Canvas because they already use
+  utilitarian app surfaces.
+
+### 7. Trading polish as refactor, not feature work
+
+Current gap: trading has useful domain tests and services, but UX/api code still
+contains duplicated logging, raw console calls, and mixed concerns in UI
+components.
+
+Next step:
+
+- Replace adapter/service `console.*` with `@flows/core` logger.
+- Move wizard constants and formatting helpers out of `StepWizard.svelte`.
+- Type the enriched market-state view model explicitly.
+- Add a short trading README route/API map that matches current code.
+
+### 8. Testing gate cleanup
+
+Current gap: coverage is good for many packages, but the gate still has blind
+spots.
+
+- `@flows/backend` now runs Vitest and has a health-route test.
+- There is no root `vitest.workspace.ts`.
+- UI E2E exists but is not part of the light CI gate.
+
+Next step:
+
+- After splitting app startup, add backend route tests.
+- Add root contract checks for "no production any", "no raw SQL outside
+  repository/database files", and "no hardcoded localhost in UI API code".
+- Decide whether Playwright stays manual or becomes a separate optional CI job.
+
+## Suggested execution order
+
+1. Tooling enforcement: lint every flow, then fix surfaced `any` in production.
+2. Backend app factory split, unlocking route tests.
+3. Lyrics canvas repository/service extraction.
+4. UI data-access pass: Eden client factory usage in loaders and Canvas API.
+5. Design-system primitives, then apply them to Chat/Canvas.
+6. Trading polish/refactor.
+
+This order keeps behavior stable while making the next change easier than the
+previous one.

--- a/docs/templates/pr_template.md
+++ b/docs/templates/pr_template.md
@@ -1,34 +1,35 @@
 # [PR Title]
 
-## 🚀 Summary
+## Summary
 
 [Brief summary of what this PR accomplishes]
 
-## 🛠️ Key Changes
+## Key Changes
 
-### 🏗️ Refactoring
-
-- [Change 1]
-- [Change 2]
-
-### 🎨 UI Polish
+### Refactoring
 
 - [Change 1]
 - [Change 2]
 
-### ⚡ Features
+### UI Polish
 
 - [Change 1]
 - [Change 2]
 
-### 🐛 Fixes
+### Features
 
 - [Change 1]
 - [Change 2]
 
-## ✅ Verification
+### Fixes
 
-- [ ] `pnpm check` passed (0 errors)
-- [ ] Browser QA performed
-- [ ] No console errors
-- [ ] Visual regression checked (if UI changed)
+- [Change 1]
+- [Change 2]
+
+## Verification
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm check`
+- [ ] `pnpm test`
+- [ ] `pnpm build` when package entrypoints or build behavior changed

--- a/packages/backend/eslint.config.mjs
+++ b/packages/backend/eslint.config.mjs
@@ -2,9 +2,18 @@ import js from '@eslint/js';
 import globals from 'globals';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
-import prettierPlugin from 'eslint-plugin-prettier';
 
-const ignores = ['dist/', 'node_modules/', 'outputs/'];
+const ignores = [
+  'dist/',
+  'node_modules/',
+  'outputs/',
+  'coverage/',
+  '../core/dist/',
+  '../core/coverage/',
+  '../shared/dist/',
+  '../flows/*/dist/',
+  '../flows/*/coverage/',
+];
 
 export default [
   {
@@ -25,12 +34,14 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tseslint,
-      prettier: prettierPlugin,
     },
     rules: {
       ...tseslint.configs.recommended.rules,
-      'prettier/prettier': 'warn',
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
     },
   },
 ];

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,13 +5,14 @@
     "type": "commonjs",
     "main": "./dist/api/app.js",
     "scripts": {
-        "dev": "tsx watch src/api/app.ts",
-        "start": "node dist/api/app.js",
+        "dev": "tsx watch src/api/server.ts",
+        "start": "node dist/api/server.js",
         "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
         "typecheck": "tsc --noEmit",
-        "lint": "eslint src --ext .ts",
-        "lint:fix": "eslint src --ext .ts --fix",
-        "test": "echo 'No tests'"
+        "lint": "eslint --no-error-on-unmatched-pattern \"src/**/*.ts\" \"tests/**/*.ts\" \"../core/src/**/*.ts\" \"../core/tests/**/*.ts\" \"../shared/src/**/*.ts\" \"../flows/*/src/**/*.ts\" \"../flows/*/tests/**/*.ts\"",
+        "lint:fix": "eslint --fix --no-error-on-unmatched-pattern \"src/**/*.ts\" \"tests/**/*.ts\" \"../core/src/**/*.ts\" \"../core/tests/**/*.ts\" \"../shared/src/**/*.ts\" \"../flows/*/src/**/*.ts\" \"../flows/*/tests/**/*.ts\"",
+        "test": "vitest run --passWithNoTests",
+        "test:coverage": "vitest run --coverage --passWithNoTests"
     },
     "dependencies": {
         "@elysiajs/cors": "^1.4.0",
@@ -41,6 +42,8 @@
         "prettier": "^3.3.3",
         "tsc-alias": "^1.8.16",
         "tsx": "^4.19.2",
-        "typescript": "^5.6.3"
+        "@vitest/coverage-v8": "^4.1.9",
+        "typescript": "^5.6.3",
+        "vitest": "^4.1.9"
     }
 }

--- a/packages/backend/src/api/app.ts
+++ b/packages/backend/src/api/app.ts
@@ -4,12 +4,7 @@
  * This package is just the Elysia server that composes
  * route modules from each flow package.
  */
-import * as dotenv from 'dotenv';
 import * as path from 'path';
-
-// Load .env from monorepo root (2 levels up from packages/backend/)
-dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
-
 import { Elysia } from 'elysia';
 import { node } from '@elysiajs/node';
 import { cors } from '@elysiajs/cors';
@@ -21,105 +16,79 @@ import { createTradingRoutes } from '@flows/trading';
 import { chatRoutes } from '@flows/chat';
 import { canvasFlowRoutes } from '@flows/canvas';
 import { logger } from '@flows/core';
+import type { BackendConfig } from './config';
 
 const log = logger.child({ module: 'Server' });
 
-// Load config from environment
-const config = {
-  port: parseInt(process.env.PORT || '4173'),
-  spotify: {
-    clientId: process.env.SPOTIFY_CLIENT_ID || '',
-    clientSecret: process.env.SPOTIFY_CLIENT_SECRET || '',
-    redirectUri:
-      process.env.SPOTIFY_REDIRECT_URI || 'http://127.0.0.1:4173/api/spotify/auth/callback',
-    successUrl: process.env.SPOTIFY_SUCCESS_URL || 'http://localhost:5173/?connected=true#/spotify',
-    refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
-    pageLimit: parseInt(process.env.SPOTIFY_PAGE_LIMIT || '5'),
-  },
-};
+// Check if the SvelteKit static output exists for same-origin serving.
+const uiBuildPath = path.resolve(__dirname, '../../../ui/build');
 
-// Warn about missing Spotify credentials at startup (non-fatal — other flows work without them)
-if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
-  log.warn(
-    'SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET not set — Spotify flow will not authenticate',
-  );
+export function createApp(config: BackendConfig) {
+  const hasUiBuild = fs.existsSync(uiBuildPath);
+
+  return new Elysia({ adapter: node() })
+    // CORS
+    .use(
+      cors({
+        origin: true,
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      }),
+    )
+
+    // Static UI serving (if built)
+    .use(
+      hasUiBuild
+        ? staticPlugin({
+            assets: uiBuildPath,
+            prefix: '/',
+            headers: {
+              'Cache-Control': 'no-cache',
+            },
+          })
+        : new Elysia(),
+    )
+
+    // Request ID middleware
+    .derive(() => ({
+      requestId: crypto.randomUUID(),
+    }))
+
+    // Health check
+    .get('/api/health', () => ({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      flows: ['spotify', 'lyrics', 'trading', 'chat', 'canvas'],
+    }))
+
+    // Flow routes (from flow packages)
+    .use(createSpotifyRoutes(config))
+    .use(createLyricsRoutes())
+    .use(createTradingRoutes())
+    .use(chatRoutes)
+    .use(canvasFlowRoutes)
+
+    // Error handler
+    .onError(({ error, code, set }) => {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      log.error({ error: errMsg, code }, 'Request error');
+
+      if (code === 'NOT_FOUND') {
+        // Try to serve index.html for SPA routing
+        if (hasUiBuild) {
+          const indexPath = path.join(uiBuildPath, 'index.html');
+          if (fs.existsSync(indexPath)) {
+            set.headers['Content-Type'] = 'text/html';
+            return fs.readFileSync(indexPath, 'utf-8');
+          }
+        }
+        set.status = 404;
+        return { error: 'Not Found' };
+      }
+
+      set.status = 500;
+      return { error: 'Internal Server Error' };
+    });
 }
 
-// Check if UI dist folder exists for static serving
-const uiDistPath = path.resolve(__dirname, '../../ui/dist');
-const hasUiDist = fs.existsSync(uiDistPath);
-
-export const app = new Elysia({ adapter: node() })
-  // CORS
-  .use(
-    cors({
-      origin: true,
-      methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    }),
-  )
-
-  // Static UI serving (if built)
-  .use(
-    hasUiDist
-      ? staticPlugin({
-          assets: uiDistPath,
-          prefix: '/',
-          headers: {
-            'Cache-Control': 'no-cache',
-          },
-        })
-      : new Elysia(),
-  )
-
-  // Request ID middleware
-  .derive(() => ({
-    requestId: crypto.randomUUID(),
-  }))
-
-  // Health check
-  .get('/api/health', () => ({
-    status: 'ok',
-    timestamp: new Date().toISOString(),
-    flows: ['spotify', 'lyrics', 'trading', 'chat'],
-  }))
-
-  // Flow routes (from flow packages)
-  .use(createSpotifyRoutes(config))
-  .use(createLyricsRoutes())
-  .use(createTradingRoutes())
-  .use(chatRoutes)
-  .use(canvasFlowRoutes)
-
-  // Error handler
-  .onError(({ error, code, set }) => {
-    const errMsg = error instanceof Error ? error.message : String(error);
-    log.error({ error: errMsg, code }, 'Request error');
-
-    if (code === 'NOT_FOUND') {
-      // Try to serve index.html for SPA routing
-      if (hasUiDist) {
-        const indexPath = path.join(uiDistPath, 'index.html');
-        if (fs.existsSync(indexPath)) {
-          set.headers['Content-Type'] = 'text/html';
-          return fs.readFileSync(indexPath, 'utf-8');
-        }
-      }
-      set.status = 404;
-      return { error: 'Not Found' };
-    }
-
-    set.status = 500;
-    return { error: 'Internal Server Error' };
-  });
-
 // Export type for Eden
-export type App = typeof app;
-
-// Start server
-app.listen(config.port, () => {
-  log.info({ port: config.port }, 'Server started');
-  log.info({ url: `http://localhost:${config.port}` }, 'Listening');
-  if (hasUiDist) {
-    log.info({ path: uiDistPath }, 'Serving UI');
-  }
-});
+export type App = ReturnType<typeof createApp>;

--- a/packages/backend/src/api/config.ts
+++ b/packages/backend/src/api/config.ts
@@ -1,0 +1,33 @@
+export interface BackendConfig {
+  port: number;
+  spotify: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    successUrl: string;
+    refreshToken?: string;
+    pageLimit: number;
+  };
+}
+
+type Env = Record<string, string | undefined>;
+
+function parseInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+export function createBackendConfigFromEnv(env: Env = process.env): BackendConfig {
+  return {
+    port: parseInteger(env.PORT, 4173),
+    spotify: {
+      clientId: env.SPOTIFY_CLIENT_ID || '',
+      clientSecret: env.SPOTIFY_CLIENT_SECRET || '',
+      redirectUri: env.SPOTIFY_REDIRECT_URI || 'http://127.0.0.1:4173/api/spotify/auth/callback',
+      successUrl: env.SPOTIFY_SUCCESS_URL || 'http://localhost:5173/spotify?connected=true',
+      refreshToken: env.SPOTIFY_REFRESH_TOKEN,
+      pageLimit: parseInteger(env.SPOTIFY_PAGE_LIMIT, 5),
+    },
+  };
+}

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -1,0 +1,29 @@
+/**
+ * Process entrypoint for the backend host.
+ *
+ * Keep app construction import-safe: tests and typed clients import `app.ts`
+ * without binding a port.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { logger } from '@flows/core';
+import { createApp } from './app';
+import { createBackendConfigFromEnv } from './config';
+
+dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
+
+const log = logger.child({ module: 'Server' });
+const config = createBackendConfigFromEnv();
+
+if (!config.spotify.clientId || !config.spotify.clientSecret) {
+  log.warn(
+    'SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET not set — Spotify flow will not authenticate',
+  );
+}
+
+const app = createApp(config);
+
+app.listen(config.port, () => {
+  log.info({ port: config.port }, 'Server started');
+  log.info({ url: `http://localhost:${config.port}` }, 'Listening');
+});

--- a/packages/backend/tests/api/app.test.ts
+++ b/packages/backend/tests/api/app.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../../src/api/app';
+import type { BackendConfig } from '../../src/api/config';
+
+function makeConfig(overrides: Partial<BackendConfig> = {}): BackendConfig {
+  return {
+    port: 4173,
+    spotify: {
+      clientId: '',
+      clientSecret: '',
+      redirectUri: 'http://127.0.0.1:4173/api/spotify/auth/callback',
+      successUrl: 'http://localhost:5173/spotify?connected=true',
+      refreshToken: undefined,
+      pageLimit: 5,
+    },
+    ...overrides,
+  };
+}
+
+describe('backend app', () => {
+  it('serves the health route without binding a port', async () => {
+    const app = createApp(makeConfig());
+    const response = await app.handle(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'ok',
+      flows: ['spotify', 'lyrics', 'trading', 'chat', 'canvas'],
+    });
+  });
+});

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['dist/**', 'coverage/**'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@flows/canvas': path.resolve(__dirname, '../flows/canvas/src/index.ts'),
+      '@flows/chat': path.resolve(__dirname, '../flows/chat/src/index.ts'),
+      '@flows/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@flows/lyrics': path.resolve(__dirname, '../flows/lyrics/src/index.ts'),
+      '@flows/shared': path.resolve(__dirname, '../shared/src/index.ts'),
+      '@flows/spotify': path.resolve(__dirname, '../flows/spotify/src/index.ts'),
+      '@flows/trading': path.resolve(__dirname, '../flows/trading/src/index.ts'),
+    },
+  },
+});

--- a/packages/core/tests/llm/llm-client.test.ts
+++ b/packages/core/tests/llm/llm-client.test.ts
@@ -27,12 +27,29 @@ function makeTestProvider(name: string) {
     };
 }
 
-function makeRotationClient(providers: ReturnType<typeof makeTestProvider>[]): any {
-    const client = Object.create(LLMClient.prototype) as any;
-    client.provider = providers[0];
-    client.rotationProviders = providers;
-    client.rotationIndex = 0;
+function makeDirectClient(provider: ReturnType<typeof makeTestProvider>): LLMClient {
+    const client = Object.create(LLMClient.prototype) as LLMClient;
+    Reflect.set(client, 'provider', provider);
+    Reflect.set(client, 'rotationProviders', null);
+    Reflect.set(client, 'rotationIndex', 0);
     return client;
+}
+
+function makeRotationClient(providers: ReturnType<typeof makeTestProvider>[]): LLMClient {
+    const client = Object.create(LLMClient.prototype) as LLMClient;
+    Reflect.set(client, 'provider', providers[0]);
+    Reflect.set(client, 'rotationProviders', providers);
+    Reflect.set(client, 'rotationIndex', 0);
+    return client;
+}
+
+function setRotationIndex(client: LLMClient, index: number): void {
+    Reflect.set(client, 'rotationIndex', index);
+}
+
+function clearProviderCache(): void {
+    const cache = Reflect.get(LLMClient, 'providerCache') as Map<unknown, unknown>;
+    cache.clear();
 }
 
 async function* toAsyncGen(events: LLMStreamEvent[]): AsyncGenerator<LLMStreamEvent> {
@@ -50,7 +67,7 @@ describe('LLMClient constructor', () => {
     beforeEach(() => {
         origEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
         for (const k of ENV_KEYS) delete process.env[k];
-        (LLMClient as any).providerCache.clear();
+        clearProviderCache();
     });
 
     afterEach(() => {
@@ -78,19 +95,13 @@ describe('LLMClient constructor', () => {
 describe('LLMClient direct mode', () => {
     it('isRotation is false for a direct client', () => {
         const p1 = makeTestProvider('groq');
-        const client = Object.create(LLMClient.prototype) as any;
-        client.provider = p1;
-        client.rotationProviders = null;
-        client.rotationIndex = 0;
+        const client = makeDirectClient(p1);
         expect(client.isRotation).toBe(false);
     });
 
     it('listAllModelCatalogs returns only current provider in direct mode', () => {
         const p1 = makeTestProvider('groq');
-        const client = Object.create(LLMClient.prototype) as any;
-        client.provider = p1;
-        client.rotationProviders = null;
-        client.rotationIndex = 0;
+        const client = makeDirectClient(p1);
         const catalogs = client.listAllModelCatalogs();
         expect(catalogs).toHaveLength(1);
         expect(catalogs[0].id).toBe('groq-id');
@@ -178,7 +189,7 @@ describe('LLMClient rotation — generate()', () => {
         p1.generate.mockResolvedValue(okResponse('groq'));
         p2.generate.mockResolvedValue(okResponse('openrouter'));
         const client = makeRotationClient([p1, p2]);
-        client.rotationIndex = 1;
+        setRotationIndex(client, 1);
 
         const res = await client.generate(req);
         expect(res.provider).toBe('openrouter');
@@ -193,7 +204,7 @@ describe('LLMClient rotation — generate()', () => {
 describe('LLMClient rotation — generateStream()', () => {
     const req: LLMRequest = { messages: [{ role: 'user', content: 'hi' }] };
 
-    async function collectStream(client: any): Promise<LLMStreamEvent[]> {
+    async function collectStream(client: LLMClient): Promise<LLMStreamEvent[]> {
         const events: LLMStreamEvent[] = [];
         for await (const e of client.generateStream(req)) {
             events.push(e);
@@ -314,7 +325,7 @@ describe('LLMClient.parseProviderModel', () => {
             expect(msg).not.toMatch(/Invalid model format/);
         } finally {
             delete process.env.OPENROUTER_API_KEY;
-            (LLMClient as any).providerCache.clear();
+            clearProviderCache();
         }
     });
 });
@@ -324,10 +335,7 @@ describe('LLMClient.parseProviderModel', () => {
 describe('LLMClient listModelCatalog', () => {
     it('returns catalog from the current provider in direct mode', () => {
         const p1 = makeTestProvider('groq');
-        const client = Object.create(LLMClient.prototype) as any;
-        client.provider = p1;
-        client.rotationProviders = null;
-        client.rotationIndex = 0;
+        const client = makeDirectClient(p1);
         const catalog = client.listModelCatalog();
         expect(catalog).toHaveLength(1);
         expect(catalog[0].id).toBe('groq-id');

--- a/packages/core/tests/llm/providers/gemini-format.test.ts
+++ b/packages/core/tests/llm/providers/gemini-format.test.ts
@@ -4,8 +4,19 @@ const { mockGenerateContent } = vi.hoisted(() => ({
     mockGenerateContent: vi.fn(),
 }));
 
+interface MockGoogleGenAI {
+    models: {
+        generateContent: typeof mockGenerateContent;
+    };
+}
+
+interface CapturedContent {
+    role: string;
+    parts: Array<{ text: string }>;
+}
+
 vi.mock('@google/genai', () => ({
-    GoogleGenAI: vi.fn(function (this: any) {
+    GoogleGenAI: vi.fn(function (this: MockGoogleGenAI) {
         this.models = { generateContent: mockGenerateContent };
     }),
 }));
@@ -17,8 +28,8 @@ const okGenAIResponse = {
     usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
 };
 
-function capturedContents(): any[] {
-    return mockGenerateContent.mock.calls[0][0].contents;
+function capturedContents(): CapturedContent[] {
+    return mockGenerateContent.mock.calls[0][0].contents as CapturedContent[];
 }
 
 describe('GeminiProvider formatMessages', () => {

--- a/packages/core/tests/llm/providers/openai-compatible.test.ts
+++ b/packages/core/tests/llm/providers/openai-compatible.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OpenAICompatibleProvider } from '../../../src/llm/providers/openai-compatible';
-import type { ModelInfo } from '../../../src/llm/types';
+import type { LLMStreamEvent, ModelInfo } from '../../../src/llm/types';
 
 // ── Test fixtures ─────────────────────────────────────────────────────
 
@@ -54,8 +54,8 @@ function sseData(obj: object): string {
     return `data: ${JSON.stringify(obj)}\n\n`;
 }
 
-async function collectStream(gen: AsyncGenerator<any>): Promise<any[]> {
-    const events: any[] = [];
+async function collectStream(gen: AsyncGenerator<LLMStreamEvent>): Promise<LLMStreamEvent[]> {
+    const events: LLMStreamEvent[] = [];
     for await (const e of gen) events.push(e);
     return events;
 }

--- a/packages/core/tests/llm/stream-parser.test.ts
+++ b/packages/core/tests/llm/stream-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseOpenAIStream } from '../../src/llm/providers/stream-parser';
+import type { LLMStreamEvent } from '../../src/llm/types';
 
 function makeSSEResponse(chunks: string[]): Response {
     const encoder = new TextEncoder();
@@ -18,8 +19,8 @@ function sseData(obj: object): string {
     return `data: ${JSON.stringify(obj)}\n\n`;
 }
 
-async function collect(gen: AsyncGenerator<any>): Promise<any[]> {
-    const events: any[] = [];
+async function collect(gen: AsyncGenerator<LLMStreamEvent>): Promise<LLMStreamEvent[]> {
+    const events: LLMStreamEvent[] = [];
     for await (const e of gen) {
         events.push(e);
     }

--- a/packages/flows/lyrics/src/backend/canvas/canvas.routes.ts
+++ b/packages/flows/lyrics/src/backend/canvas/canvas.routes.ts
@@ -1,130 +1,57 @@
 import { Elysia, t } from 'elysia';
-import crypto from 'crypto';
-import { 
-    tokenize, 
-    saveAnalysis, 
-    findAnalysisBySourceId,
-    createDatabase
-} from '@flows/core';
-import type { CanvasAnalysis, CanvasSource, MUSIC_LAYERS } from '@flows/shared';
-import { analyzeLyrics } from './music-analyzer';
+import type { LyricsRepository } from '../../domain/ports';
+import { SQLiteLyricsCanvasRepository } from './repository';
+import { LyricsCanvasService } from './service';
 
-// We need read access to the music.db to get track details and lyrics
-const musicDb = createDatabase('music.db');
+export function createCanvasRoutes(lyricsRepository: LyricsRepository) {
+  const service = new LyricsCanvasService(new SQLiteLyricsCanvasRepository(), lyricsRepository);
 
-function getTrackDetails(trackId: string) {
-    const row = musicDb.prepare(`
-        SELECT 
-            t.id, 
-            t.title, 
-            t.album_image_url as imageUrl,
-            GROUP_CONCAT(a.name, ', ') as artist,
-            l.plain_lyrics as plainLyrics
-        FROM tracks t
-        LEFT JOIN track_artists ta ON t.id = ta.track_id
-        LEFT JOIN artists a ON ta.artist_id = a.id
-        LEFT JOIN lyrics l ON t.id = l.track_id
-        WHERE t.id = ?
-        GROUP BY t.id
-    `).get(trackId) as any;
+  return new Elysia({ prefix: '/:trackId/canvas' })
+    .get(
+      '/',
+      async ({ params, set }) => {
+        const result = await service.load(params.trackId);
 
-    return row;
-}
-
-function hashText(text: string): string {
-    return crypto.createHash('sha256').update(text).digest('hex');
-}
-
-export const canvasRoutes = new Elysia({ prefix: '/:trackId/canvas' })
-    .get('/', async ({ params, set }) => {
-        const { trackId } = params;
-        
-        // 1. Check if we have a cached analysis in canvas.db
-        const cached = findAnalysisBySourceId(trackId);
-        
-        if (cached) {
-            return cached;
-        }
-
-        // 2. If not, check if the track even exists and has lyrics
-        const track = getTrackDetails(trackId);
-        
-        if (!track) {
+        switch (result.kind) {
+          case 'found':
+            return result.analysis;
+          case 'track_not_found':
             set.status = 404;
             return { error: 'Track not found' };
-        }
-
-        if (!track.plainLyrics) {
+          case 'lyrics_missing':
             set.status = 404;
             return { error: 'Lyrics not available for this track' };
+          case 'analysis_missing':
+            set.status = 404;
+            return {
+              error: 'Analysis not found',
+              needsAnalysis: true,
+              source: result.source,
+            };
+        }
+      },
+      {
+        params: t.Object({
+          trackId: t.String(),
+        }),
+      },
+    )
+    .post(
+      '/analyze',
+      async ({ params, set }) => {
+        const result = await service.analyze(params.trackId);
+
+        if (result.kind === 'source_unavailable') {
+          set.status = 400;
+          return { error: 'Track or lyrics not available' };
         }
 
-        // Return a standard 404 indicating analysis is needed, but the source is valid
-        set.status = 404;
-        return { 
-            error: 'Analysis not found', 
-            needsAnalysis: true,
-            source: {
-                sourceId: track.id,
-                sourceType: 'track',
-                title: track.title,
-                author: track.artist,
-                imageUrl: track.imageUrl
-            }
-        };
-    })
-    .post('/analyze', async ({ params, set, lyricsRepository }: any) => {
-        const { trackId } = params;
-        
-        const track = getTrackDetails(trackId);
-        
-        if (!track || !track.plainLyrics) {
-            set.status = 400;
-            return { error: 'Track or lyrics not available' };
-        }
-
-        // Fetch overarching interpretation if it exists
-        const interpretation = await lyricsRepository.getInterpretation(trackId);
-
-        // 1. Tokenize the text (Deterministic)
-        const tokenAst = tokenize(track.plainLyrics);
-        
-        // 2. Analyze with LLM
-        const analysisResult = await analyzeLyrics(tokenAst, track.title, track.artist, interpretation);
-        
-        // 3. Construct the CanvasAnalysis object
-        // We need the MUSIC_LAYERS from shared
-        // Since we can't easily import the runtime value here if it's type-only, 
-        // wait, MUSIC_LAYERS is exported as a value from shared.
-        
-        const now = new Date().toISOString();
-        const textHash = hashText(track.plainLyrics);
-        
-        // Lazy-load layers to avoid circular/value import issues if any
-        const layers = [
-            { id: 'chords', name: 'Chords', icon: '🎸', color: '#4ade80' },
-            { id: 'vocal', name: 'Vocal', icon: '🎤', color: '#f59e0b' },
-            { id: 'production', name: 'Production', icon: '🎛️', color: '#818cf8' },
-            { id: 'meaning', name: 'Meaning', icon: '💡', color: '#22d3ee' }
-        ];
-
-        const analysis: CanvasAnalysis = {
-            id: `ca_${crypto.randomUUID()}`,
-            sourceId: trackId,
-            sourceType: 'track',
-            sourceTextHash: textHash,
-            tokenAst,
-            annotations: analysisResult.annotations,
-            layers,
-            meta: analysisResult.meta,
-            modelUsed: 'gemini-2.5-pro', // we should ideally get this from the LLM client response, but hardcoding for now or we can get it later
-            providerUsed: 'gemini',
-            createdAt: now,
-            updatedAt: now,
-        };
-
-        // 4. Save to canvas.db
-        saveAnalysis(analysis);
-
-        return analysis;
-    });
+        return result.analysis;
+      },
+      {
+        params: t.Object({
+          trackId: t.String(),
+        }),
+      },
+    );
+}

--- a/packages/flows/lyrics/src/backend/canvas/repository.ts
+++ b/packages/flows/lyrics/src/backend/canvas/repository.ts
@@ -1,0 +1,57 @@
+import { musicDb } from '@flows/spotify';
+import type Database from 'better-sqlite3';
+
+export interface LyricsCanvasTrack {
+  id: string;
+  title: string;
+  artist: string;
+  imageUrl: string | null;
+  plainLyrics: string | null;
+}
+
+interface TrackDetailsRow {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  artist: string | null;
+  plainLyrics: string | null;
+}
+
+export interface LyricsCanvasRepository {
+  findTrackDetails(trackId: string): LyricsCanvasTrack | null;
+}
+
+export class SQLiteLyricsCanvasRepository implements LyricsCanvasRepository {
+  constructor(private readonly db: Database.Database = musicDb) {}
+
+  findTrackDetails(trackId: string): LyricsCanvasTrack | null {
+    const row = this.db
+      .prepare(
+        `
+        SELECT
+          t.id,
+          t.title,
+          t.album_image_url AS imageUrl,
+          GROUP_CONCAT(a.name, ', ') AS artist,
+          l.plain_lyrics AS plainLyrics
+        FROM tracks t
+        LEFT JOIN track_artists ta ON t.id = ta.track_id
+        LEFT JOIN artists a ON ta.artist_id = a.id
+        LEFT JOIN lyrics l ON t.id = l.track_id
+        WHERE t.id = ?
+        GROUP BY t.id
+      `,
+      )
+      .get(trackId) as TrackDetailsRow | undefined;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      title: row.title,
+      artist: row.artist ?? 'Unknown Artist',
+      imageUrl: row.imageUrl,
+      plainLyrics: row.plainLyrics,
+    };
+  }
+}

--- a/packages/flows/lyrics/src/backend/canvas/service.ts
+++ b/packages/flows/lyrics/src/backend/canvas/service.ts
@@ -1,0 +1,104 @@
+import crypto from 'crypto';
+import { findAnalysisBySourceId, saveAnalysis, tokenize } from '@flows/core';
+import { MUSIC_LAYERS, type CanvasAnalysis } from '@flows/shared';
+import type { LyricsRepository } from '../../domain/ports';
+import { analyzeLyrics } from './music-analyzer';
+import type { LyricsCanvasRepository, LyricsCanvasTrack } from './repository';
+
+const MEANING_LAYER = {
+  id: 'meaning',
+  name: 'Meaning',
+  icon: 'Insight',
+  color: '#22d3ee',
+};
+
+export interface LyricsCanvasSource {
+  sourceId: string;
+  sourceType: 'track';
+  title: string;
+  author: string;
+  imageUrl: string | null;
+}
+
+export type LyricsCanvasLoadResult =
+  | { kind: 'found'; analysis: CanvasAnalysis }
+  | { kind: 'track_not_found' }
+  | { kind: 'lyrics_missing' }
+  | { kind: 'analysis_missing'; source: LyricsCanvasSource };
+
+export type LyricsCanvasAnalyzeResult =
+  | { kind: 'created'; analysis: CanvasAnalysis }
+  | { kind: 'source_unavailable' };
+
+export class LyricsCanvasService {
+  constructor(
+    private readonly canvasRepository: LyricsCanvasRepository,
+    private readonly lyricsRepository: LyricsRepository,
+  ) {}
+
+  async load(trackId: string): Promise<LyricsCanvasLoadResult> {
+    const cached = findAnalysisBySourceId(trackId);
+    if (cached) {
+      return { kind: 'found', analysis: cached };
+    }
+
+    const track = this.canvasRepository.findTrackDetails(trackId);
+    if (!track) {
+      return { kind: 'track_not_found' };
+    }
+
+    if (!track.plainLyrics) {
+      return { kind: 'lyrics_missing' };
+    }
+
+    return {
+      kind: 'analysis_missing',
+      source: this.toCanvasSource(track),
+    };
+  }
+
+  async analyze(trackId: string): Promise<LyricsCanvasAnalyzeResult> {
+    const track = this.canvasRepository.findTrackDetails(trackId);
+    if (!track?.plainLyrics) {
+      return { kind: 'source_unavailable' };
+    }
+
+    const interpretation = await this.lyricsRepository.getInterpretation(trackId);
+    const tokenAst = tokenize(track.plainLyrics);
+    const analysisResult = await analyzeLyrics(tokenAst, track.title, track.artist, interpretation);
+    const now = new Date().toISOString();
+
+    const analysis: CanvasAnalysis = {
+      id: `ca_${crypto.randomUUID()}`,
+      sourceId: trackId,
+      sourceType: 'track',
+      sourceTextHash: hashText(track.plainLyrics),
+      tokenAst,
+      annotations: analysisResult.annotations,
+      layers: [...MUSIC_LAYERS, MEANING_LAYER],
+      meta: analysisResult.meta,
+      modelUsed: 'gemini-2.5-pro',
+      providerUsed: 'gemini',
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    saveAnalysis(analysis);
+
+    return { kind: 'created', analysis };
+  }
+
+  private toCanvasSource(track: LyricsCanvasTrack): LyricsCanvasSource {
+    return {
+      sourceId: track.id,
+      sourceType: 'track',
+      title: track.title,
+      author: track.artist,
+      imageUrl: track.imageUrl,
+    };
+  }
+}
+
+function hashText(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}

--- a/packages/flows/lyrics/src/backend/routes.ts
+++ b/packages/flows/lyrics/src/backend/routes.ts
@@ -4,7 +4,7 @@ import { SQLiteLyricsRepository } from './repository';
 import { SQLiteTrackRepository } from '@flows/spotify';
 import { logger, LLMClient } from '@flows/core';
 import type { LyricsStatus, TrackRepository } from '@flows/shared';
-import { canvasRoutes } from './canvas/canvas.routes';
+import { createCanvasRoutes } from './canvas/canvas.routes';
 import type { LyricsRepository, LyricsSource } from '../domain/ports';
 import { LyricsNotFoundError, LyricsFetchError } from '../domain/errors';
 
@@ -26,7 +26,7 @@ export function createLyricsRoutes() {
       .decorate('lyricsRepository', lyricsRepository)
       .decorate('trackRepository', trackRepository)
       .decorate('lrcLibAdapter', lrcLibAdapter)
-      .use(canvasRoutes)
+      .use(createCanvasRoutes(lyricsRepository))
 
       .get(
         '/:trackId',

--- a/packages/flows/lyrics/tests/backend/canvas/repository.test.ts
+++ b/packages/flows/lyrics/tests/backend/canvas/repository.test.ts
@@ -1,0 +1,72 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SQLiteLyricsCanvasRepository } from '../../../src/backend/canvas/repository';
+
+const db = new Database(':memory:');
+
+db.exec(`
+  CREATE TABLE tracks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    album_image_url TEXT
+  );
+
+  CREATE TABLE artists (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+  );
+
+  CREATE TABLE track_artists (
+    track_id TEXT NOT NULL,
+    artist_id TEXT NOT NULL,
+    PRIMARY KEY (track_id, artist_id)
+  );
+
+  CREATE TABLE lyrics (
+    track_id TEXT PRIMARY KEY,
+    plain_lyrics TEXT
+  );
+`);
+
+describe('SQLiteLyricsCanvasRepository', () => {
+  const repository = new SQLiteLyricsCanvasRepository(db);
+
+  beforeEach(() => {
+    db.exec('DELETE FROM lyrics; DELETE FROM track_artists; DELETE FROM artists; DELETE FROM tracks;');
+  });
+
+  it('returns null when the track is missing', () => {
+    expect(repository.findTrackDetails('missing')).toBeNull();
+  });
+
+  it('hydrates track metadata, artists, image and lyrics', () => {
+    db.prepare('INSERT INTO tracks (id, title, album_image_url) VALUES (?, ?, ?)').run(
+      'track-1',
+      'A Song',
+      'https://example.test/cover.jpg',
+    );
+    db.prepare('INSERT INTO artists (id, name) VALUES (?, ?)').run('artist-1', 'First Artist');
+    db.prepare('INSERT INTO artists (id, name) VALUES (?, ?)').run('artist-2', 'Second Artist');
+    db.prepare('INSERT INTO track_artists (track_id, artist_id) VALUES (?, ?)').run('track-1', 'artist-1');
+    db.prepare('INSERT INTO track_artists (track_id, artist_id) VALUES (?, ?)').run('track-1', 'artist-2');
+    db.prepare('INSERT INTO lyrics (track_id, plain_lyrics) VALUES (?, ?)').run('track-1', 'Line one');
+
+    expect(repository.findTrackDetails('track-1')).toEqual({
+      id: 'track-1',
+      title: 'A Song',
+      artist: 'First Artist, Second Artist',
+      imageUrl: 'https://example.test/cover.jpg',
+      plainLyrics: 'Line one',
+    });
+  });
+
+  it('uses a stable fallback when a track has no artists', () => {
+    db.prepare('INSERT INTO tracks (id, title) VALUES (?, ?)').run('track-1', 'Untitled');
+
+    expect(repository.findTrackDetails('track-1')).toMatchObject({
+      id: 'track-1',
+      artist: 'Unknown Artist',
+      plainLyrics: null,
+    });
+  });
+});

--- a/packages/flows/lyrics/tests/backend/canvas/service.test.ts
+++ b/packages/flows/lyrics/tests/backend/canvas/service.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasAnalysis, TokenAST } from '@flows/shared';
+import type { LyricsRepository } from '../../../src/domain/ports';
+import type { LyricsCanvasRepository, LyricsCanvasTrack } from '../../../src/backend/canvas/repository';
+
+const mocks = vi.hoisted(() => {
+  const tokenAst: TokenAST = {
+    totalTokens: 1,
+    sections: [
+      {
+        id: 's_001',
+        type: 'Verse',
+        lines: [[{ id: 't_001', text: 'hello' }]],
+      },
+    ],
+  };
+
+  return {
+    findAnalysisBySourceId: vi.fn(),
+    saveAnalysis: vi.fn(),
+    tokenize: vi.fn(() => tokenAst),
+    analyzeLyrics: vi.fn(),
+    tokenAst,
+  };
+});
+
+vi.mock('@flows/core', () => ({
+  findAnalysisBySourceId: mocks.findAnalysisBySourceId,
+  saveAnalysis: mocks.saveAnalysis,
+  tokenize: mocks.tokenize,
+}));
+
+vi.mock('../../../src/backend/canvas/music-analyzer', () => ({
+  analyzeLyrics: mocks.analyzeLyrics,
+}));
+
+const { LyricsCanvasService } = await import('../../../src/backend/canvas/service');
+
+function makeTrack(overrides: Partial<LyricsCanvasTrack> = {}): LyricsCanvasTrack {
+  return {
+    id: 'track-1',
+    title: 'A Song',
+    artist: 'An Artist',
+    imageUrl: null,
+    plainLyrics: 'hello',
+    ...overrides,
+  };
+}
+
+function makeCanvasRepository(track: LyricsCanvasTrack | null): LyricsCanvasRepository {
+  return {
+    findTrackDetails: vi.fn(() => track),
+  };
+}
+
+function makeLyricsRepository(): LyricsRepository {
+  return {
+    findByTrackId: vi.fn(async () => null),
+    save: vi.fn(async () => undefined),
+    markNotFound: vi.fn(async () => undefined),
+    getPendingTrackIds: vi.fn(async () => []),
+    getStats: vi.fn(async () => ({ total: 0, found: 0, notFound: 0, pending: 0 })),
+    getLibraryWithStatus: vi.fn(async () => []),
+    getInterpretation: vi.fn(async () => 'A cached interpretation'),
+    saveInterpretation: vi.fn(async () => undefined),
+  };
+}
+
+describe('LyricsCanvasService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findAnalysisBySourceId.mockReturnValue(null);
+    mocks.analyzeLyrics.mockResolvedValue({
+      annotations: [{ tokenId: 't_001', layerId: 'meaning', label: 'Theme', detail: 'Detail' }],
+      meta: { key: 'C', bpm: 90, mood: 'Calm' },
+    });
+  });
+
+  it('returns a cached analysis before touching the music database', async () => {
+    const cached = {
+      id: 'ca_1',
+      sourceId: 'track-1',
+      sourceType: 'track',
+      sourceTextHash: 'hash',
+      tokenAst: mocks.tokenAst,
+      annotations: [],
+      layers: [],
+      modelUsed: 'model',
+      providerUsed: 'provider',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } satisfies CanvasAnalysis;
+    mocks.findAnalysisBySourceId.mockReturnValue(cached);
+    const canvasRepository = makeCanvasRepository(makeTrack());
+
+    const service = new LyricsCanvasService(canvasRepository, makeLyricsRepository());
+
+    await expect(service.load('track-1')).resolves.toEqual({ kind: 'found', analysis: cached });
+    expect(canvasRepository.findTrackDetails).not.toHaveBeenCalled();
+  });
+
+  it('reports a valid source when lyrics exist but analysis is missing', async () => {
+    const service = new LyricsCanvasService(makeCanvasRepository(makeTrack({ imageUrl: 'cover.jpg' })), makeLyricsRepository());
+
+    await expect(service.load('track-1')).resolves.toEqual({
+      kind: 'analysis_missing',
+      source: {
+        sourceId: 'track-1',
+        sourceType: 'track',
+        title: 'A Song',
+        author: 'An Artist',
+        imageUrl: 'cover.jpg',
+      },
+    });
+  });
+
+  it('creates and saves an analysis from track lyrics', async () => {
+    const lyricsRepository = makeLyricsRepository();
+    const service = new LyricsCanvasService(makeCanvasRepository(makeTrack()), lyricsRepository);
+
+    const result = await service.analyze('track-1');
+
+    expect(result.kind).toBe('created');
+    if (result.kind !== 'created') {
+      throw new Error('Expected analysis creation');
+    }
+
+    expect(lyricsRepository.getInterpretation).toHaveBeenCalledWith('track-1');
+    expect(mocks.tokenize).toHaveBeenCalledWith('hello');
+    expect(mocks.analyzeLyrics).toHaveBeenCalledWith(
+      mocks.tokenAst,
+      'A Song',
+      'An Artist',
+      'A cached interpretation',
+    );
+    expect(result.analysis.layers.map((layer) => layer.id)).toContain('meaning');
+    expect(mocks.saveAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'track-1',
+        sourceType: 'track',
+        sourceTextHash: expect.any(String),
+        tokenAst: mocks.tokenAst,
+      }),
+    );
+  });
+
+  it('does not analyze missing lyrics', async () => {
+    const service = new LyricsCanvasService(makeCanvasRepository(makeTrack({ plainLyrics: null })), makeLyricsRepository());
+
+    await expect(service.analyze('track-1')).resolves.toEqual({ kind: 'source_unavailable' });
+    expect(mocks.analyzeLyrics).not.toHaveBeenCalled();
+    expect(mocks.saveAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/packages/flows/trading/src/backend/services/synthesizer.service.ts
+++ b/packages/flows/trading/src/backend/services/synthesizer.service.ts
@@ -30,7 +30,7 @@ export class SynthesizerService {
    * Enrich raw market state with derived metrics for the LLM.
    * Exposed public for debugging if needed.
    */
-  public enrichMarketState(state: MarketState): Record<string, any> {
+  public enrichMarketState(state: MarketState): Record<string, unknown> {
     const currentPrice = state.price.current;
 
     // Calculate distances to levels

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,8 @@
     "scripts": {
         "build": "tsc",
         "dev": "tsc --watch",
-        "test": "echo 'No tests'"
+        "test": "echo 'No tests'",
+        "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
         "typescript": "^5.6.3"

--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -1,6 +1,8 @@
 # Frontend Configuration
 # No environment variables required for local development
-# The UI connects to the backend at http://localhost:4173
+# By default, API calls use same-origin /api paths:
+# - Vite proxies /api to the backend in dev
+# - The backend serves the built UI in production
 
-# If deploying to production, you might need:
+# Optional override for a separately hosted backend:
 # VITE_API_URL=https://your-backend-url.com

--- a/packages/ui/src/lib/client.ts
+++ b/packages/ui/src/lib/client.ts
@@ -1,9 +1,22 @@
 import { treaty } from '@elysiajs/eden';
 import type { App } from '@flows/backend/src/api/app';
 
-// Type-safe API client using Eden
-// This provides autocompletion and type checking for all API calls
-export const api = treaty<App>('localhost:4173');
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+const apiBaseUrl = normalizeBaseUrl(import.meta.env.VITE_API_URL ?? '');
+
+// Type-safe API client using Eden. The default empty base resolves to same-origin:
+// Vite proxies /api in dev, and the backend serves the built UI in production.
+export function createApiClient(customFetch?: typeof fetch) {
+  return treaty<App>(apiBaseUrl, {
+    keepDomain: true,
+    fetcher: customFetch,
+  });
+}
+
+export const api = createApiClient();
 
 // Re-export types from the client for convenience
 export type { App };

--- a/packages/ui/src/lib/flows/canvas/api.test.ts
+++ b/packages/ui/src/lib/flows/canvas/api.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CanvasAnalysis } from '@flows/shared';
 import { fetchCanvasList, fetchCanvas, deleteCanvas, createAndAnalyzeCanvas } from './api';
 
-const API_BASE = 'http://localhost:4173/api/canvas';
+const API_BASE = '/api/canvas';
 
 function makeCanvas(overrides: Partial<CanvasAnalysis> = {}): CanvasAnalysis {
   return {

--- a/packages/ui/src/lib/flows/canvas/api.ts
+++ b/packages/ui/src/lib/flows/canvas/api.ts
@@ -1,6 +1,6 @@
 import type { CanvasAnalysis } from '@flows/shared';
 
-const API_BASE = 'http://localhost:4173/api/canvas';
+const API_BASE = '/api/canvas';
 
 export async function fetchCanvasList(): Promise<CanvasAnalysis[]> {
   const res = await fetch(API_BASE);

--- a/packages/ui/src/lib/flows/trading/components/CandleChart.svelte
+++ b/packages/ui/src/lib/flows/trading/components/CandleChart.svelte
@@ -1,15 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import {
-    createChart,
-    CandlestickSeries,
-    LineSeries,
-    type IChartApi,
-    type ISeriesApi,
-    type Time,
-    type CandlestickData,
-    type LineData,
-  } from 'lightweight-charts';
+  import type { IChartApi, ISeriesApi, Time, CandlestickData, LineData } from 'lightweight-charts';
   import type { Candle } from '../trading';
 
   interface Props {
@@ -26,6 +17,7 @@
   let candlestickSeries: ISeriesApi<'Candlestick'> | null = null;
   let supportLine: ISeriesApi<'Line'> | null = null;
   let resistanceLine: ISeriesApi<'Line'> | null = null;
+  let lineSeriesDefinition: typeof import('lightweight-charts').LineSeries | null = null;
 
   // Transform candles to lightweight-charts format (time in seconds)
   function transformCandles(data: Candle[]): CandlestickData<Time>[] {
@@ -47,68 +39,122 @@
     ];
   }
 
+  function updateSupportLine() {
+    if (!chart || !lineSeriesDefinition) return;
+
+    if (supportLevel && candles.length > 0) {
+      if (!supportLine) {
+        supportLine = chart.addSeries(lineSeriesDefinition, {
+          color: '#22c55e',
+          lineWidth: 2,
+          lineStyle: 2, // Dashed
+        });
+      }
+      supportLine.setData(generateLineData(supportLevel, candles));
+    } else if (supportLine) {
+      chart.removeSeries(supportLine);
+      supportLine = null;
+    }
+  }
+
+  function updateResistanceLine() {
+    if (!chart || !lineSeriesDefinition) return;
+
+    if (resistanceLevel && candles.length > 0) {
+      if (!resistanceLine) {
+        resistanceLine = chart.addSeries(lineSeriesDefinition, {
+          color: '#ef4444',
+          lineWidth: 2,
+          lineStyle: 2, // Dashed
+        });
+      }
+      resistanceLine.setData(generateLineData(resistanceLevel, candles));
+    } else if (resistanceLine) {
+      chart.removeSeries(resistanceLine);
+      resistanceLine = null;
+    }
+  }
+
   onMount(() => {
     if (!chartContainer) return;
 
-    // Create chart with v5 API
-    chart = createChart(chartContainer, {
-      width: chartContainer.clientWidth,
-      height: height,
-      layout: {
-        background: { color: 'transparent' },
-        textColor: 'rgba(255, 255, 255, 0.7)',
-      },
-      grid: {
-        vertLines: { color: 'rgba(255, 255, 255, 0.05)' },
-        horzLines: { color: 'rgba(255, 255, 255, 0.05)' },
-      },
-      rightPriceScale: {
-        borderColor: 'rgba(255, 255, 255, 0.1)',
-      },
-      timeScale: {
-        borderColor: 'rgba(255, 255, 255, 0.1)',
-        timeVisible: true,
-        secondsVisible: false,
-      },
-      localization: {
-        timeFormatter: (time: number) => {
-          const date = new Date(time * 1000);
-          return date.toLocaleString(undefined, {
-            month: 'short',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-          });
+    let disposed = false;
+    let resizeObserver: ResizeObserver | null = null;
+
+    async function initChart() {
+      const { createChart, CandlestickSeries, LineSeries } = await import('lightweight-charts');
+      if (disposed || !chartContainer) return;
+
+      lineSeriesDefinition = LineSeries;
+
+      // Create chart with v5 API
+      chart = createChart(chartContainer, {
+        width: chartContainer.clientWidth,
+        height: height,
+        layout: {
+          background: { color: 'transparent' },
+          textColor: 'rgba(255, 255, 255, 0.7)',
         },
-      },
-    });
+        grid: {
+          vertLines: { color: 'rgba(255, 255, 255, 0.05)' },
+          horzLines: { color: 'rgba(255, 255, 255, 0.05)' },
+        },
+        rightPriceScale: {
+          borderColor: 'rgba(255, 255, 255, 0.1)',
+        },
+        timeScale: {
+          borderColor: 'rgba(255, 255, 255, 0.1)',
+          timeVisible: true,
+          secondsVisible: false,
+        },
+        localization: {
+          timeFormatter: (time: number) => {
+            const date = new Date(time * 1000);
+            return date.toLocaleString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            });
+          },
+        },
+      });
 
-    // Add candlestick series using v5 API
-    candlestickSeries = chart.addSeries(CandlestickSeries, {
-      upColor: '#22c55e',
-      downColor: '#ef4444',
-      borderUpColor: '#22c55e',
-      borderDownColor: '#ef4444',
-      wickUpColor: '#22c55e',
-      wickDownColor: '#ef4444',
-    });
+      // Add candlestick series using v5 API
+      candlestickSeries = chart.addSeries(CandlestickSeries, {
+        upColor: '#22c55e',
+        downColor: '#ef4444',
+        borderUpColor: '#22c55e',
+        borderDownColor: '#ef4444',
+        wickUpColor: '#22c55e',
+        wickDownColor: '#ef4444',
+      });
 
-    // Set initial data
-    if (candles.length > 0) {
-      candlestickSeries.setData(transformCandles(candles));
-      chart.timeScale().fitContent();
+      // Set initial data
+      if (candles.length > 0) {
+        candlestickSeries.setData(transformCandles(candles));
+        chart.timeScale().fitContent();
+      }
+
+      updateSupportLine();
+      updateResistanceLine();
+
+      // Handle resize
+      resizeObserver = new ResizeObserver((entries) => {
+        if (chart && entries[0]) {
+          chart.applyOptions({ width: entries[0].contentRect.width });
+        }
+      });
+      resizeObserver.observe(chartContainer);
     }
 
-    // Handle resize
-    const resizeObserver = new ResizeObserver((entries) => {
-      if (chart && entries[0]) {
-        chart.applyOptions({ width: entries[0].contentRect.width });
-      }
-    });
-    resizeObserver.observe(chartContainer);
+    void initChart();
 
     return () => {
-      resizeObserver.disconnect();
+      disposed = true;
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
     };
   });
 
@@ -117,6 +163,10 @@
       chart.remove();
       chart = null;
     }
+    candlestickSeries = null;
+    supportLine = null;
+    resistanceLine = null;
+    lineSeriesDefinition = null;
   });
 
   // Update data when candles change
@@ -129,40 +179,12 @@
 
   // Update support line
   $effect(() => {
-    if (!chart) return;
-
-    if (supportLevel && candles.length > 0) {
-      if (!supportLine) {
-        supportLine = chart.addSeries(LineSeries, {
-          color: '#22c55e',
-          lineWidth: 2,
-          lineStyle: 2, // Dashed
-        });
-      }
-      supportLine.setData(generateLineData(supportLevel, candles));
-    } else if (supportLine) {
-      chart.removeSeries(supportLine);
-      supportLine = null;
-    }
+    updateSupportLine();
   });
 
   // Update resistance line
   $effect(() => {
-    if (!chart) return;
-
-    if (resistanceLevel && candles.length > 0) {
-      if (!resistanceLine) {
-        resistanceLine = chart.addSeries(LineSeries, {
-          color: '#ef4444',
-          lineWidth: 2,
-          lineStyle: 2, // Dashed
-        });
-      }
-      resistanceLine.setData(generateLineData(resistanceLevel, candles));
-    } else if (resistanceLine) {
-      chart.removeSeries(resistanceLine);
-      resistanceLine = null;
-    }
+    updateResistanceLine();
   });
 </script>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.48.1
         version: 8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.6.1)
@@ -96,6 +99,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@22.19.1)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@7.2.6(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.4))
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## What & why

This PR applies the housekeeping/refactor pass requested for `flow-sample` and brings over the lightweight PR delivery workflow from `ccec`, adapted to this repo's single permanent branch (`main`).

## User-visible impact

- The app now defaults to same-origin API calls, so local/prod routing is less brittle.
- The backend can be imported safely by tests and the typed UI client without starting a server.
- Lyrics Canvas behavior is easier to maintain and test because SQL and orchestration are no longer inside route handlers.
- Future tasks should follow branch -> PR -> checks -> merge instead of direct pushes to `main`.

## Changes

- Split backend app construction from process startup with `createApp(config)` and `server.ts`.
- Added backend Vitest config and a health-route smoke test.
- Expanded backend-managed lint coverage to backend/core/shared/flows and enforced `no-explicit-any`.
- Extracted Lyrics Canvas SQL into `SQLiteLyricsCanvasRepository` and analysis orchestration into `LyricsCanvasService`.
- Added Lyrics Canvas repository/service tests.
- Removed hardcoded UI localhost API defaults and aligned Canvas REST calls to same-origin paths.
- Fixed backend static UI serving to SvelteKit's `packages/ui/build` output.
- Updated docs, roadmap, architecture notes, AGENTS workflow, conventions, and PR templates.
- Moved trading chart's `lightweight-charts` value imports to browser-only dynamic import for clean SSR builds.

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `git diff --check`

Refs: housekeeping / architecture audit requested in Codex thread.
