### PR TITLE
feat: add shared UI primitives

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,6 +1,6 @@
-# Design System - Cosmic Flow
+# Design System - Flow UI
 
-Dark space theme with blue/green accents.
+Dark operational UI with semantic primitives and selectable galaxy, fire, and organic accents.
 
 ---
 
@@ -55,6 +55,14 @@ Dark space theme with blue/green accents.
 ---
 
 ## Components
+
+Shared primitives live in `packages/ui/src/lib/components/ui` and are exported from
+`@lib/components`. New flow UI should compose `Button`, `IconButton`, `Field`, `Badge`,
+`AsyncState`, and `ModalShell` before adding flow-local equivalents.
+
+Theme selection uses `data-theme` on an ancestor. The default galaxy palette is cyan,
+`data-theme="fire"` uses rose accents, and `data-theme="organic"` uses lime accents.
+Components consume semantic `--ui-*` variables rather than palette names directly.
 
 ### Cards
 

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -7,6 +7,8 @@
   --color-aurora: #10b981;
   --color-pulsar: #06b6d4;
   --color-cosmic: #8b5cf6;
+  --color-fire: #f43f5e;
+  --color-organic: #84cc16;
 }
 
 /* Cosmic Flow Design System variables (legacy/fallback if needed, or removed if @theme handles it) */
@@ -14,6 +16,27 @@
   /* Glass effect */
   --glass-bg: rgba(17, 24, 39, 0.7);
   --glass-border: rgba(255, 255, 255, 0.08);
+  --ui-accent: #06b6d4;
+  --ui-accent-strong: #0891b2;
+  --ui-focus: #22d3ee;
+  --ui-danger: #fb7185;
+  --ui-surface: #111827;
+  --ui-surface-raised: #1f2937;
+  --ui-border: rgba(148, 163, 184, 0.24);
+  --ui-text: #f8fafc;
+  --ui-text-muted: #94a3b8;
+}
+
+[data-theme='fire'] {
+  --ui-accent: #f43f5e;
+  --ui-accent-strong: #e11d48;
+  --ui-focus: #fb7185;
+}
+
+[data-theme='organic'] {
+  --ui-accent: #84cc16;
+  --ui-accent-strong: #65a30d;
+  --ui-focus: #a3e635;
 }
 
 /* ========================================
@@ -168,6 +191,216 @@ body::after {
 
 .btn-primary:active:not(:disabled) {
   @apply translate-y-0 scale-95;
+}
+
+.ui-button,
+.ui-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.ui-button:focus-visible,
+.ui-icon-button:focus-visible,
+.ui-field__control:focus-visible {
+  outline: 2px solid var(--ui-focus);
+  outline-offset: 2px;
+}
+
+.ui-button:disabled,
+.ui-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.ui-button--sm {
+  min-height: 2rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+}
+.ui-button--md {
+  min-height: 2.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+}
+.ui-button--lg {
+  min-height: 3rem;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+}
+.ui-button--primary,
+.ui-icon-button--primary {
+  background: var(--ui-accent-strong);
+  color: white;
+}
+.ui-button--primary:hover:not(:disabled),
+.ui-icon-button--primary:hover:not(:disabled) {
+  background: var(--ui-accent);
+}
+.ui-button--secondary,
+.ui-icon-button--secondary {
+  background: var(--ui-surface-raised);
+  border-color: var(--ui-border);
+  color: var(--ui-text);
+}
+.ui-button--ghost,
+.ui-icon-button--ghost {
+  background: transparent;
+  color: var(--ui-text-muted);
+}
+.ui-button--ghost:hover:not(:disabled),
+.ui-icon-button--ghost:hover:not(:disabled) {
+  background: var(--ui-surface-raised);
+  color: var(--ui-text);
+}
+.ui-button--danger,
+.ui-icon-button--danger {
+  background: color-mix(in srgb, var(--ui-danger) 16%, transparent);
+  color: var(--ui-danger);
+}
+.ui-icon-button {
+  padding: 0;
+  flex: 0 0 auto;
+}
+.ui-icon-button--sm {
+  width: 2rem;
+  height: 2rem;
+}
+.ui-icon-button--md {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+.ui-button__spinner,
+.ui-async-state__spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ui-spin 700ms linear infinite;
+}
+@keyframes ui-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ui-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+.ui-field__label {
+  color: var(--ui-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.ui-field__control {
+  width: 100%;
+  border: 1px solid var(--ui-border);
+  border-radius: 0.5rem;
+  background: var(--ui-surface);
+  color: var(--ui-text);
+  padding: 0.75rem;
+}
+.ui-field__control::placeholder {
+  color: var(--ui-text-muted);
+}
+.ui-field__control--mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.ui-field__textarea {
+  resize: none;
+}
+
+.ui-badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--ui-border);
+  border-radius: 999px;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.ui-badge--neutral {
+  color: var(--ui-text-muted);
+}
+.ui-badge--info {
+  color: var(--ui-focus);
+}
+.ui-badge--success {
+  color: #4ade80;
+}
+.ui-badge--warning {
+  color: #facc15;
+}
+.ui-badge--danger {
+  color: var(--ui-danger);
+}
+
+.ui-async-state {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  color: var(--ui-text-muted);
+  text-align: center;
+}
+.ui-async-state strong {
+  color: var(--ui-text);
+}
+.ui-async-state p {
+  margin: 0;
+  max-width: 32rem;
+}
+.ui-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(2, 6, 23, 0.78);
+}
+.ui-modal {
+  width: min(36rem, 100%);
+  max-height: min(42rem, calc(100vh - 2rem));
+  overflow: auto;
+  border: 1px solid var(--ui-border);
+  border-radius: 0.5rem;
+  background: var(--ui-surface);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+.ui-modal__header,
+.ui-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+}
+.ui-modal__header {
+  border-bottom: 1px solid var(--ui-border);
+}
+.ui-modal__header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+.ui-modal__body {
+  padding: 1rem;
+}
+.ui-modal__footer {
+  justify-content: flex-end;
+  border-top: 1px solid var(--ui-border);
 }
 
 /* Scrollbar */

--- a/packages/ui/src/lib/components/index.ts
+++ b/packages/ui/src/lib/components/index.ts
@@ -4,3 +4,5 @@ export { default as InfiniteScroll } from './common/InfiniteScroll.svelte';
 // Layout components
 export { default as Navbar } from './layout/Navbar.svelte';
 export { default as FlowLayout } from './layout/FlowLayout.svelte';
+
+export * from './ui';

--- a/packages/ui/src/lib/components/ui/AsyncState.svelte
+++ b/packages/ui/src/lib/components/ui/AsyncState.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  let {
+    state,
+    title,
+    message,
+    action,
+  }: {
+    state: 'loading' | 'empty' | 'error';
+    title: string;
+    message?: string;
+    action?: Snippet;
+  } = $props();
+</script>
+
+<div class="ui-async-state" role={state === 'error' ? 'alert' : 'status'}>
+  {#if state === 'loading'}<span class="ui-async-state__spinner" aria-hidden="true"></span>{/if}
+  <strong>{title}</strong>
+  {#if message}<p>{message}</p>{/if}
+  {#if action}<div class="ui-async-state__action">{@render action()}</div>{/if}
+</div>

--- a/packages/ui/src/lib/components/ui/Badge.svelte
+++ b/packages/ui/src/lib/components/ui/Badge.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  let {
+    children,
+    tone = 'neutral',
+  }: { children: Snippet; tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger' } = $props();
+</script>
+
+<span class="ui-badge ui-badge--{tone}">{@render children()}</span>

--- a/packages/ui/src/lib/components/ui/Button.svelte
+++ b/packages/ui/src/lib/components/ui/Button.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  interface Props extends HTMLButtonAttributes {
+    children: Snippet;
+    variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+    size?: 'sm' | 'md' | 'lg';
+    loading?: boolean;
+  }
+
+  let {
+    children,
+    variant = 'primary',
+    size = 'md',
+    loading = false,
+    disabled = false,
+    class: className = '',
+    type = 'button',
+    ...rest
+  }: Props = $props();
+</script>
+
+<button
+  {type}
+  class="ui-button ui-button--{variant} ui-button--{size} {className}"
+  disabled={disabled || loading}
+  aria-busy={loading}
+  {...rest}
+>
+  {#if loading}<span class="ui-button__spinner" aria-hidden="true"></span>{/if}
+  {@render children()}
+</button>

--- a/packages/ui/src/lib/components/ui/Field.svelte
+++ b/packages/ui/src/lib/components/ui/Field.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  let {
+    value = $bindable(''),
+    label,
+    placeholder = '',
+    multiline = false,
+    rows = 4,
+    disabled = false,
+    required = false,
+    mono = false,
+    class: className = '',
+  }: {
+    value?: string;
+    label?: string;
+    placeholder?: string;
+    multiline?: boolean;
+    rows?: number;
+    disabled?: boolean;
+    required?: boolean;
+    mono?: boolean;
+    class?: string;
+  } = $props();
+
+  const id = $props.id();
+</script>
+
+<label class="ui-field {className}" for={id}>
+  {#if label}<span class="ui-field__label">{label}</span>{/if}
+  {#if multiline}
+    <textarea
+      {id}
+      bind:value
+      {rows}
+      {placeholder}
+      {disabled}
+      {required}
+      class:ui-field__control--mono={mono}
+      class="ui-field__control ui-field__textarea"
+    ></textarea>
+  {:else}
+    <input
+      {id}
+      bind:value
+      {placeholder}
+      {disabled}
+      {required}
+      class:ui-field__control--mono={mono}
+      class="ui-field__control"
+    />
+  {/if}
+</label>

--- a/packages/ui/src/lib/components/ui/IconButton.svelte
+++ b/packages/ui/src/lib/components/ui/IconButton.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  interface Props extends HTMLButtonAttributes {
+    label: string;
+    children: Snippet;
+    variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+    size?: 'sm' | 'md';
+  }
+
+  let {
+    label,
+    children,
+    variant = 'ghost',
+    size = 'md',
+    class: className = '',
+    type = 'button',
+    ...rest
+  }: Props = $props();
+</script>
+
+<button
+  {type}
+  class="ui-icon-button ui-icon-button--{variant} ui-icon-button--{size} {className}"
+  aria-label={label}
+  title={label}
+  {...rest}
+>
+  {@render children()}
+</button>

--- a/packages/ui/src/lib/components/ui/ModalShell.svelte
+++ b/packages/ui/src/lib/components/ui/ModalShell.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import IconButton from './IconButton.svelte';
+
+  let {
+    title,
+    children,
+    footer,
+    onclose,
+  }: { title: string; children: Snippet; footer?: Snippet; onclose: () => void } = $props();
+
+  const titleId = $props.id();
+</script>
+
+<div
+  class="ui-modal-backdrop"
+  role="presentation"
+  onclick={(event) => event.currentTarget === event.target && onclose()}
+>
+  <div class="ui-modal" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+    <header class="ui-modal__header">
+      <h2 id={titleId}>{title}</h2>
+      <IconButton label="Close" onclick={onclose}>
+        <span aria-hidden="true">×</span>
+      </IconButton>
+    </header>
+    <div class="ui-modal__body">{@render children()}</div>
+    {#if footer}<footer class="ui-modal__footer">{@render footer()}</footer>{/if}
+  </div>
+</div>

--- a/packages/ui/src/lib/components/ui/index.ts
+++ b/packages/ui/src/lib/components/ui/index.ts
@@ -1,0 +1,6 @@
+export { default as AsyncState } from './AsyncState.svelte';
+export { default as Badge } from './Badge.svelte';
+export { default as Button } from './Button.svelte';
+export { default as Field } from './Field.svelte';
+export { default as IconButton } from './IconButton.svelte';
+export { default as ModalShell } from './ModalShell.svelte';

--- a/packages/ui/src/lib/components/ui/ui.test.ts
+++ b/packages/ui/src/lib/components/ui/ui.test.ts
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import AsyncState from './AsyncState.svelte';
+import Badge from './Badge.svelte';
+import Button from './Button.svelte';
+import Field from './Field.svelte';
+import IconButton from './IconButton.svelte';
+import ModalShell from './ModalShell.svelte';
+
+const textSnippet = (text: string) => createRawSnippet(() => ({ render: () => text }));
+
+describe('UI primitives', () => {
+  it('Button exposes loading and disabled state', () => {
+    render(Button, { props: { children: textSnippet('Save'), loading: true } });
+    const button = screen.getByRole('button', { name: 'Save' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('IconButton uses its label as the accessible name', async () => {
+    const onclick = vi.fn();
+    render(IconButton, { props: { label: 'Delete', children: textSnippet('×'), onclick } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onclick).toHaveBeenCalledOnce();
+  });
+
+  it('Field renders labeled single and multiline controls', () => {
+    const { unmount } = render(Field, { props: { label: 'Title', value: 'Draft' } });
+    expect(screen.getByLabelText('Title')).toHaveValue('Draft');
+    unmount();
+    render(Field, { props: { label: 'Body', multiline: true, value: 'Text' } });
+    expect(screen.getByLabelText('Body').tagName).toBe('TEXTAREA');
+  });
+
+  it('Badge exposes the selected semantic tone', () => {
+    render(Badge, { props: { tone: 'success', children: textSnippet('Ready') } });
+    expect(screen.getByText('Ready')).toHaveClass('ui-badge--success');
+  });
+
+  it('AsyncState uses alert semantics for failures', () => {
+    render(AsyncState, { props: { state: 'error', title: 'Request failed' } });
+    expect(screen.getByRole('alert')).toHaveTextContent('Request failed');
+  });
+
+  it('ModalShell exposes dialog semantics and closes from its command', async () => {
+    const onclose = vi.fn();
+    render(ModalShell, {
+      props: { title: 'Details', children: textSnippet('Content'), onclose },
+    });
+    expect(screen.getByRole('dialog', { name: 'Details' })).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { canvasStore } from './stores.svelte';
+  import { Button, Field } from '@lib/components';
 
   let title = $state('');
   let author = $state('');
@@ -23,40 +24,38 @@
   </div>
 
   <div class="flex flex-col gap-4 flex-1">
-    <div class="flex gap-4">
-      <input
-        type="text"
+    <div class="flex flex-col gap-4 sm:flex-row">
+      <Field
         placeholder="Title (optional)"
         bind:value={title}
-        class="flex-1 bg-slate-900 border border-slate-700 rounded-lg p-3 text-slate-100 placeholder-slate-500 focus:outline-none focus:border-primary-500 transition-colors"
+        class="flex-1"
         disabled={canvasStore.isAnalyzing}
       />
-      <input
-        type="text"
+      <Field
         placeholder="Author (optional)"
         bind:value={author}
-        class="flex-1 bg-slate-900 border border-slate-700 rounded-lg p-3 text-slate-100 placeholder-slate-500 focus:outline-none focus:border-primary-500 transition-colors"
+        class="flex-1"
         disabled={canvasStore.isAnalyzing}
       />
     </div>
 
-    <textarea
+    <Field
       placeholder="Paste your text here..."
       bind:value={text}
-      class="flex-1 bg-slate-900 border border-slate-700 rounded-lg p-4 text-slate-100 placeholder-slate-500 focus:outline-none focus:border-primary-500 transition-colors resize-none font-mono text-sm"
+      multiline
+      mono
+      class="flex-1"
       disabled={canvasStore.isAnalyzing}
-    ></textarea>
+    />
 
     <div class="flex justify-end pt-2">
-      <button
-        class="px-6 py-3 bg-primary-600 hover:bg-primary-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors flex items-center gap-2 shadow-lg shadow-primary-900/20"
+      <Button
+        size="lg"
         onclick={handleSubmit}
         disabled={!text.trim() || canvasStore.isAnalyzing}
+        loading={canvasStore.isAnalyzing}
       >
         {#if canvasStore.isAnalyzing}
-          <div
-            class="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"
-          ></div>
           Analyzing...
         {:else}
           <svg
@@ -73,7 +72,7 @@
           </svg>
           Analyze Text
         {/if}
-      </button>
+      </Button>
     </div>
   </div>
 </div>

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { chatStore } from '../stores.svelte';
+  import { IconButton } from '@lib/components';
 
   let inputContent = $state('');
   let textareaEl: HTMLTextAreaElement;
@@ -47,11 +48,12 @@
     ></textarea>
 
     {#if chatStore.isStreaming}
-      <button
+      <IconButton
+        label="Stop generating"
+        variant="secondary"
+        size="sm"
         onclick={() => chatStore.stopStreaming()}
-        class="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-lg bg-slate-600 text-white transition-colors hover:bg-slate-500"
-        title="Stop generating"
-        aria-label="Stop generating"
+        class="absolute right-2 bottom-2"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -61,14 +63,15 @@
         >
           <rect x="6" y="6" width="12" height="12" rx="1.5" />
         </svg>
-      </button>
+      </IconButton>
     {:else}
-      <button
+      <IconButton
+        label="Send message"
+        variant="primary"
+        size="sm"
         onclick={submit}
         disabled={!inputContent.trim() || chatStore.isLoading}
-        class="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-lg bg-cosmic-600 text-white disabled:opacity-50 disabled:bg-slate-700 disabled:cursor-not-allowed transition-colors hover:bg-cosmic-500"
-        title="Send message"
-        aria-label="Send message"
+        class="absolute right-2 bottom-2"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -80,7 +83,7 @@
             d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z"
           />
         </svg>
-      </button>
+      </IconButton>
     {/if}
   </div>
   <p class="text-center mt-2 text-[11px] text-slate-500 cursor-default select-none">


### PR DESCRIPTION
## What changed

- add shared Button, IconButton, Field, Badge, AsyncState, and ModalShell primitives
- introduce semantic UI tokens with galaxy, fire, and organic accent palettes
- migrate Canvas editor fields/action and Chat send/stop commands
- improve Canvas editor field layout at mobile breakpoints
- document primitive and theming conventions
- add accessible behavior tests for all six primitives

## Impact

Chat and Canvas begin sharing a consistent accessible control layer without changing their behavior. Future flow migrations can consume semantic variants instead of copying long utility strings.

## Validation

- `pnpm verify`
- `pnpm --filter @flows/ui build`
- UI suite: 47 files / 371 tests
- desktop visual check for Chat and Canvas
- mobile Canvas check at 390x844 with no horizontal overflow
- pre-push `pnpm check`
- pre-push `pnpm test`

Refs #24