### PR TITLE
docs: map architecture and issue follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Copy `.env.example` to `.env` and fill in the required values:
 
 - [Conventions & Best Practices](docs/conventions.md) — the engineering rules (start here)
 - [AGENTS.md](AGENTS.md) / [CLAUDE.md](CLAUDE.md) — entry point for AI agents
+- [System Map](docs/architecture/system-map.md) — package boundaries, flow contract, refactor lanes
 - [Backend Architecture](docs/architecture/backend.md) — bounded-context flows, layers, LLM
 - [UI Architecture](docs/architecture/ui.md) — SvelteKit, flows registry, Eden client
 - [Architecture Roadmap](docs/refactor-proposals/future-architecture.md)
@@ -104,8 +105,9 @@ Copy `.env.example` to `.env` and fill in the required values:
 
 ## Quality gate
 
-Personal project, minimal ceremony: everything goes to `main`, no `develop`/PRs.
-Run the full local gate before pushing anything non-trivial:
+Personal project, minimal ceremony: short-lived branches open PRs directly to
+`main`; there is no `develop` branch. Run the full local gate before pushing
+anything non-trivial:
 
 ```bash
 pnpm verify   # lint && typecheck && check && test

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,8 @@
 
 The source of truth for where this project is going — high-level vision and the low-level
 work that gets us there. Actionable items are mirrored as GitHub issues; this doc holds the
-**why** and the shape. Personal project: no deploy/CD, minimal ceremony, everything to `main`.
+**why** and the shape. Personal project: no deploy/CD, minimal ceremony, short-lived PRs to
+`main`.
 
 > Related: [#18 B2 — Board/Canvas Vision](https://github.com/jorgesalica/flow-sample/issues/18) ·
 > [#19 B1 — Ordering pass](https://github.com/jorgesalica/flow-sample/issues/19)
@@ -36,7 +37,24 @@ Mostly done across the recent modernization (Fases 0–3):
 - [x] **3b** — data via `+page.ts` loaders
 - [x] **3c** — runes-only state, drop remaining `svelte/store`
 - [x] GitHub: light CI (gate on push/PR) + PR/issue templates
-- [ ] Refactor audit pass: architecture, frontend data access, backend layering, testing, and stale docs
+- [x] Refactor audit pass: architecture, frontend data access, backend layering, testing, and stale docs
+
+---
+
+## Near-term execution queue
+
+1. **Close/split stale issues**: #31 is done; #19 should be closed after its
+   remaining work is split into sharper follow-ups.
+2. **Package boundary map**: keep `packages/flows/*` as independently testable
+   bounded modules, not separate deployable apps yet. See
+   [system-map.md](architecture/system-map.md).
+3. **UI design system (#24)**: add shared primitives and theme tokens, then
+   migrate Chat/Canvas first.
+4. **Trading polish (#26)**: replace raw logs, extract StepWizard constants and
+   formatting, type market-state view models, and refresh Trading docs.
+5. **Data/config/testing follow-ups**: align loaders/invalidation (#34),
+   normalize env ownership (#33), and add contract checks (#35) before growing
+   the Board/Canvas epic.
 
 ---
 
@@ -97,5 +115,6 @@ obvious). This epic makes the LLM output genuinely useful.
 
 - Conventions: [docs/conventions.md](conventions.md). Architecture:
   [backend](architecture/backend.md) · [ui](architecture/ui.md).
-- Branch directly on `main`; run `pnpm verify` before pushing; commit each coherent step.
+- Work on a short-lived branch, open a PR to `main`, wait for checks, then merge
+  through GitHub. Run `pnpm verify` before pushing non-trivial changes.
 - This roadmap is living — reorder, split into issues, and check things off as we go.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,67 +1,24 @@
-# System Architecture
+# Architecture
 
-This document provides a high-level overview of the Flow Sample architecture.
+Start here when changing package boundaries, backend layering, frontend data
+access, or the flow model.
 
-## Overview
+## Current Maps
 
-```mermaid
-graph TD
-    User["User"] --> UI["UI (Svelte)"]
-    User --> CLI["CLI"]
-    
-    UI --> API["API (Elysia)"]
-    API --> UseCase["Application Layer"]
-    CLI --> UseCase
-    
-    UseCase --> Domain["Domain Layer"]
-    UseCase --> Infra["Infrastructure Layer"]
-    
-    Infra --> SQLite["SQLite"]
-    Infra --> SpotifyAPI["Spotify API"]
-```
+- [System Map and Refactor Boundaries](./system-map.md) - workspace map,
+  package responsibilities, flow extraction contract, and refactor lanes.
+- [Backend Architecture](./backend.md) - Elysia host, bounded-context flow
+  packages, repositories, services, adapters, and LLM core.
+- [UI Architecture](./ui.md) - SvelteKit routes, flow registry, Eden client,
+  frontend flow modules, and testing.
+- [Server Architecture](./server.md) - backend runtime details.
 
-## Layered Architecture (per Flow)
+## Working Rule
 
-Each independent flow package (`packages/flows/*`) follows a layered architecture pattern:
+The package split is intentional: `packages/backend` hosts the app,
+`packages/ui` renders it, `packages/core` owns shared infrastructure,
+`packages/shared` owns cross-boundary contracts, and `packages/flows/*` own
+backend bounded contexts.
 
-| Layer | Location | Responsibility |
-| ----- | -------- | -------------- |
-| **API** | `src/api/` | HTTP routes (Elysia), validation |
-| **Domain** | `src/domain/` | Pure business logic, equations, entities |
-| **Infrastructure** | `src/infrastructure/` | External API clients, repositories |
-
-## Tech Stack
-
-| Component | Technology |
-| --------- | ---------- |
-| **UI** | Svelte 5, Vite 7, Tailwind CSS 4, Chart.js |
-| **Server** | Elysia (Node.js adapter) |
-| **Database** | SQLite (better-sqlite3) |
-| **Validation** | Zod, TypeBox |
-| **Logging** | Pino |
-
-## Directory Structure
-
-```text
-flow-sample/
-├── packages/
-│   ├── core/                           # Shared infrastructure (DB connection, Logger, LLM integration)
-│   ├── backend/                        # API server host (Elysia app init)
-│   ├── flows/                          # Independent bounded contexts
-│   │   ├── shared/                     # Shared types and DTOs
-│   │   ├── chat/                       # Chat Flow (Dynamic LLM provider integration)
-│   │   ├── spotify/                    # Spotify Flow (API + DB + Domain)
-│   │   ├── lyrics/                     # Lyrics Flow (API + DB + Domain)
-│   │   └── trading/                    # Trading Flow (API + SSE + Domain)
-│   └── ui/                             # Frontend application (Svelte 5)
-├── data/                               # SQLite database volume
-├── outputs/                            # Generated data
-└── docs/
-    └── architecture/                   # This documentation
-```
-
-## Detailed Documentation
-
-- [UI Architecture](./ui.md)
-- [Server Architecture](./server.md)
-- [Backend Architecture](./backend.md)
+Keep the separation, but do not treat each flow as a separately deployable app
+until its contracts are explicit and tested.

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -1,5 +1,8 @@
 # Backend Architecture
 
+For the cross-package map and refactor lanes, see
+[System Map and Refactor Boundaries](./system-map.md).
+
 ## Overview
 
 The backend has been refactored from a monolithic layered architecture into isolated **Bounded Contexts (Flows)**. Each flow is distributed as its own workspace package under `packages/flows/*`.

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -1,0 +1,197 @@
+# System Map and Refactor Boundaries
+
+Status: 2026-07-09.
+
+This document is the working map for future cleanup. It describes the current
+package/component boundaries, which boundaries are worth keeping, and which
+refactor lanes should be tackled next.
+
+Reference baseline: the `ccec` repo has stronger governance and production
+discipline than this personal playground. The parts that transfer well are:
+
+- issue-backed execution order
+- short-lived branches and PRs into the permanent branch
+- typed Eden data access through SvelteKit loaders
+- UI primitives instead of repeated ad hoc states
+- tests that validate behavior and contracts, not implementation details
+
+The parts that should stay lighter here are deployment, auth, database
+migrations, and environment topology.
+
+## Runtime Map
+
+```mermaid
+flowchart LR
+    user["User"] --> ui["packages/ui\nSvelteKit app"]
+    ui --> routes["SvelteKit routes\n+page.ts / +page.svelte"]
+    routes --> eden["Eden Treaty client\nlib/client.ts"]
+    eden --> host["packages/backend\nElysia app host"]
+    host --> mounted["Mounted flow route factories"]
+
+    mounted --> spotify["@flows/spotify"]
+    mounted --> lyrics["@flows/lyrics"]
+    mounted --> trading["@flows/trading"]
+    mounted --> chat["@flows/chat"]
+    mounted --> canvas["@flows/canvas"]
+
+    spotify --> core["@flows/core"]
+    lyrics --> core
+    trading --> core
+    chat --> core
+    canvas --> core
+
+    spotify --> shared["@flows/shared"]
+    lyrics --> shared
+    trading --> shared
+    chat --> shared
+    canvas --> shared
+    ui --> shared
+
+    spotify --> sqlite[("SQLite")]
+    lyrics --> sqlite
+    trading --> sqlite
+    chat --> sqlite
+
+    spotify --> spotifyApi["Spotify API"]
+    lyrics --> lrcLib["LrcLib API"]
+    trading --> binance["Binance"]
+    chat --> llm["LLM providers"]
+    canvas --> llm
+```
+
+## Workspace Responsibilities
+
+| Workspace | Role | Should Own | Should Not Own |
+| --- | --- | --- | --- |
+| `packages/backend` | Application host | app config, CORS/static setup, route mounting, process startup split | business rules, SQL, provider SDK calls |
+| `packages/ui` | Browser app | routes, loaders, flow surfaces, registry, UI state, design primitives | backend domain internals, raw API URLs, persistent server state |
+| `packages/core` | Shared infrastructure | logger, cache, database factory, LLM client/providers | flow-specific business rules, DTOs, route handlers |
+| `packages/shared` | Cross-boundary contract | DTOs, constants, public unions crossing UI/server | implementation details, persistence rows, SDK types |
+| `packages/flows/*` | Backend bounded contexts | domain, ports, adapters, repositories, services, Elysia route factory | global app startup, unrelated flow logic, UI components |
+
+## Opinion on Flow Packages
+
+Keeping each backend flow as its own workspace package is the right direction
+for this repo, but the goal should be "independently testable bounded modules",
+not "five deployable apps" yet.
+
+The separation pays for itself when a flow has at least one of these:
+
+- external adapter concerns, such as Spotify, LrcLib, Binance, or LLM providers
+- persistence, migrations, or repository tests
+- domain logic that can be tested without Elysia
+- package-specific dependencies that should not leak into every other flow
+- a plausible future where the flow is extracted or disabled
+
+The separation becomes counterproductive when a package is only a thin route
+wrapper with no domain, no tests, and no dependency differences. New flows
+should start small, but once they persist data or call an external service they
+should follow the package pattern.
+
+### Flow Extraction Contract
+
+A flow is "extractable enough" when these are true:
+
+- It exports a route factory from `src/index.ts`.
+- Its public client/server DTOs live in `@flows/shared`.
+- It does not import sibling flow internals.
+- External APIs live behind adapters implementing domain ports.
+- SQL is isolated to `repository.ts` or clearly named repository files.
+- Runtime config is passed into factories or named env factories.
+- It has focused package tests for domain, repositories, services, and routes
+  where relevant.
+- Its README documents route prefixes, env vars, external services, and test
+  commands.
+
+Current known exception: shared music database ownership still leaks through
+the Spotify/Lyrics boundary. That should become neutral ownership before the
+Board/Canvas work grows.
+
+## Frontend Component Map
+
+```mermaid
+flowchart TD
+    shell["App shell\n+layout.svelte"] --> home["Home board\npages/Landing.svelte"]
+    shell --> flowRoutes["Flow routes\nroutes/<flow>/+page.svelte"]
+    flowRoutes --> loaders["+page.ts loaders"]
+    loaders --> apiClient["Typed API client\nlib/client.ts"]
+    flowRoutes --> flowUi["Flow UI modules\nlib/flows/<flow>"]
+    flowUi --> flowState["Flow state\n*.svelte.ts"]
+    flowUi --> flowApi["Flow API facade\napi.ts"]
+    flowUi --> flowComponents["Flow components\ncomponents/*"]
+    flowUi --> sharedUi["Shared UI primitives\nlib/components/ui (target)"]
+    home --> registry["Flow registry\nlib/flows/registry.ts"]
+```
+
+Target shape:
+
+- Route files stay thin: load data, pass props, render the flow surface.
+- Flow surfaces own page-level composition.
+- Components own visual fragments and ephemeral UI state.
+- `*.svelte.ts` modules own reusable flow state only when there is a documented
+  reason not to keep state local.
+- Server data comes from loaders and Eden, then mutations call Eden and
+  invalidate the relevant loader key.
+- Raw `fetch` is limited to cases Eden does not model cleanly, such as SSE.
+
+## Backend Component Map
+
+```mermaid
+flowchart TD
+    server["server.ts\nprocess startup"] --> config["config.ts\nenv parsing"]
+    config --> app["app.ts\ncreateApp(config)"]
+    app --> routes["flow route factories"]
+    routes --> service["services / use cases"]
+    routes --> repo["repositories"]
+    service --> repo
+    service --> ports["domain ports"]
+    ports --> adapters["adapters / providers"]
+    repo --> db["better-sqlite3"]
+    service --> domain["domain logic"]
+    routes --> errors["HTTP error mapping"]
+```
+
+Target shape:
+
+- `server.ts` is the only file that starts listening.
+- `app.ts` is import-safe and testable with `app.handle(...)`.
+- Route handlers validate, map HTTP to domain, and call services or
+  repositories.
+- Services orchestrate use cases but do not own SQL or HTTP response details.
+- Repositories own SQL and row hydration.
+- Domain code is pure TypeScript.
+
+## Refactor Lanes
+
+1. **Issue cleanup and governance**
+   Close resolved issues, split stale umbrella issues, and keep roadmap/workflow
+   docs aligned with the PR process.
+
+2. **Package boundary hardening**
+   Define the flow extraction contract in docs, remove sibling-flow leaks, and
+   move shared database ownership to neutral infrastructure.
+
+3. **UI design system (#24)**
+   Add shared primitives first (`Button`, `IconButton`, `Field`, `Badge`,
+   `AsyncState`, `ModalShell`), then migrate one flow at a time.
+
+4. **UI data-access alignment (#34)**
+   Move server data into loaders where practical, centralize invalidation keys,
+   and keep raw `fetch` only for SSE or browser-only exceptions.
+
+5. **Trading polish (#26)**
+   Replace raw logs, extract wizard constants/formatting, type market-state view
+   models, and document Trading routes/API.
+
+6. **Config and env ownership (#33)**
+   Keep env reads in composition roots or explicitly named env factories. Pass
+   config into routes/services when behavior changes by environment.
+
+7. **Testing and contract checks (#35)**
+   Consider a root Vitest workspace plus contract checks for no production
+   `any`, no raw SQL outside repositories, and no hardcoded API origins.
+
+8. **Board/Canvas vision (#18)**
+   Start only after the base UI/data contracts are clearer. First slice should
+   render the existing `FlowDefinition` registry as board items before adding
+   persistence or cross-flow relationships.

--- a/docs/architecture/ui.md
+++ b/docs/architecture/ui.md
@@ -1,5 +1,8 @@
 # UI Architecture
 
+For the cross-package map and refactor lanes, see
+[System Map and Refactor Boundaries](./system-map.md).
+
 The frontend is a **SvelteKit** app (Svelte 5 runes) that talks to the Elysia backend
 through a typed **Eden Treaty** client. It is organized as a set of vertical **flows**
 (spotify, lyrics, trading, chat, canvas) hung on a central board.

--- a/docs/refactor-proposals/architecture-audit-2026-07-09.md
+++ b/docs/refactor-proposals/architecture-audit-2026-07-09.md
@@ -135,12 +135,16 @@ Next step:
 
 ## Suggested execution order
 
-1. Tooling enforcement: lint every flow, then fix surfaced `any` in production.
-2. Backend app factory split, unlocking route tests.
-3. Lyrics canvas repository/service extraction.
-4. UI data-access pass: Eden client factory usage in loaders and Canvas API.
-5. Design-system primitives, then apply them to Chat/Canvas.
-6. Trading polish/refactor.
+Updated after PR #32:
+
+1. Close #31 and split/close #19 so the issue tracker matches the current code.
+2. UI data-access pass (#34): loaders, invalidation constants, and Eden-first Canvas
+   CRUD where practical.
+3. Design-system primitives (#24), then apply them to Chat/Canvas.
+4. Trading polish/refactor (#26).
+5. Config/env ownership pass (#33) for LLM and Trading factories.
+6. Testing gate cleanup (#35): root contract checks and an explicit decision on
+   Playwright in CI.
 
 This order keeps behavior stable while making the next change easier than the
 previous one.


### PR DESCRIPTION
## Summary

- add a current system map for workspace/package boundaries, frontend/backend component maps, and refactor lanes
- align README, roadmap, architecture index, and audit docs with the PR-to-main workflow
- document the flow-package separation rule: bounded modules now, not separately deployable apps yet

## Issue triage

- Closed #31 as completed after PR #32
- Closed #19 as completed/split
- Created #33 for env/config ownership
- Created #34 for UI data-access alignment
- Created #35 for architecture contract checks
- Added first-slice execution comments to #24 and #26

## Validation

- `pnpm verify`
- `git diff --check`
- pre-push hook also ran `pnpm check` and `pnpm test`

Refs #24 #26 #33 #34 #35