### PR TITLE
refactor: polish trading flow boundaries

### DIFF
--- a/packages/flows/trading/README.md
+++ b/packages/flows/trading/README.md
@@ -5,10 +5,22 @@ Trading bot flow — real-time BTC/USDT analysis using Binance WebSocket, fracta
 ## Architecture
 
 ```text
-adapter/    → Binance WebSocket client, candle aggregation
-analysis/   → Hurst exponent, fractal detection, ATR calculation
-advisor/    → AI insight generation (OpenRouter LLM integration)
-routes      → Elysia API routes + SSE streaming (/api/trading/*)
+packages/flows/trading/src/
+├── adapters/binance/       # REST history + WebSocket market-data edge
+├── domain/math/            # Hurst, fractals, candle patterns
+├── domain/types/           # market and advisor domain types
+└── backend/
+    ├── config.ts           # static thresholds + runtime env factory
+    ├── database.ts         # SQLite schema and prepared statements
+    ├── routes.ts           # Elysia HTTP/SSE composition
+    └── services/           # analyst, synthesizer, mentor, stream orchestration
+
+packages/ui/src/lib/flows/trading/
+├── api.ts                  # Eden calls and SSE adapter
+├── stores.svelte.ts        # client runtime state
+├── wizard.ts               # timeframe definitions and pure presentation calculations
+├── TradingFlow.svelte      # dashboard/wizard composition
+└── components/             # StepWizard and CandleChart
 ```
 
 ## Key Features
@@ -40,8 +52,19 @@ services do not read `process.env` directly.
 | POST | `/api/trading/start` | Start candle stream |
 | POST | `/api/trading/stop` | Stop candle stream |
 | GET | `/api/trading/candles` | Historical candles |
+| GET | `/api/trading/candles/live` | Current in-memory candle snapshot |
 | GET | `/api/trading/klines` | Klines for wizard |
 | GET | `/api/trading/fractals` | Detected fractals |
 | POST | `/api/trading/advisor/toggle` | Toggle AI advisor |
+| GET | `/api/trading/advisor/status` | Current advisor state |
+| GET | `/api/trading/insight` | Latest persisted insight |
 | POST | `/api/trading/insight/generate` | Generate insight |
+| POST | `/api/trading/wizard/insight` | Generate one cascade timeframe insight |
 | GET | `/api/trading/stream` | SSE live stream |
+
+## UI Data Flow
+
+The route loader hydrates the initial status, candle window, and latest insight. Runtime
+updates then arrive through the SSE adapter into `stores.svelte.ts`. The Cascade Wizard
+requests historical windows through Eden; `wizard.ts` owns timeframe definitions and
+pure display calculations, while `StepWizard.svelte` owns interaction and rendering.

--- a/packages/flows/trading/src/adapters/binance/binance-rest.ts
+++ b/packages/flows/trading/src/adapters/binance/binance-rest.ts
@@ -6,6 +6,9 @@
  */
 
 import type { Candle } from './types';
+import { logger } from '@flows/core';
+
+const log = logger.child({ module: 'BinanceRestAdapter' });
 
 const BINANCE_REST_BASE = 'https://api.binance.com/api/v3';
 
@@ -44,14 +47,14 @@ export async function fetchKlines(
   url.searchParams.set('interval', interval);
   url.searchParams.set('limit', Math.min(limit, 1000).toString());
 
-  console.log(`[BinanceREST] Fetching ${limit} klines for ${symbol}@${interval}`);
+  log.debug({ symbol, interval, limit }, 'Fetching historical klines');
 
   try {
     const response = await fetch(url.toString());
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error(`[BinanceREST] API error: ${response.status} - ${errorText}`);
+      log.error({ status: response.status, response: errorText }, 'Binance API error');
       throw new Error(`Binance API error: ${response.status}`);
     }
 
@@ -70,10 +73,10 @@ export async function fetchKlines(
       isClosed: true, // Historical klines are always closed
     }));
 
-    console.log(`[BinanceREST] Fetched ${candles.length} klines successfully`);
+    log.debug({ symbol, interval, count: candles.length }, 'Historical klines fetched');
     return candles;
   } catch (error) {
-    console.error(`[BinanceREST] Failed to fetch klines:`, error);
+    log.error({ error }, 'Failed to fetch historical klines');
     throw error;
   }
 }

--- a/packages/flows/trading/src/adapters/binance/binance-stream.ts
+++ b/packages/flows/trading/src/adapters/binance/binance-stream.ts
@@ -1,6 +1,9 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
 import type { BinanceKlinePayload, Candle, ConnectionState } from './types';
+import { logger } from '@flows/core';
+
+const log = logger.child({ module: 'BinanceStreamAdapter' });
 
 const BINANCE_WS_BASE = 'wss://stream.binance.com:9443/ws';
 const RECONNECT_DELAY_MS = 5000;
@@ -12,7 +15,7 @@ const MAX_RECONNECT_ATTEMPTS = 10;
  * Usage:
  * ```ts
  * const stream = new BinanceStream('BTCUSDT', '1m');
- * stream.on('candle', (candle) => console.log(candle));
+ * stream.on('candle', handleCandle);
  * stream.connect();
  * ```
  */
@@ -46,7 +49,7 @@ export class BinanceStream extends EventEmitter {
     const streamName = `${this.symbol.toLowerCase()}@kline_${this.interval}`;
     const url = `${BINANCE_WS_BASE}/${streamName}`;
 
-    console.log(`[BinanceStream] Connecting to ${url}`);
+    log.info({ url }, 'Connecting to Binance stream');
 
     try {
       this.ws = new WebSocket(url);
@@ -54,7 +57,7 @@ export class BinanceStream extends EventEmitter {
       this.ws.on('open', () => {
         this.state = 'connected';
         this.reconnectAttempts = 0;
-        console.log(`[BinanceStream] Connected to ${this.symbol}@${this.interval}`);
+        log.info({ symbol: this.symbol, interval: this.interval }, 'Binance stream connected');
         this.emit('connected');
         this.startPingInterval();
       });
@@ -68,25 +71,25 @@ export class BinanceStream extends EventEmitter {
       });
 
       this.ws.on('close', (code: number, reason: Buffer) => {
-        console.log(`[BinanceStream] Disconnected (code: ${code}, reason: ${reason.toString()})`);
+        log.warn({ code, reason: reason.toString() }, 'Binance stream disconnected');
         this.cleanup();
         this.emit('disconnected');
         this.scheduleReconnect();
       });
 
       this.ws.on('error', (error: Error) => {
-        console.error(`[BinanceStream] Error:`, error.message);
+        log.error({ error: error.message }, 'Binance stream error');
         this.emit('error', error);
       });
     } catch (error) {
-      console.error(`[BinanceStream] Failed to connect:`, error);
+      log.error({ error }, 'Failed to connect to Binance stream');
       this.scheduleReconnect();
     }
   }
 
   /** Disconnect from WebSocket */
   disconnect(): void {
-    console.log(`[BinanceStream] Disconnecting...`);
+    log.info('Disconnecting Binance stream');
     this.cleanup();
     if (this.ws) {
       this.ws.close(1000, 'Manual disconnect');
@@ -119,14 +122,14 @@ export class BinanceStream extends EventEmitter {
         this.emit('candle', candle);
       }
     } catch (error) {
-      console.error(`[BinanceStream] Failed to parse message:`, error);
+      log.error({ error }, 'Failed to parse Binance stream message');
     }
   }
 
   /** Schedule reconnection with exponential backoff */
   private scheduleReconnect(): void {
     if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-      console.error(`[BinanceStream] Max reconnection attempts reached. Giving up.`);
+      log.error({ attempts: this.reconnectAttempts }, 'Binance stream reconnect limit reached');
       this.state = 'disconnected';
       return;
     }
@@ -135,8 +138,9 @@ export class BinanceStream extends EventEmitter {
     const delay = RECONNECT_DELAY_MS * Math.pow(2, this.reconnectAttempts);
     this.reconnectAttempts++;
 
-    console.log(
-      `[BinanceStream] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`,
+    log.warn(
+      { delay, attempt: this.reconnectAttempts, maxAttempts: MAX_RECONNECT_ATTEMPTS },
+      'Scheduling Binance stream reconnect',
     );
 
     this.reconnectTimeout = setTimeout(() => {

--- a/packages/ui/src/lib/client-logger.ts
+++ b/packages/ui/src/lib/client-logger.ts
@@ -1,0 +1,16 @@
+type LogContext = Record<string, unknown>;
+
+function write(method: 'debug' | 'error', message: string, context?: LogContext): void {
+  if (method === 'debug' && !import.meta.env.DEV) return;
+  const payload = context ? [message, context] : [message];
+  console[method](...payload);
+}
+
+export const clientLogger = {
+  debug(message: string, context?: LogContext): void {
+    write('debug', message, context);
+  },
+  error(message: string, context?: LogContext): void {
+    write('error', message, context);
+  },
+};

--- a/packages/ui/src/lib/flows/trading/TradingFlow.svelte
+++ b/packages/ui/src/lib/flows/trading/TradingFlow.svelte
@@ -197,10 +197,6 @@
             interval,
             limit
           ) => {
-            console.log(
-              `[Wizard] Generating ${stepLabel} insight via wizard endpoint (${interval}, ${limit} candles)`
-            );
-
             const result = await generateWizardInsight({
               interval,
               limit,
@@ -210,7 +206,6 @@
             });
 
             if (result) {
-              console.log(`[Wizard] ${stepLabel} insight received:`, result.meta);
               return { insight: result.insight, analysis: result.analysis };
             }
             return null;

--- a/packages/ui/src/lib/flows/trading/api.ts
+++ b/packages/ui/src/lib/flows/trading/api.ts
@@ -1,6 +1,7 @@
 // Trading Flow API Functions
 import { showError, showSuccess } from '@lib/toast';
 import { api } from '@lib/client';
+import { clientLogger } from '@lib/client-logger';
 import type { Candle, AdvisorNote } from '@flows/shared';
 import { tradingStore } from './stores.svelte';
 import type {
@@ -10,6 +11,7 @@ import type {
   FractalsResponse,
   AdvisorToggleResponse,
   InsightResponse,
+  WizardAnalysis,
   WizardInsightResponse,
 } from './types';
 
@@ -21,7 +23,7 @@ export async function fetchTradingStatus(): Promise<void> {
     if (result.trading) tradingStore.setTradingState(result.trading);
     if (result.advisor) tradingStore.setAdvisorState(result.advisor);
   } catch (error) {
-    console.error('[TradingFlow] Status fetch failed:', error);
+    clientLogger.error('Trading status fetch failed', { error });
   }
 }
 
@@ -39,7 +41,7 @@ export async function startTrading(): Promise<void> {
     await fetchTradingStatus();
   } catch (error) {
     showError('Failed to start trading stream');
-    console.error(error);
+    clientLogger.error('Trading stream start failed', { error });
   }
 }
 
@@ -57,7 +59,7 @@ export async function stopTrading(): Promise<void> {
     await fetchTradingStatus();
   } catch (error) {
     showError('Failed to stop trading stream');
-    console.error(error);
+    clientLogger.error('Trading stream stop failed', { error });
   }
 }
 
@@ -70,7 +72,7 @@ export async function fetchCandles(limit: number = 100): Promise<void> {
     const result = data as unknown as CandlesResponse;
     tradingStore.setCandles(result.candles || []);
   } catch (error) {
-    console.error('[TradingFlow] Candles fetch failed:', error);
+    clientLogger.error('Trading candles fetch failed', { error });
   }
 }
 
@@ -83,7 +85,7 @@ export async function fetchFractals(limit: number = 50): Promise<void> {
     const result = data as unknown as FractalsResponse;
     tradingStore.setFractals(result.nodes || []);
   } catch (error) {
-    console.error('[TradingFlow] Fractals fetch failed:', error);
+    clientLogger.error('Trading fractals fetch failed', { error });
   }
 }
 
@@ -102,7 +104,7 @@ export async function fetchKlines(interval: string, limit: number = 100): Promis
     const result = data as unknown as CandlesResponse;
     return result.candles || [];
   } catch (error) {
-    console.error('[TradingFlow] Klines fetch failed:', error);
+    clientLogger.error('Trading klines fetch failed', { error });
     return [];
   }
 }
@@ -116,7 +118,7 @@ export async function toggleAdvisor(): Promise<void> {
     showSuccess(result.message);
   } catch (error) {
     showError('Failed to toggle advisor');
-    console.error(error);
+    clientLogger.error('Trading advisor toggle failed', { error });
   }
 }
 
@@ -136,7 +138,7 @@ export async function generateInsight(): Promise<void> {
     }
   } catch (error) {
     showError('Failed to generate insight');
-    console.error(error);
+    clientLogger.error('Trading insight generation failed', { error });
   } finally {
     tradingStore.setLoadingInsight(false);
   }
@@ -153,7 +155,7 @@ export async function generateWizardInsight(params: {
   previousInsights: { label: string; insight: AdvisorNote }[];
 }): Promise<{
   insight: AdvisorNote;
-  analysis: Record<string, unknown>;
+  analysis: WizardAnalysis;
   meta: Record<string, unknown>;
 } | null> {
   try {
@@ -172,7 +174,7 @@ export async function generateWizardInsight(params: {
     }
   } catch (error) {
     showError('Failed to generate wizard insight');
-    console.error('[TradingFlow] Wizard insight failed:', error);
+    clientLogger.error('Trading wizard insight failed', { error });
     return null;
   }
 }
@@ -188,7 +190,7 @@ export async function fetchLatestInsight(): Promise<void> {
       tradingStore.setLatestInsight(insight);
     }
   } catch (error) {
-    console.error('[TradingFlow] Insight fetch failed:', error);
+    clientLogger.error('Trading insight fetch failed', { error });
   }
 }
 
@@ -222,7 +224,7 @@ export function connectToStream(): void {
   });
 
   eventSource.onerror = () => {
-    console.error('[TradingFlow] SSE connection error');
+    clientLogger.error('Trading SSE connection failed');
     disconnectFromStream();
   };
 }

--- a/packages/ui/src/lib/flows/trading/components/StepWizard.svelte
+++ b/packages/ui/src/lib/flows/trading/components/StepWizard.svelte
@@ -1,94 +1,9 @@
 <script lang="ts">
   import CandleChart from './CandleChart.svelte';
   import type { Candle, AdvisorNote } from '../trading';
-
-  interface TimeframeStep {
-    id: number;
-    label: string;
-    interval: string;
-    focus: string;
-    icon: string;
-    candleLimit: number;
-    promptContext: string;
-  }
-
-  const STEPS: TimeframeStep[] = [
-    {
-      id: 1,
-      label: '1D',
-      interval: '1d', // Daily candles over ~10 months
-      focus: 'Daily Candles',
-      icon: '🌍',
-      candleLimit: 300, // ~10 months of daily candles
-      promptContext:
-        'Analyze the last 10 MONTHS of price action using DAILY candles to determine the overall market bias. Is this a trending or ranging market? What is the dominant direction? Identify key support/resistance zones visible at this macro scale.',
-    },
-    {
-      id: 2,
-      label: '4H',
-      interval: '4h', // 4-hour candles over ~1 month
-      focus: '4-Hour Candles',
-      icon: '🏗️',
-      candleLimit: 180, // 30 days × 6 candles/day = 180
-      promptContext:
-        'Analyze the last MONTH using 4-HOUR candles to identify key structural levels. Where are the major support and resistance zones? Are there any structural shifts (higher highs/lows or lower highs/lows)?',
-    },
-    {
-      id: 3,
-      label: '1H',
-      interval: '1h', // Hourly candles over ~1 month
-      focus: 'Hourly Candles',
-      icon: '🎯',
-      candleLimit: 720, // 30 days × 24 candles/day = 720
-      promptContext:
-        'Analyze the last MONTH using HOURLY candles to look for trade setups. Are there any candlestick patterns forming? Is price approaching a key level where a reaction is likely? What is the short-term trend direction?',
-    },
-    {
-      id: 4,
-      label: '15m',
-      interval: '15m', // 15-minute candles (~10 days due to Binance 1000 limit)
-      focus: '15-Min Candles',
-      icon: '⚡',
-      candleLimit: 1000, // 30 days × 96/day = 2880, capped at 1000 (~10 days)
-      promptContext:
-        'Analyze the most recent price action using 15-MINUTE candles for entry timing. What is the immediate price action? Where would be the optimal entry point and stop loss? Look for micro-patterns and momentum signals.',
-    },
-  ];
-
-  interface RegimeAnalysis {
-    classification: string;
-    hurst_exponent: number;
-    fractal_dimension: number;
-  }
-
-  interface FractalStructure {
-    nearest_resistance: string | number;
-    distance_to_resistance: string;
-    nearest_support: string | number;
-    distance_to_support: string;
-    support_touch_count: number;
-    resistance_touch_count: number;
-  }
-
-  interface Indicators {
-    rsi?: string;
-    macd?: {
-      histogram: string;
-      bias: string;
-    };
-  }
-
-  interface WizardAnalysis {
-    regime_analysis?: RegimeAnalysis;
-    fractal_structure?: FractalStructure;
-    indicators?: Indicators;
-    candle_patterns?: string[];
-  }
-
-  interface WizardInsightResult {
-    insight: AdvisorNote;
-    analysis: WizardAnalysis;
-  }
+  import type { WizardAnalysis, WizardInsightViewModel } from '../types';
+  import { calculateWizardMetrics, formatCompactVolume, TRADING_WIZARD_STEPS } from '../wizard';
+  import { clientLogger } from '@lib/client-logger';
 
   interface Props {
     onFetchKlines: (interval: string, limit: number) => Promise<Candle[]>;
@@ -98,7 +13,7 @@
       previousInsights: { label: string; insight: AdvisorNote }[],
       interval: string,
       limit: number
-    ) => Promise<WizardInsightResult | null>;
+    ) => Promise<WizardInsightViewModel | null>;
   }
 
   let { onFetchKlines, onGenerateInsightForTimeframe }: Props = $props();
@@ -113,17 +28,18 @@
   // Per-step analysis data (from backend computation)
   let stepAnalysis: Record<string, WizardAnalysis> = $state({});
 
-  const activeStep = $derived(STEPS[currentStep]);
-  const canGoNext = $derived(currentStep < STEPS.length - 1);
+  const activeStep = $derived(TRADING_WIZARD_STEPS[currentStep]);
+  const canGoNext = $derived(currentStep < TRADING_WIZARD_STEPS.length - 1);
   const canGoPrev = $derived(currentStep > 0);
   const currentInsight = $derived(stepInsights[activeStep.label] || null);
+  const metrics = $derived(calculateWizardMetrics(candles));
 
   async function loadStepData() {
     isLoadingCandles = true;
     try {
       candles = await onFetchKlines(activeStep.interval, activeStep.candleLimit);
     } catch (error) {
-      console.error('Failed to fetch klines:', error);
+      clientLogger.error('Trading wizard failed to fetch klines', { error });
       candles = [];
     } finally {
       isLoadingCandles = false;
@@ -138,16 +54,17 @@
       // MATRIOSHKA: Collect insights from all previous steps
       const previousInsights: { label: string; insight: AdvisorNote }[] = [];
       for (let i = 0; i < currentStep; i++) {
-        const step = STEPS[i];
+        const step = TRADING_WIZARD_STEPS[i];
         const insight = stepInsights[step.label];
         if (insight) {
           previousInsights.push({ label: step.label, insight });
         }
       }
 
-      console.log(
-        `[Wizard Matrioshka] Step ${activeStep.label} has ${previousInsights.length} previous insights`
-      );
+      clientLogger.debug('Trading wizard assembled cascade context', {
+        step: activeStep.label,
+        previousInsightCount: previousInsights.length,
+      });
 
       const result = await onGenerateInsightForTimeframe(
         activeStep.label,
@@ -161,7 +78,7 @@
         stepAnalysis[activeStep.label] = result.analysis;
       }
     } catch (error) {
-      console.error('Failed to generate insight:', error);
+      clientLogger.error('Trading wizard failed to generate insight', { error });
     } finally {
       isLoadingInsight = false;
     }
@@ -182,7 +99,7 @@
   }
 
   async function goToStep(stepIndex: number) {
-    if (stepIndex >= 0 && stepIndex < STEPS.length) {
+    if (stepIndex >= 0 && stepIndex < TRADING_WIZARD_STEPS.length) {
       currentStep = stepIndex;
       await loadStepData();
     }
@@ -197,7 +114,7 @@
 <div class="space-y-6">
   <!-- Step Navigation -->
   <div class="flex items-center justify-center gap-2 flex-wrap">
-    {#each STEPS as step, index (step.id)}
+    {#each TRADING_WIZARD_STEPS as step, index (step.id)}
       <button
         onclick={() => goToStep(index)}
         class="relative flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-300
@@ -213,7 +130,7 @@
           <span class="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full"></span>
         {/if}
       </button>
-      {#if index < STEPS.length - 1}
+      {#if index < TRADING_WIZARD_STEPS.length - 1}
         <span class="text-white/20 hidden md:inline">→</span>
       {/if}
     {/each}
@@ -249,25 +166,7 @@
       <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider mb-3">
         📊 Metrics ({activeStep.label})
       </h4>
-      {#if candles.length > 0}
-        {@const firstCandle = candles[0]}
-        {@const lastCandle = candles[candles.length - 1]}
-        {@const highMax = Math.max(...candles.map((c) => c.high))}
-        {@const lowMin = Math.min(...candles.map((c) => c.low))}
-        {@const priceChange = ((lastCandle.close - firstCandle.open) / firstCandle.open) * 100}
-        {@const volatility = ((highMax - lowMin) / lastCandle.close) * 100}
-        {@const totalVolume = candles.reduce((sum, c) => sum + c.volume, 0)}
-        {@const dateFrom = new Date(firstCandle.openTime).toLocaleDateString('es-AR', {
-          day: '2-digit',
-          month: 'short',
-          year: '2-digit',
-        })}
-        {@const dateTo = new Date(lastCandle.closeTime).toLocaleDateString('es-AR', {
-          day: '2-digit',
-          month: 'short',
-          year: '2-digit',
-        })}
-
+      {#if metrics}
         <div class="grid grid-cols-2 gap-3 text-sm">
           <!-- Fetched data -->
           <div
@@ -276,11 +175,11 @@
             <span class="px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 font-semibold"
               >📡 Fetched</span
             >
-            <span>{dateFrom} → {dateTo}</span>
+            <span>{metrics.dateFrom} → {metrics.dateTo}</span>
           </div>
           <div>
             <span class="text-white/50">Velas:</span>
-            <span class="font-bold text-white">{candles.length}</span>
+            <span class="font-bold text-white">{metrics.candleCount}</span>
           </div>
           <div>
             <span class="text-white/50">Intervalo:</span>
@@ -289,16 +188,12 @@
           <div>
             <span class="text-white/50">Último:</span>
             <span class="font-bold text-amber-400">
-              ${lastCandle.close.toLocaleString()}
+              ${metrics.last.toLocaleString()}
             </span>
           </div>
           <div>
             <span class="text-white/50">Volumen Total:</span>
-            <span class="font-bold text-white"
-              >{totalVolume >= 1000
-                ? (totalVolume / 1000).toFixed(1) + 'K'
-                : totalVolume.toFixed(1)}</span
-            >
+            <span class="font-bold text-white">{formatCompactVolume(metrics.totalVolume)}</span>
           </div>
 
           <!-- Calculated data -->
@@ -312,24 +207,28 @@
           <div>
             <span class="text-white/50">High:</span>
             <span class="font-bold text-green-400">
-              ${highMax.toLocaleString()}
+              ${metrics.high.toLocaleString()}
             </span>
           </div>
           <div>
             <span class="text-white/50">Low:</span>
             <span class="font-bold text-red-400">
-              ${lowMin.toLocaleString()}
+              ${metrics.low.toLocaleString()}
             </span>
           </div>
           <div>
             <span class="text-white/50">Variación:</span>
-            <span class="font-bold {priceChange >= 0 ? 'text-green-400' : 'text-red-400'}">
-              {priceChange >= 0 ? '+' : ''}{priceChange.toFixed(2)}%
+            <span
+              class="font-bold {metrics.priceChangePercent >= 0
+                ? 'text-green-400'
+                : 'text-red-400'}"
+            >
+              {metrics.priceChangePercent >= 0 ? '+' : ''}{metrics.priceChangePercent.toFixed(2)}%
             </span>
           </div>
           <div>
             <span class="text-white/50">Volatilidad:</span>
-            <span class="font-bold text-orange-400">{volatility.toFixed(2)}%</span>
+            <span class="font-bold text-orange-400">{metrics.volatilityPercent.toFixed(2)}%</span>
           </div>
         </div>
       {:else}
@@ -517,7 +416,7 @@
     </button>
 
     <span class="text-white/40 text-sm">
-      Step {currentStep + 1} of {STEPS.length}
+      Step {currentStep + 1} of {TRADING_WIZARD_STEPS.length}
     </span>
 
     <button

--- a/packages/ui/src/lib/flows/trading/types.ts
+++ b/packages/ui/src/lib/flows/trading/types.ts
@@ -34,9 +34,35 @@ export interface InsightResponse {
 export interface WizardInsightResponse {
   success: boolean;
   insight?: AdvisorNote;
-  analysis?: Record<string, unknown>;
+  analysis?: WizardAnalysis;
   meta?: Record<string, unknown>;
   error?: string;
+}
+
+export interface WizardAnalysis {
+  regime_analysis?: {
+    classification: string;
+    hurst_exponent: number;
+    fractal_dimension: number;
+  };
+  fractal_structure?: {
+    nearest_resistance: string | number;
+    distance_to_resistance: string;
+    nearest_support: string | number;
+    distance_to_support: string;
+    support_touch_count: number;
+    resistance_touch_count: number;
+  };
+  indicators?: {
+    rsi?: string;
+    macd?: { histogram: string; bias: string };
+  };
+  candle_patterns?: string[];
+}
+
+export interface WizardInsightViewModel {
+  insight: AdvisorNote;
+  analysis: WizardAnalysis;
 }
 
 /**

--- a/packages/ui/src/lib/flows/trading/wizard.test.ts
+++ b/packages/ui/src/lib/flows/trading/wizard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { Candle } from '@flows/shared';
+import { calculateWizardMetrics, formatCompactVolume, TRADING_WIZARD_STEPS } from './wizard';
+
+const candle = (overrides: Partial<Candle> = {}): Candle => ({
+  symbol: 'BTCUSDT',
+  interval: '1d',
+  openTime: 1_700_000_000_000,
+  closeTime: 1_700_086_400_000,
+  open: 100,
+  high: 120,
+  low: 80,
+  close: 110,
+  volume: 1500,
+  isClosed: true,
+  ...overrides,
+});
+
+describe('trading wizard presenter', () => {
+  it('keeps the cascade steps ordered from macro to entry timing', () => {
+    expect(TRADING_WIZARD_STEPS.map((step) => step.interval)).toEqual(['1d', '4h', '1h', '15m']);
+    expect(TRADING_WIZARD_STEPS.map((step) => step.candleLimit)).toEqual([300, 180, 720, 1000]);
+  });
+
+  it('calculates view metrics from a candle window', () => {
+    const result = calculateWizardMetrics([
+      candle(),
+      candle({ openTime: 1_700_086_400_000, close: 132, high: 140, low: 105, volume: 2500 }),
+    ]);
+    expect(result).toMatchObject({
+      candleCount: 2,
+      high: 140,
+      low: 80,
+      last: 132,
+      priceChangePercent: 32,
+      totalVolume: 4000,
+    });
+  });
+
+  it('returns no metrics for an empty window and formats volume consistently', () => {
+    expect(calculateWizardMetrics([])).toBeNull();
+    expect(formatCompactVolume(4000)).toBe('4.0K');
+    expect(formatCompactVolume(25)).toBe('25.0');
+  });
+});

--- a/packages/ui/src/lib/flows/trading/wizard.ts
+++ b/packages/ui/src/lib/flows/trading/wizard.ts
@@ -1,0 +1,96 @@
+import type { Candle } from '@flows/shared';
+
+export interface TimeframeStep {
+  id: number;
+  label: string;
+  interval: string;
+  focus: string;
+  icon: string;
+  candleLimit: number;
+  promptContext: string;
+}
+
+export interface WizardMetrics {
+  candleCount: number;
+  dateFrom: string;
+  dateTo: string;
+  high: number;
+  low: number;
+  last: number;
+  priceChangePercent: number;
+  volatilityPercent: number;
+  totalVolume: number;
+}
+
+export const TRADING_WIZARD_STEPS: readonly TimeframeStep[] = [
+  {
+    id: 1,
+    label: '1D',
+    interval: '1d',
+    focus: 'Daily Candles',
+    icon: '🌍',
+    candleLimit: 300,
+    promptContext:
+      'Analyze the last 10 MONTHS of price action using DAILY candles to determine the overall market bias. Is this a trending or ranging market? What is the dominant direction? Identify key support/resistance zones visible at this macro scale.',
+  },
+  {
+    id: 2,
+    label: '4H',
+    interval: '4h',
+    focus: '4-Hour Candles',
+    icon: '🏗️',
+    candleLimit: 180,
+    promptContext:
+      'Analyze the last MONTH using 4-HOUR candles to identify key structural levels. Where are the major support and resistance zones? Are there any structural shifts (higher highs/lows or lower highs/lows)?',
+  },
+  {
+    id: 3,
+    label: '1H',
+    interval: '1h',
+    focus: 'Hourly Candles',
+    icon: '🎯',
+    candleLimit: 720,
+    promptContext:
+      'Analyze the last MONTH using HOURLY candles to look for trade setups. Are there any candlestick patterns forming? Is price approaching a key level where a reaction is likely? What is the short-term trend direction?',
+  },
+  {
+    id: 4,
+    label: '15m',
+    interval: '15m',
+    focus: '15-Min Candles',
+    icon: '⚡',
+    candleLimit: 1000,
+    promptContext:
+      'Analyze the most recent price action using 15-MINUTE candles for entry timing. What is the immediate price action? Where would be the optimal entry point and stop loss? Look for micro-patterns and momentum signals.',
+  },
+];
+
+const DATE_FORMAT = new Intl.DateTimeFormat('es-AR', {
+  day: '2-digit',
+  month: 'short',
+  year: '2-digit',
+});
+
+export function calculateWizardMetrics(candles: Candle[]): WizardMetrics | null {
+  if (candles.length === 0) return null;
+  const first = candles[0];
+  const last = candles[candles.length - 1];
+  const high = Math.max(...candles.map((candle) => candle.high));
+  const low = Math.min(...candles.map((candle) => candle.low));
+
+  return {
+    candleCount: candles.length,
+    dateFrom: DATE_FORMAT.format(first.openTime),
+    dateTo: DATE_FORMAT.format(last.closeTime),
+    high,
+    low,
+    last: last.close,
+    priceChangePercent: ((last.close - first.open) / first.open) * 100,
+    volatilityPercent: ((high - low) / last.close) * 100,
+    totalVolume: candles.reduce((sum, candle) => sum + candle.volume, 0),
+  };
+}
+
+export function formatCompactVolume(value: number): string {
+  return value >= 1000 ? `${(value / 1000).toFixed(1)}K` : value.toFixed(1);
+}

--- a/packages/ui/src/routes/trading/+page.ts
+++ b/packages/ui/src/routes/trading/+page.ts
@@ -13,6 +13,7 @@ import type {
   TradingPageData,
 } from '@lib/flows/trading/types';
 import type { PageLoad } from './$types';
+import { clientLogger } from '@lib/client-logger';
 
 // SPA only — SSR is disabled (also set globally in the root +layout.ts).
 export const ssr = false;
@@ -27,7 +28,7 @@ async function loadStatus(): Promise<Pick<TradingPageData, 'trading' | 'advisor'
       advisor: result.advisor ?? null,
     };
   } catch (err) {
-    console.error('[TradingFlow] Status load failed:', err);
+    clientLogger.error('Trading status loader failed', { error: err });
     return { trading: null, advisor: null };
   }
 }
@@ -41,7 +42,7 @@ async function loadCandles(limit: number): Promise<TradingPageData['candles']> {
     const result = data as unknown as CandlesResponse;
     return result.candles ?? [];
   } catch (err) {
-    console.error('[TradingFlow] Candles load failed:', err);
+    clientLogger.error('Trading candles loader failed', { error: err });
     return [];
   }
 }
@@ -56,7 +57,7 @@ async function loadInsight(): Promise<TradingPageData['insight']> {
     if (result.debugContext) insight._debugContext = result.debugContext;
     return insight;
   } catch (err) {
-    console.error('[TradingFlow] Insight load failed:', err);
+    clientLogger.error('Trading insight loader failed', { error: err });
     return null;
   }
 }


### PR DESCRIPTION
## What changed

- extract Cascade Wizard timeframe definitions and presentation calculations into a pure presenter
- add explicit WizardAnalysis and WizardInsightViewModel contracts
- replace Trading console calls with structured backend and client logger adapters
- remove debug-only logging from TradingFlow composition
- update the Trading README with current backend/UI ownership and complete API map
- add focused presenter tests for step order, metrics, empty windows, and volume formatting

## Impact

Trading behavior and prompts are unchanged. StepWizard is smaller, calculations are independently testable, and runtime logs now carry structured context.

## Validation

- `pnpm verify`
- `pnpm build`
- Trading backend: 134 tests
- UI: 48 files / 374 tests
- svelte-check: 0 errors / 0 warnings
- pre-push `pnpm check`
- pre-push `pnpm test`

Closes #26