### PR TITLE
refactor: migrate spotify ui primitives

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -54,7 +54,8 @@ component is justified when it owns domain behavior, not merely different colors
 
 ## Migration Status
 
-Canvas editor controls and Chat send/stop actions use the shared primitives. Remaining
-flows and the application shell should migrate in small PRs under issue #24. Legacy
+Canvas editor controls, Chat send/stop actions, and Spotify controls use the shared
+primitives. Remaining flows and the application shell should migrate in small PRs under
+issue #24. Legacy
 cosmic/glass utilities remain in `app.css`; removing or consolidating them is part of that
 migration, not documentation housekeeping.

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -315,6 +315,10 @@ body::after {
 .ui-field__control::placeholder {
   color: var(--ui-text-muted);
 }
+.ui-select {
+  cursor: pointer;
+  appearance: auto;
+}
 .ui-field__control--mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }

--- a/packages/ui/src/lib/components/ui/Button.svelte
+++ b/packages/ui/src/lib/components/ui/Button.svelte
@@ -4,6 +4,8 @@
 
   interface Props extends HTMLButtonAttributes {
     children: Snippet;
+    href?: string;
+    rel?: string;
     variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
     size?: 'sm' | 'md' | 'lg';
     loading?: boolean;
@@ -11,6 +13,8 @@
 
   let {
     children,
+    href,
+    rel,
     variant = 'primary',
     size = 'md',
     loading = false,
@@ -21,13 +25,27 @@
   }: Props = $props();
 </script>
 
-<button
-  {type}
-  class="ui-button ui-button--{variant} ui-button--{size} {className}"
-  disabled={disabled || loading}
-  aria-busy={loading}
-  {...rest}
->
-  {#if loading}<span class="ui-button__spinner" aria-hidden="true"></span>{/if}
-  {@render children()}
-</button>
+{#if href}
+  <a
+    {href}
+    {rel}
+    class="ui-button ui-button--{variant} ui-button--{size} {className}"
+    aria-busy={loading}
+    aria-disabled={disabled || loading}
+    title={rest.title}
+  >
+    {#if loading}<span class="ui-button__spinner" aria-hidden="true"></span>{/if}
+    {@render children()}
+  </a>
+{:else}
+  <button
+    {type}
+    class="ui-button ui-button--{variant} ui-button--{size} {className}"
+    disabled={disabled || loading}
+    aria-busy={loading}
+    {...rest}
+  >
+    {#if loading}<span class="ui-button__spinner" aria-hidden="true"></span>{/if}
+    {@render children()}
+  </button>
+{/if}

--- a/packages/ui/src/lib/components/ui/Field.svelte
+++ b/packages/ui/src/lib/components/ui/Field.svelte
@@ -2,7 +2,10 @@
   let {
     value = $bindable(''),
     label,
+    labelHidden = false,
     placeholder = '',
+    type = 'text',
+    oninput,
     multiline = false,
     rows = 4,
     disabled = false,
@@ -12,7 +15,10 @@
   }: {
     value?: string;
     label?: string;
+    labelHidden?: boolean;
     placeholder?: string;
+    type?: 'text' | 'search';
+    oninput?: (event: Event) => void;
     multiline?: boolean;
     rows?: number;
     disabled?: boolean;
@@ -25,7 +31,7 @@
 </script>
 
 <label class="ui-field {className}" for={id}>
-  {#if label}<span class="ui-field__label">{label}</span>{/if}
+  {#if label}<span class:sr-only={labelHidden} class="ui-field__label">{label}</span>{/if}
   {#if multiline}
     <textarea
       {id}
@@ -40,7 +46,9 @@
   {:else}
     <input
       {id}
+      {type}
       bind:value
+      {oninput}
       {placeholder}
       {disabled}
       {required}

--- a/packages/ui/src/lib/components/ui/ui.test.ts
+++ b/packages/ui/src/lib/components/ui/ui.test.ts
@@ -18,6 +18,11 @@ describe('UI primitives', () => {
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
+  it('Button renders navigation as a styled link', () => {
+    render(Button, { props: { children: textSnippet('Connect'), href: '/connect' } });
+    expect(screen.getByRole('link', { name: 'Connect' })).toHaveAttribute('href', '/connect');
+  });
+
   it('IconButton uses its label as the accessible name', async () => {
     const onclick = vi.fn();
     render(IconButton, { props: { label: 'Delete', children: textSnippet('×'), onclick } });
@@ -31,6 +36,13 @@ describe('UI primitives', () => {
     unmount();
     render(Field, { props: { label: 'Body', multiline: true, value: 'Text' } });
     expect(screen.getByLabelText('Body').tagName).toBe('TEXTAREA');
+  });
+
+  it('Field supports an accessible search control', () => {
+    render(Field, {
+      props: { label: 'Search library', labelHidden: true, type: 'search', value: '' },
+    });
+    expect(screen.getByRole('searchbox', { name: 'Search library' })).toBeInTheDocument();
   });
 
   it('Badge exposes the selected semantic tone', () => {

--- a/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte
+++ b/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import Controls from './components/Controls.svelte';
-  import TrackCard from './components/TrackCard.svelte';
-  import SearchBar from './components/SearchBar.svelte';
-  import FilterPanel from './components/FilterPanel.svelte';
+  import { toast } from 'svelte-5-french-toast';
+  import type { GenreCount, SearchOptions, Track, YearCount } from '@flows/shared';
+  import { AsyncState, Button, FlowLayout } from '@lib/components';
   import InfiniteScroll from '@lib/components/common/InfiniteScroll.svelte';
-  import { FlowLayout } from '@lib/components';
-  import SpotifyHeader from './components/SpotifyHeader.svelte';
-  import InsightsPanel from './components/InsightsPanel.svelte';
-  import { spotifyStore } from './stores.svelte';
-  import { loadTracks } from './api';
-  import type { GenreCount, Track, SearchOptions, YearCount } from '@flows/shared';
   import type { TopStats } from '@lib/types';
+  import { loadTracks } from './api';
+  import Controls from './components/Controls.svelte';
+  import FilterPanel from './components/FilterPanel.svelte';
+  import InsightsPanel from './components/InsightsPanel.svelte';
+  import SearchBar from './components/SearchBar.svelte';
+  import SpotifyHeader from './components/SpotifyHeader.svelte';
+  import TrackCard from './components/TrackCard.svelte';
+  import { spotifyStore } from './stores.svelte';
 
   interface Props {
     tracks?: Track[];
@@ -33,11 +34,6 @@
     isAuthenticated,
   }: Props = $props();
 
-  // Page title
-  const pageTitle = 'Spotify Flow - Your Music Library';
-
-  import { toast } from 'svelte-5-french-toast';
-
   $effect(() => {
     if (tracks !== undefined) spotifyStore.tracks = tracks;
     if (totalTracks !== undefined) spotifyStore.totalTracks = totalTracks;
@@ -47,84 +43,74 @@
   });
 
   onMount(() => {
-    // Check for success redirect
     const url = new URL(window.location.href);
     if (url.searchParams.get('connected') === 'true') {
       toast.success('Successfully connected to Spotify!', {
         position: 'bottom-right',
         className: 'glass text-cosmic font-medium',
       });
-      // Clean up URL
       url.searchParams.delete('connected');
       window.history.replaceState({}, '', url.toString());
     }
   });
 
   function handleLoadMore() {
-    const nextPage = (spotifyStore.searchOptions.page || 1) + 1;
-    loadTracks({ page: nextPage }, true);
+    loadTracks({ page: (spotifyStore.searchOptions.page || 1) + 1 }, true);
+  }
+
+  function clearFilters() {
+    loadTracks({
+      page: 1,
+      limit: 24,
+      q: '',
+      genre: undefined,
+      year: undefined,
+      sortBy: 'added_at',
+      sortOrder: 'desc',
+    });
   }
 </script>
 
 <svelte:head>
-  <title>{pageTitle}</title>
+  <title>Spotify Flow - Your Music Library</title>
 </svelte:head>
 
 <FlowLayout>
-  <div class="flex flex-col gap-6">
-    <!-- Header -->
+  <div class="flex flex-col gap-6" data-theme="organic">
     <SpotifyHeader stats={spotifyStore.topStats} />
-
-    <!-- Insights Section -->
     <InsightsPanel stats={spotifyStore.topStats} />
 
-    <!-- Controls -->
-    <div class="flex items-center">
-      <Controls />
-    </div>
+    <div class="flex items-center"><Controls /></div>
 
-    <!-- Filters Toolbar -->
     <div
-      class="glass p-4 flex flex-col md:flex-row gap-4 items-center justify-between sticky top-4 z-10"
+      class="glass sticky top-4 z-10 flex flex-col items-center justify-between gap-4 p-4 md:flex-row"
     >
-      <div class="flex-grow w-full md:w-auto">
-        <SearchBar />
-      </div>
-      <div class="flex gap-2 w-full md:w-auto">
-        <FilterPanel {genres} {years} />
-      </div>
+      <div class="w-full flex-grow md:w-auto"><SearchBar /></div>
+      <div class="flex w-full gap-2 md:w-auto"><FilterPanel {genres} {years} /></div>
     </div>
 
-    <!-- Track Grid -->
-    <section
-      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 min-h-[50vh]"
-    >
+    <section class="min-h-[50vh]" aria-label="Spotify tracks">
       {#if spotifyStore.isLoading && spotifyStore.tracks.length === 0}
-        <!-- Loading Skeleton -->
-        {#each [0, 1, 2, 3, 4, 5, 6, 7] as i (i)}
-          <div class="glass h-48 skeleton"></div>
-        {/each}
+        <AsyncState state="loading" title="Loading your library" />
+      {:else if spotifyStore.tracks.length === 0}
+        {#snippet clearFiltersAction()}
+          <Button variant="secondary" onclick={clearFilters}>Clear all filters</Button>
+        {/snippet}
+        <AsyncState
+          state="empty"
+          title="No tracks found"
+          message="Try clearing the current search and filters."
+          action={clearFiltersAction}
+        />
       {:else}
-        {#each spotifyStore.tracks as track (track.id)}
-          <TrackCard {track} />
-        {:else}
-          {#if !spotifyStore.isLoading}
-            <div class="col-span-full py-16 text-center">
-              <div class="text-5xl mb-4 opacity-30">🔍</div>
-              <p class="text-white/50">No tracks found matching your filters.</p>
-              <button
-                class="mt-4 text-aurora hover:opacity-80 underline transition-opacity"
-                onclick={() => loadTracks({ page: 1, limit: 24 })}
-              >
-                Clear all filters
-              </button>
-            </div>
-          {/if}
-        {/each}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {#each spotifyStore.tracks as track (track.id)}
+            <TrackCard {track} />
+          {/each}
+        </div>
       {/if}
     </section>
 
-    <!-- Infinite Scroll Trigger -->
     {#if spotifyStore.tracks.length > 0}
       <InfiniteScroll
         hasMore={spotifyStore.tracks.length < spotifyStore.totalTracks}
@@ -133,9 +119,6 @@
       />
     {/if}
 
-    <!-- Footer -->
-    <footer class="text-center text-white/20 text-sm mt-12 pb-8">
-      Cosmic Flow — Spotify Edition
-    </footer>
+    <footer class="mt-12 pb-8 text-center text-sm text-white/20">Flow Sample - Spotify</footer>
   </div>
 </FlowLayout>

--- a/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte.test.ts
+++ b/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 import type { Track, SearchOptions } from '@flows/shared';
 import type { TopStats } from '@lib/types';
@@ -111,24 +111,39 @@ describe('SpotifyFlow render states', () => {
     render(SpotifyFlow, { props: props() });
 
     expect(screen.getByRole('heading', { name: 'Spotify Flow' })).toBeInTheDocument();
-    expect(screen.getByText('Cosmic Flow — Spotify Edition')).toBeInTheDocument();
+    expect(screen.getByText('Flow Sample - Spotify')).toBeInTheDocument();
   });
 
-  it('shows loading skeletons when loading with no tracks yet', () => {
+  it('shows the shared loading state when loading with no tracks yet', () => {
     // Drive the loading state via the runes store before render (no tracks yet).
     spotifyStore.isLoading = true;
-    const { container } = render(SpotifyFlow, { props: props() });
+    render(SpotifyFlow, { props: props() });
 
-    // Eight skeleton placeholders, and no empty-state message while loading.
-    expect(container.querySelectorAll('.skeleton')).toHaveLength(8);
+    expect(screen.getByRole('status')).toHaveTextContent('Loading your library');
     expect(screen.queryByText(/no tracks found/i)).not.toBeInTheDocument();
   });
 
   it('shows the empty state with a clear-filters action when not loading and no tracks', () => {
     render(SpotifyFlow, { props: props() });
 
-    expect(screen.getByText(/no tracks found matching your filters/i)).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('No tracks found');
     expect(screen.getByRole('button', { name: /clear all filters/i })).toBeInTheDocument();
+  });
+
+  it('clears all search and filter options from the empty state', async () => {
+    render(SpotifyFlow, { props: props() });
+
+    await fireEvent.click(screen.getByRole('button', { name: /clear all filters/i }));
+
+    expect(loadTracks).toHaveBeenCalledWith({
+      page: 1,
+      limit: 24,
+      q: '',
+      genre: undefined,
+      year: undefined,
+      sortBy: 'added_at',
+      sortOrder: 'desc',
+    });
   });
 
   it('renders a track card per track in the data state', async () => {

--- a/packages/ui/src/lib/flows/spotify/components/Controls.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/Controls.svelte
@@ -1,71 +1,29 @@
 <script lang="ts">
   import { spotifyStore } from '../stores.svelte';
   import { fetchFromSpotify, loadTracks, cancelSync } from '../api';
+  import { Button } from '@lib/components';
 
   async function handleRefresh() {
     await loadTracks({ page: 1 });
   }
 </script>
 
-<div class="flex gap-2">
-  <button
-    onclick={handleRefresh}
-    disabled={spotifyStore.isLoading}
-    class="px-4 py-2 glass hover:bg-nebula/20 rounded-lg transition-all active:scale-95 disabled:opacity-50 text-cosmic flex items-center gap-2"
-  >
-    {#if spotifyStore.isLoading}
-      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-        ></circle>
-        <path
-          class="opacity-75"
-          fill="currentColor"
-          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-        ></path>
-      </svg>
-    {/if}
+<div class="flex flex-wrap gap-2">
+  <Button onclick={handleRefresh} loading={spotifyStore.isLoading} variant="secondary">
     Refresh
-  </button>
+  </Button>
 
   {#if spotifyStore.isAuthenticated}
-    <button
+    <Button
       onclick={spotifyStore.isLoading ? cancelSync : fetchFromSpotify}
-      class="btn-primary flex items-center gap-2 transition-transform hover:scale-105 active:scale-95"
+      variant={spotifyStore.isLoading ? 'danger' : 'primary'}
       title="Sync with Spotify to get latest tracks"
     >
-      {#if spotifyStore.isLoading}
-        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-          ></circle>
-          <path
-            class="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          ></path>
-        </svg>
-        Cancel
-      {:else}
-        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-          <path
-            d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"
-          />
-        </svg>
-        Sync with Spotify
-      {/if}
-    </button>
+      {spotifyStore.isLoading ? 'Cancel sync' : 'Sync with Spotify'}
+    </Button>
   {:else}
-    <a
-      href="/api/spotify/auth/login"
-      rel="external"
-      class="btn-primary flex items-center gap-2 transition-transform hover:scale-105 active:scale-95 bg-aurora text-void"
-      title="Connect your Spotify account"
-    >
-      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-        <path
-          d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"
-        />
-      </svg>
+    <Button href="/api/spotify/auth/login" rel="external" title="Connect your Spotify account">
       Connect Spotify
-    </a>
+    </Button>
   {/if}
 </div>

--- a/packages/ui/src/lib/flows/spotify/components/FilterPanel.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/FilterPanel.svelte
@@ -1,20 +1,34 @@
 <script lang="ts">
-  import { spotifyStore } from '../stores.svelte';
+  import type { GenreCount, SelectOption, YearCount } from '@flows/shared';
+  import { Badge, Button } from '@lib/components';
   import { loadTracks } from '../api';
-  import type { GenreCount, YearCount } from '@flows/shared';
+  import { spotifyStore } from '../stores.svelte';
+  import FilterSelect from './FilterSelect.svelte';
 
   let { genres = [], years = [] }: { genres?: GenreCount[]; years?: YearCount[] } = $props();
-
   let isOpen = $state(false);
-
-  // Local filter values (synced with store)
   let selectedGenre = $state(spotifyStore.searchOptions.genre || '');
   let selectedYear = $state(spotifyStore.searchOptions.year?.toString() || '');
   let sortBy = $state(spotifyStore.searchOptions.sortBy || 'added_at');
   let sortOrder = $state(spotifyStore.searchOptions.sortOrder || 'desc');
 
-  // Count active filters
-  let activeFilterCount = $derived(
+  const genreOptions = $derived<SelectOption[]>([
+    { value: '', label: 'All Genres' },
+    ...genres.map(({ genre, count }) => ({ value: genre, label: `${genre} (${count})` })),
+  ]);
+  const yearOptions = $derived<SelectOption[]>([
+    { value: '', label: 'All Years' },
+    ...years.map(({ year, count }) => ({ value: year.toString(), label: `${year} (${count})` })),
+  ]);
+  const sortOptions: SelectOption[] = [
+    { value: 'added_at', label: 'Date Added' },
+    { value: 'title', label: 'Title' },
+  ];
+  const orderOptions: SelectOption[] = [
+    { value: 'desc', label: 'Descending' },
+    { value: 'asc', label: 'Ascending' },
+  ];
+  const activeFilterCount = $derived(
     (selectedGenre ? 1 : 0) +
       (selectedYear ? 1 : 0) +
       (sortBy !== 'added_at' || sortOrder !== 'desc' ? 1 : 0)
@@ -23,7 +37,7 @@
   function applyFilters() {
     loadTracks({
       genre: selectedGenre || undefined,
-      year: selectedYear ? parseInt(selectedYear) : undefined,
+      year: selectedYear ? Number.parseInt(selectedYear, 10) : undefined,
       sortBy: sortBy as 'added_at' | 'title',
       sortOrder: sortOrder as 'asc' | 'desc',
       page: 1,
@@ -38,115 +52,79 @@
     sortOrder = 'desc';
     loadTracks({ page: 1 });
   }
-
-  function togglePanel() {
-    isOpen = !isOpen;
-  }
 </script>
 
-<!-- Filter Button -->
-<button
-  onclick={togglePanel}
-  class="glass px-4 py-2 rounded-xl text-cosmic outline-none cursor-pointer hover:bg-nebula/20 active:scale-95 transition-all flex items-center gap-2"
->
-  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
-    />
-  </svg>
-  <span>Filters</span>
-  {#if activeFilterCount > 0}
-    <span class="ml-1 px-1.5 py-0.5 text-[10px] bg-aurora rounded-full font-bold text-void"
-      >{activeFilterCount}</span
-    >
-  {/if}
-  <svg
-    class="w-4 h-4 transition-transform {isOpen ? 'rotate-180' : ''}"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
+<div class="relative">
+  <Button
+    variant="secondary"
+    onclick={() => (isOpen = !isOpen)}
+    aria-expanded={isOpen}
+    aria-controls="spotify-filter-panel"
   >
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-  </svg>
-</button>
+    Filters
+    {#if activeFilterCount > 0}<Badge tone="info">{activeFilterCount}</Badge>{/if}
+  </Button>
 
-<!-- Expandable Panel -->
-{#if isOpen}
-  <div
-    class="absolute top-full left-0 right-0 mt-2 p-4 rounded-xl border border-white/20 bg-nebula z-50 shadow-2xl shadow-aurora/10"
-  >
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      <!-- Genre Filter -->
-      <div class="flex flex-col gap-1">
-        <label for="filter-genre" class="text-xs text-pulsar uppercase tracking-wide">Genre</label>
-        <select
+  {#if isOpen}
+    <div id="spotify-filter-panel" class="spotify-filter-panel" aria-label="Spotify filters">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <FilterSelect
           id="filter-genre"
-          class="glass px-3 py-2 rounded-lg bg-void text-cosmic outline-none cursor-pointer text-sm focus:ring-2 focus:ring-aurora/50"
+          label="Genre"
           bind:value={selectedGenre}
-        >
-          <option value="" class="bg-void">All Genres</option>
-          {#each genres as g (g.genre)}
-            <option value={g.genre} class="bg-void">{g.genre} ({g.count})</option>
-          {/each}
-        </select>
-      </div>
-
-      <!-- Year Filter -->
-      <div class="flex flex-col gap-1">
-        <label for="filter-year" class="text-xs text-pulsar uppercase tracking-wide">Year</label>
-        <select
+          options={genreOptions}
+        />
+        <FilterSelect
           id="filter-year"
-          class="glass px-3 py-2 rounded-lg bg-void text-cosmic outline-none cursor-pointer text-sm focus:ring-2 focus:ring-aurora/50"
+          label="Year"
           bind:value={selectedYear}
-        >
-          <option value="" class="bg-void">All Years</option>
-          {#each years as y (y.year)}
-            <option value={y.year.toString()} class="bg-void">{y.year} ({y.count})</option>
-          {/each}
-        </select>
-      </div>
-
-      <!-- Sort By -->
-      <div class="flex flex-col gap-1">
-        <label for="filter-sortby" class="text-xs text-pulsar uppercase tracking-wide"
-          >Sort By</label
-        >
-        <select
+          options={yearOptions}
+        />
+        <FilterSelect
           id="filter-sortby"
-          class="glass px-3 py-2 rounded-lg bg-void text-cosmic outline-none cursor-pointer text-sm focus:ring-2 focus:ring-aurora/50"
+          label="Sort By"
           bind:value={sortBy}
-        >
-          <option value="added_at" class="bg-void">Date Added</option>
-          <option value="title" class="bg-void">Title</option>
-        </select>
-      </div>
-
-      <!-- Sort Order -->
-      <div class="flex flex-col gap-1">
-        <label for="filter-order" class="text-xs text-pulsar uppercase tracking-wide">Order</label>
-        <select
+          options={sortOptions}
+        />
+        <FilterSelect
           id="filter-order"
-          class="glass px-3 py-2 rounded-lg bg-void text-cosmic outline-none cursor-pointer text-sm focus:ring-2 focus:ring-aurora/50"
+          label="Order"
           bind:value={sortOrder}
-        >
-          <option value="desc" class="bg-void">Descending</option>
-          <option value="asc" class="bg-void">Ascending</option>
-        </select>
+          options={orderOptions}
+        />
+      </div>
+      <div class="mt-4 flex flex-wrap justify-end gap-2 border-t border-white/10 pt-4">
+        <Button variant="ghost" onclick={clearFilters}>Clear all</Button>
+        <Button onclick={applyFilters}>Apply filters</Button>
       </div>
     </div>
+  {/if}
+</div>
 
-    <!-- Action Buttons -->
-    <div class="flex justify-end gap-3 mt-4 pt-4 border-t border-nebula/20">
-      <button
-        onclick={clearFilters}
-        class="px-4 py-2 rounded-lg text-sm text-pulsar hover:text-cosmic transition-colors"
-      >
-        Clear All
-      </button>
-      <button onclick={applyFilters} class="btn-primary"> Apply Filters </button>
-    </div>
-  </div>
-{/if}
+<style>
+  .spotify-filter-panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    z-index: 55;
+    width: min(32rem, calc(100vw - 2rem));
+    padding: 1rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface);
+    box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+  }
+
+  @media (max-width: 640px) {
+    .spotify-filter-panel {
+      position: fixed;
+      top: 4.5rem;
+      right: 1rem;
+      bottom: auto;
+      left: 1rem;
+      width: auto;
+      max-height: calc(100vh - 5.5rem);
+      overflow-y: auto;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/FilterSelect.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/FilterSelect.svelte
@@ -12,15 +12,11 @@
   let { id, label, value = $bindable(), options }: Props = $props();
 </script>
 
-<div class="flex flex-col gap-1">
-  <label for={id} class="text-xs text-pulsar uppercase tracking-wide">{label}</label>
-  <select
-    {id}
-    class="glass px-3 py-2 rounded-lg bg-void text-cosmic outline-none cursor-pointer text-sm focus:ring-2 focus:ring-aurora/50"
-    bind:value
-  >
+<div class="ui-field">
+  <label for={id} class="ui-field__label">{label}</label>
+  <select {id} class="ui-field__control ui-select" bind:value>
     {#each options as opt (opt.value)}
-      <option value={opt.value} class="bg-void">{opt.label}</option>
+      <option value={opt.value}>{opt.label}</option>
     {/each}
   </select>
 </div>

--- a/packages/ui/src/lib/flows/spotify/components/Pagination.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/Pagination.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { spotifyStore } from '../stores.svelte';
   import { loadTracks } from '../api';
+  import { Button } from '@lib/components';
 
   let currentPage = $derived(spotifyStore.searchOptions.page || 1);
   let limit = $derived(spotifyStore.searchOptions.limit || 24);
@@ -16,13 +17,13 @@
 
 {#if totalPages > 1}
   <div class="flex justify-center items-center gap-2 py-8">
-    <button
+    <Button
       onclick={() => goToPage(currentPage - 1)}
       disabled={currentPage === 1}
-      class="px-4 py-2 glass rounded-lg hover:bg-white/10 disabled:opacity-30 disabled:hover:bg-transparent transition-colors text-white"
+      variant="secondary"
     >
       ← Previous
-    </button>
+    </Button>
 
     <div class="flex items-center gap-1 px-4 text-white/50">
       <span class="font-semibold text-white">{currentPage}</span>
@@ -30,12 +31,12 @@
       <span>{totalPages}</span>
     </div>
 
-    <button
+    <Button
       onclick={() => goToPage(currentPage + 1)}
       disabled={currentPage === totalPages}
-      class="px-4 py-2 glass rounded-lg hover:bg-white/10 disabled:opacity-30 disabled:hover:bg-transparent transition-colors text-white"
+      variant="secondary"
     >
       Next →
-    </button>
+    </Button>
   </div>
 {/if}

--- a/packages/ui/src/lib/flows/spotify/components/SearchBar.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/SearchBar.svelte
@@ -1,46 +1,50 @@
 <script lang="ts">
-  import { spotifyStore } from '../stores.svelte';
+  import { Field, IconButton } from '@lib/components';
   import { loadTracks } from '../api';
+  import { spotifyStore } from '../stores.svelte';
 
   let value = $state(spotifyStore.searchOptions.q || '');
   let timer: ReturnType<typeof setTimeout> | null = null;
 
-  function handleInput(e: Event) {
-    const val = (e.target as HTMLInputElement).value;
-    value = val;
-
-    // Debounced search
+  function handleInput(event: Event) {
+    const nextValue = (event.target as HTMLInputElement).value;
+    value = nextValue;
     if (timer) clearTimeout(timer);
-    timer = setTimeout(() => {
-      loadTracks({ q: val, page: 1 });
-    }, 400);
+    timer = setTimeout(() => loadTracks({ q: nextValue, page: 1 }), 400);
   }
 
   function handleClear() {
+    if (timer) clearTimeout(timer);
     value = '';
     loadTracks({ q: '', page: 1 });
   }
 </script>
 
-<div class="relative w-full max-w-md">
-  <div class="absolute inset-y-0 left-3 flex items-center pointer-events-none">
-    <span class="text-white/30 text-lg">🔍</span>
-  </div>
-  <input
-    type="text"
+<div class="spotify-search relative w-full max-w-md">
+  <Field
+    label="Search library"
+    labelHidden
+    type="search"
     placeholder="Search tracks, artists, albums..."
     bind:value
     oninput={handleInput}
-    class="w-full glass pl-10 pr-10 py-2 rounded-xl border border-white/10
-           focus:border-purple-400 focus:ring-1 focus:ring-purple-400
-           bg-black/20 text-white placeholder-white/30 outline-none transition-all"
   />
   {#if value}
-    <button
-      onclick={handleClear}
-      class="absolute inset-y-0 right-3 flex items-center text-white/30 hover:text-white transition-colors"
-    >
-      ✕
-    </button>
+    <IconButton label="Clear search" onclick={handleClear} size="sm" class="spotify-search__clear">
+      &times;
+    </IconButton>
   {/if}
 </div>
+
+<style>
+  :global(.spotify-search .ui-field__control) {
+    padding-right: 2.75rem;
+  }
+
+  :global(.spotify-search__clear) {
+    position: absolute;
+    top: 50%;
+    right: 0.375rem;
+    transform: translateY(-50%);
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/SearchBar.svelte.test.ts
+++ b/packages/ui/src/lib/flows/spotify/components/SearchBar.svelte.test.ts
@@ -49,12 +49,12 @@ describe('SearchBar', () => {
 
   it('shows a clear button only once there is a value', async () => {
     render(SearchBar);
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
 
     const input = screen.getByPlaceholderText('Search tracks, artists, albums...');
     await fireEvent.input(input, { target: { value: 'x' } });
 
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
   });
 
   it('clears the query and reloads when the clear button is clicked', async () => {
@@ -64,7 +64,7 @@ describe('SearchBar', () => {
     );
     await fireEvent.input(input, { target: { value: 'jazz' } });
 
-    await fireEvent.click(screen.getByRole('button'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
 
     expect(input.value).toBe('');
     expect(loadTracks).toHaveBeenCalledWith({ q: '', page: 1 });

--- a/packages/ui/src/lib/flows/spotify/components/TrackCard.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/TrackCard.svelte
@@ -3,6 +3,7 @@
   import AlbumArt from './AlbumArt.svelte';
   import GenreBadges from './GenreBadges.svelte';
   import LyricsModal from '@lib/flows/lyrics/components/LyricsModal.svelte';
+  import { Button } from '@lib/components';
 
   interface Props {
     track: Track;
@@ -74,8 +75,9 @@
     <!-- Footer Stats -->
     <div class="flex justify-between items-center mt-auto pt-3">
       <!-- Lyrics Button -->
-      <button
-        class="text-[10px] text-white/90 hover:text-aurora transition-colors px-2 py-1 bg-white/5 hover:bg-white/10 rounded font-medium"
+      <Button
+        variant="ghost"
+        size="sm"
         onclick={(e) => {
           e.stopPropagation();
           showLyrics = true;
@@ -83,7 +85,7 @@
         title="View lyrics"
       >
         Lyrics
-      </button>
+      </Button>
 
       <!-- Added date -->
       <span class="text-[10px] text-pulsar/80 ml-2">


### PR DESCRIPTION
## What & why

Migrate Spotify to the shared UI primitives and semantic theme tokens as the next focused slice of #24.

Closes #49. Refs #24.

## Changes

- extends Button with a typed link mode for navigation commands
- extends Field with accessible search input support
- migrates Spotify refresh/sync/connect, search/clear, filter actions, pagination, and Lyrics action
- reuses FilterSelect for all filter menus and Badge for active filter count
- replaces local skeleton/empty markup with AsyncState
- makes Clear all filters reset query, genre, year, and ordering instead of only page
- adds responsive filter-panel containment and semantic organic accent tokens
- updates primitive/Spotify tests and design-system migration docs

## User-visible impact

Spotify controls are visually and behaviorally consistent with Chat/Canvas. Search has an explicit accessible name, filters expose expanded state, and the filter panel remains contained on mobile.

## Verification

- `pnpm verify`
- `pnpm build`
- UI: 48 files / 377 tests
- total: 911 tests/contracts
- Svelte check: 0 errors, 0 warnings
- desktop browser: filter panel and labels verified, no horizontal overflow
- mobile 390x844: filter panel fully visible, document width 383/383, no overflow
- browser console: 0 errors