### PR TITLE
refactor(ui): migrate lyrics canvas primitives

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -54,8 +54,8 @@ component is justified when it owns domain behavior, not merely different colors
 
 ## Migration Status
 
-Canvas editor controls, Chat send/stop actions, Spotify controls, and the Lyrics list
-surface use the shared primitives. Remaining surfaces and the application shell should
-migrate in small PRs under issue #24. Legacy
+Canvas editor controls, Chat send/stop actions, Spotify controls, and the Lyrics list and
+analysis surfaces use the shared primitives. Remaining surfaces and the application shell
+should migrate in small PRs under issue #24. Legacy
 cosmic/glass utilities remain in `app.css`; removing or consolidating them is part of that
 migration, not documentation housekeeping.

--- a/packages/ui/src/lib/components/canvas/LayerToggle.svelte
+++ b/packages/ui/src/lib/components/canvas/LayerToggle.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { AnnotationLayer } from '@flows/shared';
+  import { Button } from '@lib/components';
 
   interface Props {
     layers: AnnotationLayer[];
@@ -33,17 +34,19 @@
 <div class="layer-toggles" class:disabled>
   {#each layers as layer (layer.id)}
     {@const isActive = activeLayers.includes(layer.id)}
-    <button
-      class="layer-btn"
-      class:active={isActive}
+    <Button
+      class="layer-btn{isActive ? ' active' : ''}"
       style="--layer-color: {layer.color}"
       {disabled}
+      variant="secondary"
+      size="sm"
+      aria-pressed={isActive}
       onclick={() => toggleLayer(layer.id)}
       title="Toggle {layer.name}"
     >
       <span class="icon">{layer.icon}</span>
       <span class="name">{layer.name}</span>
-    </button>
+    </Button>
   {/each}
 </div>
 
@@ -59,28 +62,11 @@
     pointer-events: none;
   }
 
-  .layer-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--surface-800);
-    border: 1px solid var(--surface-700);
+  :global(.layer-toggles .layer-btn) {
     border-radius: 9999px;
-    color: var(--surface-300);
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
   }
 
-  .layer-btn:hover:not(:disabled) {
-    background: var(--surface-700);
-    border-color: var(--surface-600);
-    color: var(--surface-100);
-  }
-
-  .layer-btn.active {
+  :global(.layer-toggles .layer-btn.active) {
     background: color-mix(in srgb, var(--layer-color) 15%, transparent);
     border-color: var(--layer-color);
     color: var(--layer-color);

--- a/packages/ui/src/lib/components/canvas/LayerToggle.svelte.test.ts
+++ b/packages/ui/src/lib/components/canvas/LayerToggle.svelte.test.ts
@@ -21,11 +21,13 @@ describe('LayerToggle', () => {
     expect(screen.getByText('🎸')).toBeInTheDocument();
   });
 
-  it('marks active layers with the active class and leaves others inactive', () => {
+  it('exposes active layers through aria-pressed and leaves others inactive', () => {
     render(LayerToggle, { props: { layers: LAYERS, activeLayers: ['meaning'] } });
 
     const meaningBtn = screen.getByTitle('Toggle Meaning');
     const chordsBtn = screen.getByTitle('Toggle Chords');
+    expect(meaningBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(chordsBtn).toHaveAttribute('aria-pressed', 'false');
     expect(meaningBtn.className).toContain('active');
     expect(chordsBtn.className).not.toContain('active');
   });

--- a/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte
+++ b/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte
@@ -6,6 +6,7 @@
   import TokenRenderer from '@components/canvas/TokenRenderer.svelte';
   import LayerToggle from '@components/canvas/LayerToggle.svelte';
   import TokenTooltip from '@components/canvas/TokenTooltip.svelte';
+  import { AsyncState, Badge, Button } from '@lib/components';
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';
 
@@ -136,16 +137,17 @@
   }
 </script>
 
-<div class="canvas-container">
+<div class="canvas-container" data-theme="organic">
   {#if loading}
     <div class="center-state">
-      <div class="spinner"></div>
-      <p>Loading canvas...</p>
+      <AsyncState state="loading" title="Loading canvas" />
     </div>
   {:else if error}
-    <div class="center-state error">
-      <p>{error}</p>
-      <button class="btn" onclick={loadData}>Retry</button>
+    {#snippet retryAction()}
+      <Button variant="danger" onclick={loadData}>Retry</Button>
+    {/snippet}
+    <div class="center-state">
+      <AsyncState state="error" title="Canvas unavailable" message={error} action={retryAction} />
     </div>
   {:else if !analysis && statusInfo}
     <div class="center-state empty">
@@ -157,14 +159,9 @@
 
       <div class="actions">
         <p class="description">Generate a musical analysis for this track using AI.</p>
-        <button class="btn primary" onclick={handleAnalyze} disabled={analyzing}>
-          {#if analyzing}
-            <div class="spinner small"></div>
-            Analyzing Lyrics... (This may take a minute)
-          {:else}
-            Generate Analysis
-          {/if}
-        </button>
+        <Button onclick={handleAnalyze} loading={analyzing}>
+          {analyzing ? 'Analyzing Lyrics... (This may take a minute)' : 'Generate Analysis'}
+        </Button>
       </div>
     </div>
   {:else if analysis}
@@ -175,13 +172,13 @@
           {#if analysis.meta}
             <div class="meta-tags">
               {#if analysis.meta.key}
-                <span class="tag">🎵 {analysis.meta.key}</span>
+                <Badge tone="info">Key: {analysis.meta.key}</Badge>
               {/if}
               {#if analysis.meta.bpm}
-                <span class="tag">⏱️ {analysis.meta.bpm} BPM</span>
+                <Badge tone="neutral">{analysis.meta.bpm} BPM</Badge>
               {/if}
               {#if analysis.meta.mood}
-                <span class="tag">✨ {analysis.meta.mood}</span>
+                <Badge tone="success">Mood: {analysis.meta.mood}</Badge>
               {/if}
             </div>
           {/if}
@@ -189,26 +186,9 @@
 
         <div class="controls">
           <LayerToggle layers={analysis.layers} bind:activeLayers />
-          <button
-            class="btn primary small"
-            onclick={handleAnalyze}
-            disabled={analyzing}
-            title="Regenerate Analysis"
-          >
-            {#if analyzing}
-              <div class="spinner small"></div>
-            {:else}
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                ><path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                /></svg
-              >
-              Regenerate
-            {/if}
-          </button>
+          <Button onclick={handleAnalyze} loading={analyzing} size="sm" title="Regenerate Analysis">
+            {analyzing ? 'Regenerating...' : 'Regenerate'}
+          </Button>
         </div>
       </div>
     </header>
@@ -242,18 +222,15 @@
           {:else}
             <div class="empty-meaning">
               <p>No overarching meaning analysis found.</p>
-              <button
-                class="btn small mt-4"
+              <Button
+                variant="secondary"
+                size="sm"
+                class="meaning-action"
                 onclick={handleGenerateMeaning}
-                disabled={isInterpreting}
+                loading={isInterpreting}
               >
-                {#if isInterpreting}
-                  <div class="spinner small"></div>
-                  Generating...
-                {:else}
-                  Generate Meaning
-                {/if}
-              </button>
+                {isInterpreting ? 'Generating...' : 'Generate Meaning'}
+              </Button>
             </div>
           {/if}
         </div>
@@ -326,57 +303,6 @@
     gap: 1rem;
   }
 
-  .btn {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.5rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s;
-    border: 1px solid var(--surface-700);
-    background: var(--surface-800);
-    color: var(--surface-100);
-  }
-
-  .btn.primary {
-    background: var(--primary-600);
-    border-color: var(--primary-500);
-  }
-
-  .btn:hover:not(:disabled) {
-    transform: translateY(-2px);
-    filter: brightness(1.1);
-  }
-
-  .btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .spinner {
-    width: 2rem;
-    height: 2rem;
-    border: 3px solid var(--surface-700);
-    border-top-color: var(--primary-500);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-  }
-
-  .spinner.small {
-    width: 1.25rem;
-    height: 1.25rem;
-    border-width: 2px;
-    border-top-color: white;
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
   .canvas-header {
     position: sticky;
     top: 0;
@@ -399,8 +325,10 @@
 
   .controls {
     display: flex;
+    min-width: 0;
     gap: 1rem;
     align-items: center;
+    flex-wrap: wrap;
   }
 
   .title-area h1 {
@@ -412,14 +340,6 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-  }
-
-  .tag {
-    font-size: 0.75rem;
-    padding: 0.25rem 0.5rem;
-    background: var(--surface-800);
-    border-radius: 0.25rem;
-    color: var(--surface-300);
   }
 
   .canvas-layout {
@@ -435,6 +355,7 @@
 
   .canvas-main {
     width: 100%;
+    min-width: 0;
   }
 
   .canvas-sidebar {
@@ -470,5 +391,39 @@
     text-align: center;
     color: var(--surface-400);
     padding: 2rem 0;
+  }
+
+  :global(.meaning-action) {
+    margin-top: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .canvas-header {
+      padding: 1rem;
+    }
+
+    .header-content,
+    .controls {
+      width: 100%;
+    }
+
+    .controls {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .canvas-layout {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 1rem;
+      padding: 1rem;
+    }
+
+    .canvas-sidebar {
+      position: static;
+    }
+
+    .sidebar-content {
+      max-height: none;
+    }
   }
 </style>

--- a/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte.test.ts
+++ b/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte.test.ts
@@ -89,7 +89,7 @@ describe('LyricsCanvas', () => {
 
     render(LyricsCanvas, { props: { trackId: 'track-1' } });
 
-    expect(screen.getByText('Loading canvas...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Loading canvas');
   });
 
   it('renders the needs-analysis state with a Generate Analysis button', async () => {
@@ -108,9 +108,9 @@ describe('LyricsCanvas', () => {
     render(LyricsCanvas, { props: { trackId: 'track-1' } });
 
     expect(await screen.findByText('Canvas Analysis')).toBeInTheDocument();
-    expect(screen.getByText('🎵 A minor')).toBeInTheDocument();
-    expect(screen.getByText('⏱️ 120 BPM')).toBeInTheDocument();
-    expect(screen.getByText('✨ melancholy')).toBeInTheDocument();
+    expect(screen.getByText('Key: A minor')).toBeInTheDocument();
+    expect(screen.getByText('120 BPM')).toBeInTheDocument();
+    expect(screen.getByText('Mood: melancholy')).toBeInTheDocument();
     // Tokens rendered by the child TokenRenderer.
     expect(screen.getByText('Hello')).toBeInTheDocument();
     expect(screen.getByText('world')).toBeInTheDocument();
@@ -129,7 +129,9 @@ describe('LyricsCanvas', () => {
 
     render(LyricsCanvas, { props: { trackId: 'track-1' } });
 
-    expect(await screen.findByText('Canvas backend down')).toBeInTheDocument();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Canvas unavailable');
+    expect(alert).toHaveTextContent('Canvas backend down');
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
@@ -179,5 +181,23 @@ describe('LyricsCanvas', () => {
     await screen.findByText('Canvas Analysis');
     expect(screen.getByText('No overarching meaning analysis found.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Generate Meaning/ })).toBeInTheDocument();
+  });
+
+  it('generates the meaning from the empty interpretation state', async () => {
+    getCanvasAnalysis.mockResolvedValue(makeAnalysis());
+    getLyrics.mockResolvedValue(null);
+    interpretLyrics.mockImplementation(
+      async (_id: string, onEvent: (e: InterpretEvent) => void) => {
+        onEvent({ type: 'cached', interpretation: 'A resolved meaning.' });
+      }
+    );
+
+    render(LyricsCanvas, { props: { trackId: 'track-1' } });
+    const generateBtn = await screen.findByRole('button', { name: 'Generate Meaning' });
+
+    await fireEvent.click(generateBtn);
+
+    expect(interpretLyrics).toHaveBeenCalledWith('track-1', expect.any(Function));
+    expect(await screen.findByText('A resolved meaning.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- migrate LyricsCanvas loading, error, action, and metadata UI to shared design-system primitives
- migrate LayerToggle to the shared Button while exposing pressed state semantically
- make the analysis layout responsive without horizontal overflow
- update component tests and design-system migration documentation

## User impact

Lyrics analysis now follows the same interaction and accessibility conventions as the other migrated flows, including clearer async states and a single-column mobile layout.

## Areas touched

- `packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte`
- `packages/ui/src/lib/components/canvas/LayerToggle.svelte`
- related component tests
- `docs/design-system.md`

## Validation

- `pnpm verify`
- `pnpm build`
- browser validation at 1280x721 and 390x844
- no horizontal overflow at either viewport
- layer toggles expose and update `aria-pressed`
- browser console: no errors

Closes #53
Refs #24