### PR TITLE
refactor: make runtime config explicit

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -173,7 +173,7 @@ branch: **PRs target `main`**. There is no `develop` branch here.
 `pnpm check:architecture` enforces the rules that can be detected reliably without a
 heavy static-analysis framework. It checks production sources for explicit `any`,
 hardcoded localhost origins in UI API modules, SQL calls outside persistence modules,
-and direct imports between sibling flow packages. The command is part of `pnpm verify`,
+environment reads outside named config factories, and direct imports between sibling flow packages. The command is part of `pnpm verify`,
 and its own behavior is covered by `pnpm test:architecture`.
 
 The only sibling-flow exception is the current Lyrics -> Spotify dependency in the Lyrics

--- a/packages/backend/src/api/app.ts
+++ b/packages/backend/src/api/app.ts
@@ -12,7 +12,7 @@ import { staticPlugin } from '@elysiajs/static';
 import * as fs from 'fs';
 import { createSpotifyRoutes } from '@flows/spotify';
 import { createLyricsRoutes } from '@flows/lyrics';
-import { createTradingRoutes } from '@flows/trading';
+import { createTradingConfigFromEnv, createTradingRoutes } from '@flows/trading';
 import { chatRoutes } from '@flows/chat';
 import { canvasFlowRoutes } from '@flows/canvas';
 import { logger } from '@flows/core';
@@ -63,7 +63,7 @@ export function createApp(config: BackendConfig) {
     // Flow routes (from flow packages)
     .use(createSpotifyRoutes(config))
     .use(createLyricsRoutes())
-    .use(createTradingRoutes())
+    .use(createTradingRoutes(createTradingConfigFromEnv()))
     .use(chatRoutes)
     .use(canvasFlowRoutes)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,10 +37,10 @@ Each model in the catalog has a `tier` and `pricing`:
 ### Usage
 
 ```typescript
-import { createLLMClient } from '@flows/core';
+import { createLLMClientFromEnv } from '@flows/core';
 
-// Uses LLM_PROVIDER env var (default: gemini)
-const client = createLLMClient();
+// The named composition factory reads LLM_PROVIDER, LLM_MODEL, and provider API keys.
+const client = createLLMClientFromEnv();
 const response = await client.generate({
     messages: [{ role: 'user', content: 'Hello!' }],
 });
@@ -54,14 +54,17 @@ console.log(response.model);     // "gemini-2.5-flash"
 ```typescript
 import { LLMClient } from '@flows/core';
 
-const client = new LLMClient('groq');
+const client = new LLMClient('groq', groqApiKey, 'llama-3.3-70b-versatile');
 ```
 
 **Rotation mode** — round-robin across free providers (auto-fallback on 429):
 
 ```typescript
-const client = LLMClient.createRotation();
-// Or via env: LLM_PROVIDER=rotation
+const client = createLLMClientFromEnv({
+    LLM_PROVIDER: 'rotation',
+    GROQ_API_KEY: groqApiKey,
+    OPENROUTER_API_KEY: openRouterApiKey,
+});
 ```
 
 ### File Structure

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,15 @@ export { logger } from './logger';
 export { SimpleCache } from './cache';
 
 // LLM — Client
-export { LLMClient, createLLMClient, type LLMProviderType } from './llm';
+export {
+  LLMClient,
+  createLLMClient,
+  createLLMClientFromEnv,
+  createLLMConfigFromEnv,
+  type LLMEnv,
+  type LLMProviderType,
+  type LLMRuntimeConfig,
+} from './llm';
 
 // LLM — Types
 export type {

--- a/packages/core/src/llm/client.ts
+++ b/packages/core/src/llm/client.ts
@@ -7,19 +7,12 @@ import { GroqProvider } from './providers/groq/groq-provider';
 import { OpenRouterProvider } from './providers/openrouter/openrouter-provider';
 import { CerebrasProvider } from './providers/cerebras/cerebras-provider';
 import { MistralProvider } from './providers/mistral/mistral-provider';
+import { createLLMConfigFromEnv, getProviderEnvVar, type LLMRuntimeConfig } from './env';
 
 export type LLMProviderType = 'gemini' | 'groq' | 'openrouter' | 'cerebras' | 'mistral';
 
 // ── Free provider rotation order ─────────────────────────────────────
 const FREE_ROTATION_ORDER: LLMProviderType[] = ['groq', 'openrouter', 'cerebras', 'mistral'];
-
-const PROVIDER_ENV_VARS: Record<LLMProviderType, string> = {
-    gemini: 'GEMINI_API_KEY',
-    groq: 'GROQ_API_KEY',
-    openrouter: 'OPENROUTER_API_KEY',
-    cerebras: 'CEREBRAS_API_KEY',
-    mistral: 'MISTRAL_API_KEY',
-};
 
 /**
  * LLMClient: Factory & facade for LLM providers.
@@ -44,17 +37,18 @@ export class LLMClient {
     private rotationProviders: BaseLLMProvider[] | null = null;
     private rotationIndex = 0;
 
-    constructor(providerType: LLMProviderType = 'gemini', apiKey?: string) {
-        const key = apiKey || getApiKeyForProvider(providerType);
+    constructor(providerType: LLMProviderType = 'gemini', apiKey?: string, defaultModel?: string) {
+        const runtime = createLLMConfigFromEnv();
+        const key = apiKey || runtime.apiKeys[providerType];
 
         if (!key) {
             throw new Error(
                 `API key not found for provider: ${providerType}. ` +
-                `Set the env var: ${PROVIDER_ENV_VARS[providerType]}.`,
+                `Set the env var: ${getProviderEnvVar(providerType)}.`,
             );
         }
 
-        this.provider = createProviderInstance(providerType, key);
+        this.provider = createProviderInstance(providerType, key, defaultModel || runtime.model);
     }
 
     // ── Rotation factory ─────────────────────────────────────────────
@@ -64,20 +58,20 @@ export class LLMClient {
      * On 429 or error, it tries the next provider in the list.
      * Only providers with API keys set in env will be included.
      */
-    static createRotation(): LLMClient {
+    static createRotation(config: LLMRuntimeConfig = createLLMConfigFromEnv()): LLMClient {
         const providers: BaseLLMProvider[] = [];
 
         for (const type of FREE_ROTATION_ORDER) {
-            const key = getApiKeyForProvider(type);
+            const key = config.apiKeys[type];
             if (key) {
-                providers.push(createProviderInstance(type, key));
+                providers.push(createProviderInstance(type, key, config.model));
             }
         }
 
         if (providers.length === 0) {
             throw new Error(
                 `[LLMClient] No free providers configured. Set at least one of: ` +
-                FREE_ROTATION_ORDER.map((t) => PROVIDER_ENV_VARS[t]).join(', '),
+                FREE_ROTATION_ORDER.map(getProviderEnvVar).join(', '),
             );
         }
 
@@ -221,12 +215,12 @@ export class LLMClient {
      * Get model catalogs grouped by provider.
      * Returns all providers that have API keys configured.
      */
-    static getModelCatalogGrouped(): { provider: string; models: ModelInfo[] }[] {
+    static getModelCatalogGrouped(config: LLMRuntimeConfig = createLLMConfigFromEnv()): { provider: string; models: ModelInfo[] }[] {
         const groups: { provider: string; models: ModelInfo[] }[] = [];
         const ALL_PROVIDERS: LLMProviderType[] = ['gemini', 'groq', 'openrouter', 'cerebras', 'mistral'];
 
         for (const type of ALL_PROVIDERS) {
-            const key = getApiKeyForProvider(type);
+            const key = config.apiKeys[type];
             if (!key) continue;
 
             const provider = LLMClient.getOrCreateProvider(type, key);
@@ -273,7 +267,7 @@ export class LLMClient {
         const providerType = providerAndModel.slice(0, colonIdx) as LLMProviderType;
         const modelId = providerAndModel.slice(colonIdx + 1);
 
-        const key = getApiKeyForProvider(providerType);
+        const key = createLLMConfigFromEnv().apiKeys[providerType];
         if (!key) {
             throw new Error(`API key not configured for provider: ${providerType}`);
         }
@@ -376,23 +370,19 @@ function stripJsonFences(content: string): string {
     return out.trim();
 }
 
-function createProviderInstance(type: LLMProviderType, apiKey: string): BaseLLMProvider {
+function createProviderInstance(type: LLMProviderType, apiKey: string, defaultModel?: string): BaseLLMProvider {
     switch (type) {
         case 'gemini':
-            return new GeminiProvider(apiKey);
+            return new GeminiProvider(apiKey, defaultModel);
         case 'groq':
-            return new GroqProvider(apiKey);
+            return new GroqProvider(apiKey, defaultModel);
         case 'openrouter':
-            return new OpenRouterProvider(apiKey);
+            return new OpenRouterProvider(apiKey, defaultModel);
         case 'cerebras':
-            return new CerebrasProvider(apiKey);
+            return new CerebrasProvider(apiKey, defaultModel);
         case 'mistral':
-            return new MistralProvider(apiKey);
+            return new MistralProvider(apiKey, defaultModel);
         default:
             throw new Error(`Unsupported LLM provider: ${type}`);
     }
-}
-
-function getApiKeyForProvider(type: LLMProviderType): string | undefined {
-    return process.env[PROVIDER_ENV_VARS[type]];
 }

--- a/packages/core/src/llm/env.ts
+++ b/packages/core/src/llm/env.ts
@@ -1,0 +1,38 @@
+import type { LLMProviderType } from './client';
+
+export type LLMEnv = Record<string, string | undefined>;
+
+export interface LLMRuntimeConfig {
+    provider: LLMProviderType | 'rotation';
+    model?: string;
+    apiKeys: Partial<Record<LLMProviderType, string>>;
+}
+
+const PROVIDER_ENV_VARS: Record<LLMProviderType, string> = {
+    gemini: 'GEMINI_API_KEY',
+    groq: 'GROQ_API_KEY',
+    openrouter: 'OPENROUTER_API_KEY',
+    cerebras: 'CEREBRAS_API_KEY',
+    mistral: 'MISTRAL_API_KEY',
+};
+
+const PROVIDERS = Object.keys(PROVIDER_ENV_VARS) as LLMProviderType[];
+
+export function createLLMConfigFromEnv(env: LLMEnv = process.env): LLMRuntimeConfig {
+    const requestedProvider = env.LLM_PROVIDER || 'gemini';
+    const provider = requestedProvider === 'rotation' || PROVIDERS.includes(requestedProvider as LLMProviderType)
+        ? requestedProvider as LLMProviderType | 'rotation'
+        : 'gemini';
+    const apiKeys: Partial<Record<LLMProviderType, string>> = {};
+
+    for (const type of PROVIDERS) {
+        const value = env[PROVIDER_ENV_VARS[type]];
+        if (value) apiKeys[type] = value;
+    }
+
+    return { provider, model: env.LLM_MODEL, apiKeys };
+}
+
+export function getProviderEnvVar(type: LLMProviderType): string {
+    return PROVIDER_ENV_VARS[type];
+}

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -9,6 +9,7 @@ export { LLMClient, type LLMProviderType } from './client';
 
 // ── Factory ──────────────────────────────────────────────────────────
 import { LLMClient, type LLMProviderType } from './client';
+import { createLLMConfigFromEnv, type LLMEnv } from './env';
 
 /**
  * Create an LLMClient using environment variables.
@@ -17,15 +18,18 @@ import { LLMClient, type LLMProviderType } from './client';
  * - LLM_PROVIDER=groq     → uses Groq directly
  * - Defaults to gemini
  */
-export function createLLMClient(): LLMClient {
-    const providerType = process.env.LLM_PROVIDER || 'gemini';
+export function createLLMClientFromEnv(env?: LLMEnv): LLMClient {
+    const config = createLLMConfigFromEnv(env);
 
-    if (providerType === 'rotation') {
-        return LLMClient.createRotation();
+    if (config.provider === 'rotation') {
+        return LLMClient.createRotation(config);
     }
 
-    return new LLMClient(providerType as LLMProviderType);
+    return new LLMClient(config.provider, config.apiKeys[config.provider], config.model);
 }
+
+export const createLLMClient = createLLMClientFromEnv;
+export { createLLMConfigFromEnv, type LLMEnv, type LLMRuntimeConfig } from './env';
 
 // ── Types ────────────────────────────────────────────────────────────
 export type {

--- a/packages/core/src/llm/providers/cerebras/cerebras-provider.ts
+++ b/packages/core/src/llm/providers/cerebras/cerebras-provider.ts
@@ -2,13 +2,13 @@ import { OpenAICompatibleProvider } from '../openai-compatible';
 import { CEREBRAS_MODELS, CEREBRAS_DEFAULT_MODEL, CEREBRAS_BASE_URL } from './models';
 
 export class CerebrasProvider extends OpenAICompatibleProvider {
-    constructor(apiKey: string) {
+    constructor(apiKey: string, defaultModel?: string) {
         super(apiKey, {
             baseUrl: CEREBRAS_BASE_URL,
             providerName: 'cerebras',
             defaultModel: CEREBRAS_DEFAULT_MODEL,
             catalog: CEREBRAS_MODELS,
-        });
+        }, defaultModel);
     }
 }
 

--- a/packages/core/src/llm/providers/gemini/gemini-provider.ts
+++ b/packages/core/src/llm/providers/gemini/gemini-provider.ts
@@ -10,16 +10,16 @@ const log = logger.child({ module: 'GeminiProvider' });
  * Gemini LLM Provider
  *
  * Uses Google's Gemini API via @google/genai SDK.
- * Model configurable via LLM_MODEL env var, defaults to gemini-2.5-flash
+ * Model is injected by the LLM env factory and defaults to gemini-2.5-flash.
  */
 export class GeminiProvider extends BaseLLMProvider {
     private client: GoogleGenAI;
     private _defaultModel: string;
 
-    constructor(apiKey: string) {
+    constructor(apiKey: string, defaultModel?: string) {
         super(apiKey);
         this.client = new GoogleGenAI({ apiKey });
-        this._defaultModel = process.env.LLM_MODEL || GEMINI_DEFAULT_MODEL;
+        this._defaultModel = defaultModel || GEMINI_DEFAULT_MODEL;
         log.debug({ model: this._defaultModel }, 'GeminiProvider initialized');
     }
 

--- a/packages/core/src/llm/providers/groq/groq-provider.ts
+++ b/packages/core/src/llm/providers/groq/groq-provider.ts
@@ -2,13 +2,13 @@ import { OpenAICompatibleProvider } from '../openai-compatible';
 import { GROQ_MODELS, GROQ_DEFAULT_MODEL, GROQ_BASE_URL } from './models';
 
 export class GroqProvider extends OpenAICompatibleProvider {
-    constructor(apiKey: string) {
+    constructor(apiKey: string, defaultModel?: string) {
         super(apiKey, {
             baseUrl: GROQ_BASE_URL,
             providerName: 'groq',
             defaultModel: GROQ_DEFAULT_MODEL,
             catalog: GROQ_MODELS,
-        });
+        }, defaultModel);
     }
 }
 

--- a/packages/core/src/llm/providers/mistral/mistral-provider.ts
+++ b/packages/core/src/llm/providers/mistral/mistral-provider.ts
@@ -2,13 +2,13 @@ import { OpenAICompatibleProvider } from '../openai-compatible';
 import { MISTRAL_MODELS, MISTRAL_DEFAULT_MODEL, MISTRAL_BASE_URL } from './models';
 
 export class MistralProvider extends OpenAICompatibleProvider {
-    constructor(apiKey: string) {
+    constructor(apiKey: string, defaultModel?: string) {
         super(apiKey, {
             baseUrl: MISTRAL_BASE_URL,
             providerName: 'mistral',
             defaultModel: MISTRAL_DEFAULT_MODEL,
             catalog: MISTRAL_MODELS,
-        });
+        }, defaultModel);
     }
 }
 

--- a/packages/core/src/llm/providers/openai-compatible.ts
+++ b/packages/core/src/llm/providers/openai-compatible.ts
@@ -18,10 +18,10 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     private readonly cfg: OpenAICompatibleConfig;
     private readonly _defaultModel: string;
 
-    constructor(apiKey: string, cfg: OpenAICompatibleConfig) {
+    constructor(apiKey: string, cfg: OpenAICompatibleConfig, defaultModel?: string) {
         super(apiKey);
         this.cfg = cfg;
-        this._defaultModel = process.env.LLM_MODEL || cfg.defaultModel;
+        this._defaultModel = defaultModel || cfg.defaultModel;
         console.log(`[${cfg.providerName}] Initialized with model: ${this._defaultModel}`);
     }
 

--- a/packages/core/src/llm/providers/openrouter/openrouter-provider.ts
+++ b/packages/core/src/llm/providers/openrouter/openrouter-provider.ts
@@ -2,14 +2,14 @@ import { OpenAICompatibleProvider } from '../openai-compatible';
 import { OPENROUTER_MODELS, OPENROUTER_DEFAULT_MODEL, OPENROUTER_BASE_URL } from './models';
 
 export class OpenRouterProvider extends OpenAICompatibleProvider {
-    constructor(apiKey: string) {
+    constructor(apiKey: string, defaultModel?: string) {
         super(apiKey, {
             baseUrl: OPENROUTER_BASE_URL,
             providerName: 'openrouter',
             defaultModel: OPENROUTER_DEFAULT_MODEL,
             catalog: OPENROUTER_MODELS,
             extraHeaders: { 'HTTP-Referer': 'https://github.com/flow-sample' },
-        });
+        }, defaultModel);
     }
 }
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,10 +1,19 @@
 import pino from 'pino';
 
-const isDev = process.env.NODE_ENV !== 'production';
+type LoggerEnv = Record<string, string | undefined>;
+
+export function createLoggerConfigFromEnv(env: LoggerEnv = process.env) {
+    return {
+        isDev: env.NODE_ENV !== 'production',
+        level: env.LOG_LEVEL || 'info',
+    };
+}
+
+const config = createLoggerConfigFromEnv();
 
 export const logger = pino({
-    level: process.env.LOG_LEVEL || 'info',
-    transport: isDev
+    level: config.level,
+    transport: config.isDev
         ? {
             target: 'pino-pretty',
             options: {

--- a/packages/core/tests/llm/env.test.ts
+++ b/packages/core/tests/llm/env.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createLLMConfigFromEnv } from '../../src/llm/env';
+
+describe('createLLMConfigFromEnv', () => {
+    it('defaults to Gemini without inventing API keys', () => {
+        expect(createLLMConfigFromEnv({})).toEqual({
+            provider: 'gemini',
+            model: undefined,
+            apiKeys: {},
+        });
+    });
+
+    it('collects provider, model, and available API keys', () => {
+        expect(createLLMConfigFromEnv({
+            LLM_PROVIDER: 'rotation',
+            LLM_MODEL: 'configured-model',
+            GROQ_API_KEY: 'groq-key',
+            OPENROUTER_API_KEY: 'openrouter-key',
+        })).toEqual({
+            provider: 'rotation',
+            model: 'configured-model',
+            apiKeys: { groq: 'groq-key', openrouter: 'openrouter-key' },
+        });
+    });
+
+    it('falls back to Gemini for an unknown provider', () => {
+        expect(createLLMConfigFromEnv({ LLM_PROVIDER: 'unknown' }).provider).toBe('gemini');
+    });
+});

--- a/packages/core/tests/llm/providers/gemini-provider.test.ts
+++ b/packages/core/tests/llm/providers/gemini-provider.test.ts
@@ -128,24 +128,11 @@ describe('GeminiProvider metadata', () => {
     });
 
     it('defaults the model to the gemini default', () => {
-        const orig = process.env.LLM_MODEL;
-        delete process.env.LLM_MODEL;
-        try {
-            expect(new GeminiProvider('k').defaultModel).toBe(GEMINI_DEFAULT_MODEL);
-        } finally {
-            if (orig !== undefined) process.env.LLM_MODEL = orig;
-        }
+        expect(new GeminiProvider('k').defaultModel).toBe(GEMINI_DEFAULT_MODEL);
     });
 
-    it('respects the LLM_MODEL env override for the default model', () => {
-        const orig = process.env.LLM_MODEL;
-        process.env.LLM_MODEL = 'gemini-from-env';
-        try {
-            expect(new GeminiProvider('k').defaultModel).toBe('gemini-from-env');
-        } finally {
-            if (orig === undefined) delete process.env.LLM_MODEL;
-            else process.env.LLM_MODEL = orig;
-        }
+    it('respects an injected default model', () => {
+        expect(new GeminiProvider('k', 'gemini-configured').defaultModel).toBe('gemini-configured');
     });
 
     it('returns the static model catalog', () => {

--- a/packages/core/tests/llm/providers/openai-compatible.test.ts
+++ b/packages/core/tests/llm/providers/openai-compatible.test.ts
@@ -10,14 +10,14 @@ const TEST_CATALOG: ModelInfo[] = [
 ];
 
 class TestProvider extends OpenAICompatibleProvider {
-    constructor(apiKey: string, extraHeaders?: Record<string, string>) {
+    constructor(apiKey: string, extraHeaders?: Record<string, string>, defaultModel?: string) {
         super(apiKey, {
             baseUrl: 'https://api.test.example',
             providerName: 'testprovider',
             defaultModel: 'model-a',
             catalog: TEST_CATALOG,
             extraHeaders,
-        });
+        }, defaultModel);
     }
 }
 
@@ -72,7 +72,6 @@ describe('OpenAICompatibleProvider', () => {
 
     afterEach(() => {
         vi.unstubAllGlobals();
-        delete process.env.LLM_MODEL;
     });
 
     // ── Properties ────────────────────────────────────────────────────
@@ -82,9 +81,8 @@ describe('OpenAICompatibleProvider', () => {
             expect(new TestProvider('key').defaultModel).toBe('model-a');
         });
 
-        it('LLM_MODEL env var overrides the catalog default', () => {
-            process.env.LLM_MODEL = 'model-b';
-            expect(new TestProvider('key').defaultModel).toBe('model-b');
+        it('an injected model overrides the catalog default', () => {
+            expect(new TestProvider('key', undefined, 'model-b').defaultModel).toBe('model-b');
         });
 
         it('providerName returns the configured name', () => {

--- a/packages/flows/trading/README.md
+++ b/packages/flows/trading/README.md
@@ -20,6 +20,18 @@ routes      → Elysia API routes + SSE streaming (/api/trading/*)
 - Server-Sent Events (SSE) for live UI updates
 - Start/stop stream controls and advisor toggle
 
+## Runtime Configuration
+
+`createTradingConfigFromEnv()` owns environment parsing at composition time. The route
+factory receives the resulting `{ symbol, interval, advisorAutoStart }` object, and
+services do not read `process.env` directly.
+
+| Variable | Default | Purpose |
+| :------- | :------ | :------ |
+| `TRADING_SYMBOL` | `BTCUSDT` | Binance pair used by the stream and analysis services |
+| `TRADING_INTERVAL` | `1m` | Default candle interval |
+| `ADVISOR_AUTO_START` | `false` | Enables the mentor service during route composition when set to `true` |
+
 ## API Routes
 
 | Method | Path | Description |

--- a/packages/flows/trading/src/backend/config.ts
+++ b/packages/flows/trading/src/backend/config.ts
@@ -125,10 +125,26 @@ export const TRADING_CONFIG = {
    * Default trading pair and timeframe (overridable via environment variables)
    */
   DEFAULTS: {
-    SYMBOL: process.env.TRADING_SYMBOL || 'BTCUSDT',
-    INTERVAL: process.env.TRADING_INTERVAL || '1m',
+    SYMBOL: 'BTCUSDT',
+    INTERVAL: '1m',
   },
 } as const;
+
+type Env = Record<string, string | undefined>;
+
+export interface TradingRuntimeConfig {
+  symbol: string;
+  interval: string;
+  advisorAutoStart: boolean;
+}
+
+export function createTradingConfigFromEnv(env: Env = process.env): TradingRuntimeConfig {
+  return {
+    symbol: env.TRADING_SYMBOL || TRADING_CONFIG.DEFAULTS.SYMBOL,
+    interval: env.TRADING_INTERVAL || TRADING_CONFIG.DEFAULTS.INTERVAL,
+    advisorAutoStart: env.ADVISOR_AUTO_START === 'true',
+  };
+}
 
 /**
  * Type-safe access to configuration values

--- a/packages/flows/trading/src/backend/routes.ts
+++ b/packages/flows/trading/src/backend/routes.ts
@@ -2,7 +2,7 @@ import { Elysia, t } from 'elysia';
 import { getTradingService, getMentorService, getSynthesizerService, AnalystService } from './services';
 import { fetchKlines, type KlineInterval } from '../adapters/binance';
 import { createLLMClient, logger } from '@flows/core';
-import { TRADING_CONFIG } from './config';
+import { createTradingConfigFromEnv, TRADING_CONFIG, type TradingRuntimeConfig } from './config';
 
 const log = logger.child({ module: 'TradingRoutes' });
 import {
@@ -19,9 +19,9 @@ import {
  *
  * Endpoints for the Trading Bot Flow (N1-N6)
  */
-export function createTradingRoutes() {
-  const tradingService = getTradingService();
-  const mentorService = getMentorService();
+export function createTradingRoutes(config: TradingRuntimeConfig = createTradingConfigFromEnv()) {
+  const tradingService = getTradingService({ symbol: config.symbol, interval: config.interval });
+  const mentorService = getMentorService(config.symbol, config.advisorAutoStart);
 
   return (
     new Elysia({ prefix: '/api/trading' })

--- a/packages/flows/trading/src/backend/services/mentor.service.ts
+++ b/packages/flows/trading/src/backend/services/mentor.service.ts
@@ -34,11 +34,9 @@ export class MentorService {
   private insightCount: number = 0;
   private symbol: string;
 
-  constructor(symbol?: string) {
+  constructor(symbol?: string, autoStart: boolean = false) {
     this.symbol = symbol || TRADING_CONFIG.DEFAULTS.SYMBOL;
 
-    // Auto-start based on environment
-    const autoStart = process.env.ADVISOR_AUTO_START === 'true';
     if (autoStart) {
       this.enable();
     }
@@ -272,9 +270,9 @@ export class MentorService {
 // Singleton
 let mentorInstance: MentorService | null = null;
 
-export function getMentorService(symbol?: string): MentorService {
+export function getMentorService(symbol?: string, autoStart: boolean = false): MentorService {
   if (!mentorInstance) {
-    mentorInstance = new MentorService(symbol);
+    mentorInstance = new MentorService(symbol, autoStart);
   }
   return mentorInstance;
 }

--- a/packages/flows/trading/src/index.ts
+++ b/packages/flows/trading/src/index.ts
@@ -3,7 +3,12 @@
 // Backend exports
 export { createTradingRoutes } from './backend/routes';
 export { getTradingService, getMentorService, getSynthesizerService, AnalystService } from './backend/services';
-export { TRADING_CONFIG, type TradingConfig } from './backend/config';
+export {
+  createTradingConfigFromEnv,
+  TRADING_CONFIG,
+  type TradingConfig,
+  type TradingRuntimeConfig,
+} from './backend/config';
 
 // Domain math exports
 export {

--- a/packages/flows/trading/tests/backend/config.test.ts
+++ b/packages/flows/trading/tests/backend/config.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { TRADING_CONFIG, MENTOR_SYSTEM_PROMPT } from '../../src/backend/config';
+import { describe, it, expect } from 'vitest';
+import {
+  createTradingConfigFromEnv,
+  TRADING_CONFIG,
+  MENTOR_SYSTEM_PROMPT,
+} from '../../src/backend/config';
 
 describe('TRADING_CONFIG static values', () => {
   it('exposes Hurst thresholds with trending > mean-reverting', () => {
@@ -49,38 +53,18 @@ describe('TRADING_CONFIG static values', () => {
   });
 });
 
-describe('TRADING_CONFIG.DEFAULTS environment parsing', () => {
-  let origSymbol: string | undefined;
-  let origInterval: string | undefined;
-
-  beforeEach(() => {
-    origSymbol = process.env.TRADING_SYMBOL;
-    origInterval = process.env.TRADING_INTERVAL;
+describe('createTradingConfigFromEnv', () => {
+  it('falls back to BTCUSDT / 1m with advisor disabled', () => {
+    const config = createTradingConfigFromEnv({});
+    expect(config).toEqual({ symbol: 'BTCUSDT', interval: '1m', advisorAutoStart: false });
   });
 
-  afterEach(() => {
-    if (origSymbol === undefined) delete process.env.TRADING_SYMBOL;
-    else process.env.TRADING_SYMBOL = origSymbol;
-    if (origInterval === undefined) delete process.env.TRADING_INTERVAL;
-    else process.env.TRADING_INTERVAL = origInterval;
-    vi.resetModules();
-  });
-
-  it('falls back to BTCUSDT / 1m when env vars are unset', async () => {
-    delete process.env.TRADING_SYMBOL;
-    delete process.env.TRADING_INTERVAL;
-    vi.resetModules();
-    const { TRADING_CONFIG: fresh } = await import('../../src/backend/config');
-    expect(fresh.DEFAULTS.SYMBOL).toBe('BTCUSDT');
-    expect(fresh.DEFAULTS.INTERVAL).toBe('1m');
-  });
-
-  it('reads symbol and interval overrides from the environment', async () => {
-    process.env.TRADING_SYMBOL = 'ETHUSDT';
-    process.env.TRADING_INTERVAL = '15m';
-    vi.resetModules();
-    const { TRADING_CONFIG: fresh } = await import('../../src/backend/config');
-    expect(fresh.DEFAULTS.SYMBOL).toBe('ETHUSDT');
-    expect(fresh.DEFAULTS.INTERVAL).toBe('15m');
+  it('reads runtime overrides explicitly', () => {
+    const config = createTradingConfigFromEnv({
+      TRADING_SYMBOL: 'ETHUSDT',
+      TRADING_INTERVAL: '15m',
+      ADVISOR_AUTO_START: 'true',
+    });
+    expect(config).toEqual({ symbol: 'ETHUSDT', interval: '15m', advisorAutoStart: true });
   });
 });

--- a/packages/flows/trading/tests/backend/mentor.service.test.ts
+++ b/packages/flows/trading/tests/backend/mentor.service.test.ts
@@ -89,12 +89,8 @@ function makeLLMClient(content: string) {
 }
 
 describe('MentorService', () => {
-  let prevAutoStart: string | undefined;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    prevAutoStart = process.env.ADVISOR_AUTO_START;
-    delete process.env.ADVISOR_AUTO_START;
     buildMessagesMock.mockReturnValue({
       messages: [
         { role: 'system', content: 'sys' },
@@ -104,22 +100,16 @@ describe('MentorService', () => {
     });
   });
 
-  afterEach(() => {
-    if (prevAutoStart === undefined) delete process.env.ADVISOR_AUTO_START;
-    else process.env.ADVISOR_AUTO_START = prevAutoStart;
-  });
-
   describe('enable / disable / toggle', () => {
-    it('starts disabled when ADVISOR_AUTO_START is not "true"', () => {
+    it('starts disabled by default', () => {
       const svc = new MentorService(SYMBOL);
       expect(svc.getState().isEnabled).toBe(false);
       expect(createLLMClientMock).not.toHaveBeenCalled();
     });
 
-    it('auto-starts when ADVISOR_AUTO_START is "true"', () => {
-      process.env.ADVISOR_AUTO_START = 'true';
+    it('auto-starts when configured', () => {
       createLLMClientMock.mockReturnValue(makeLLMClient(validInsightJson()));
-      const svc = new MentorService(SYMBOL);
+      const svc = new MentorService(SYMBOL, true);
       expect(svc.getState().isEnabled).toBe(true);
       expect(createLLMClientMock).toHaveBeenCalled();
     });

--- a/scripts/check-architecture-contracts.mjs
+++ b/scripts/check-architecture-contracts.mjs
@@ -53,6 +53,7 @@ export function checkSource(file, source) {
   const hardcodedOrigin = /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/g;
   const sqlCall = /\.(?:prepare|exec)\s*\(/g;
   const flowImport = /from\s+['"]@flows\/(spotify|lyrics|trading|chat|canvas)(?:\/[^'"]*)?['"]/g;
+  const processEnv = /process\.env/g;
 
   for (const match of source.matchAll(explicitAny)) {
     violations.push(violation(file, source, match, 'no-explicit-any', 'Replace `any` with a concrete type or safe narrowing.'));
@@ -78,6 +79,13 @@ export function checkSource(file, source) {
       if (match[1] !== flowMatch[1]) {
         violations.push(violation(file, source, match, 'no-sibling-flow-imports', 'Depend on @flows/shared, @flows/core, or an injected port instead.'));
       }
+    }
+  }
+
+  const isEnvOwner = /(?:config|env|logger)\.ts$/.test(file) || file.endsWith('/playwright.config.ts');
+  if (!isEnvOwner) {
+    for (const match of source.matchAll(processEnv)) {
+      violations.push(violation(file, source, match, 'env-in-config-only', 'Read environment variables in an explicitly named config/env factory and inject the result.'));
     }
   }
 

--- a/scripts/check-architecture-contracts.test.mjs
+++ b/scripts/check-architecture-contracts.test.mjs
@@ -35,3 +35,19 @@ test('allows the documented lyrics to spotify transition', () => {
   const violations = checkSource('packages/flows/lyrics/src/backend/repository.ts', "import { musicDb } from '@flows/spotify';");
   assert.deepEqual(violations, []);
 });
+
+test('rejects environment reads outside config factories', () => {
+  const violations = checkSource(
+    'packages/flows/trading/src/backend/services/example.ts',
+    'const enabled = process.env.FEATURE_ENABLED;',
+  );
+  assert.equal(violations[0]?.rule, 'env-in-config-only');
+});
+
+test('allows environment reads in explicitly named config modules', () => {
+  const violations = checkSource(
+    'packages/flows/trading/src/backend/config.ts',
+    'export const fromEnv = (env = process.env) => env.VALUE;',
+  );
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## What changed

- add explicit LLM and Trading environment-to-runtime config factories
- inject Trading symbol, interval, and advisor auto-start during backend composition
- remove direct environment reads from providers and MentorService
- inject model selection into provider constructors
- add tests for defaults, overrides, invalid providers, and architecture enforcement
- update Core and Trading usage documentation

## Impact

Runtime defaults remain unchanged, but services/providers are deterministic when constructed and easier to test or extract. New deep `process.env` reads now fail the architecture gate.

## Validation

- `pnpm verify`
- `pnpm build`
- focused Core, Trading, and backend checks
- pre-push `pnpm check`
- pre-push `pnpm test`
- `git diff --check`

Closes #33