### PR TITLE
refactor(ui): migrate lyrics modal shell

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -54,8 +54,8 @@ component is justified when it owns domain behavior, not merely different colors
 
 ## Migration Status
 
-Canvas editor controls, Chat send/stop actions, Spotify controls, and the Lyrics list and
-analysis surfaces use the shared primitives. Remaining surfaces and the application shell
-should migrate in small PRs under issue #24. Legacy
+Canvas editor controls, Chat send/stop actions, Spotify controls, and the Lyrics list,
+analysis, and detail modal surfaces use the shared primitives. Remaining surfaces and the
+application shell should migrate in small PRs under issue #24. Legacy
 cosmic/glass utilities remain in `app.css`; removing or consolidating them is part of that
 migration, not documentation housekeeping.

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -376,13 +376,24 @@ body::after {
   background: rgba(2, 6, 23, 0.78);
 }
 .ui-modal {
-  width: min(36rem, 100%);
-  max-height: min(42rem, calc(100vh - 2rem));
-  overflow: auto;
+  display: flex;
+  max-height: min(42rem, calc(100dvh - 2rem));
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
   border: 1px solid var(--ui-border);
   border-radius: 0.5rem;
   background: var(--ui-surface);
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+.ui-modal--sm {
+  width: min(28rem, 100%);
+}
+.ui-modal--md {
+  width: min(36rem, 100%);
+}
+.ui-modal--lg {
+  width: min(48rem, 100%);
 }
 .ui-modal__header,
 .ui-modal__footer {
@@ -395,16 +406,64 @@ body::after {
 .ui-modal__header {
   border-bottom: 1px solid var(--ui-border);
 }
+.ui-modal__media {
+  flex: 0 0 auto;
+}
+.ui-modal__heading {
+  min-width: 0;
+  flex: 1 1 auto;
+}
 .ui-modal__header h2 {
   margin: 0;
+  overflow: hidden;
   font-size: 1.125rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ui-modal__heading p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--ui-text-muted);
+  font-size: 0.875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ui-modal__actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.5rem;
 }
 .ui-modal__body {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
   padding: 1rem;
 }
 .ui-modal__footer {
   justify-content: flex-end;
   border-top: 1px solid var(--ui-border);
+}
+
+@media (max-width: 640px) {
+  .ui-modal-backdrop {
+    align-items: stretch;
+    padding: 0.5rem;
+  }
+
+  .ui-modal {
+    max-height: calc(100dvh - 1rem);
+  }
+
+  .ui-modal__header {
+    align-items: flex-start;
+    padding: 0.75rem;
+  }
+
+  .ui-modal__actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
 }
 
 /* Scrollbar */

--- a/packages/ui/src/lib/components/ui/ModalShell.svelte
+++ b/packages/ui/src/lib/components/ui/ModalShell.svelte
@@ -1,28 +1,111 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { Snippet } from 'svelte';
   import IconButton from './IconButton.svelte';
 
   let {
     title,
+    subtitle,
     children,
+    media,
+    actions,
     footer,
     onclose,
-  }: { title: string; children: Snippet; footer?: Snippet; onclose: () => void } = $props();
+    size = 'md',
+  }: {
+    title: string;
+    subtitle?: string;
+    children: Snippet;
+    media?: Snippet;
+    actions?: Snippet;
+    footer?: Snippet;
+    onclose: () => void;
+    size?: 'sm' | 'md' | 'lg';
+  } = $props();
 
   const titleId = $props.id();
+  let dialogElement: HTMLElement;
+
+  const focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
+  function getFocusableElements(): HTMLElement[] {
+    return Array.from(dialogElement.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+      (element) => !element.hasAttribute('hidden') && element.getAttribute('aria-hidden') !== 'true'
+    );
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onclose();
+      return;
+    }
+
+    if (event.key !== 'Tab') return;
+
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      dialogElement.focus();
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  }
+
+  onMount(() => {
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const firstFocusableElement = getFocusableElements()[0];
+    (firstFocusableElement ?? dialogElement).focus();
+
+    return () => previouslyFocused?.focus();
+  });
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div
   class="ui-modal-backdrop"
   role="presentation"
   onclick={(event) => event.currentTarget === event.target && onclose()}
 >
-  <div class="ui-modal" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+  <div
+    class="ui-modal ui-modal--{size}"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={titleId}
+    tabindex="-1"
+    bind:this={dialogElement}
+  >
     <header class="ui-modal__header">
-      <h2 id={titleId}>{title}</h2>
-      <IconButton label="Close" onclick={onclose}>
-        <span aria-hidden="true">×</span>
-      </IconButton>
+      {#if media}<div class="ui-modal__media">{@render media()}</div>{/if}
+      <div class="ui-modal__heading">
+        <h2 id={titleId}>{title}</h2>
+        {#if subtitle}<p>{subtitle}</p>{/if}
+      </div>
+      <div class="ui-modal__actions">
+        {#if actions}{@render actions()}{/if}
+        <IconButton label="Close" variant="secondary" onclick={onclose}>
+          <span aria-hidden="true">×</span>
+        </IconButton>
+      </div>
     </header>
     <div class="ui-modal__body">{@render children()}</div>
     {#if footer}<footer class="ui-modal__footer">{@render footer()}</footer>{/if}

--- a/packages/ui/src/lib/components/ui/ui.test.ts
+++ b/packages/ui/src/lib/components/ui/ui.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 import AsyncState from './AsyncState.svelte';
@@ -63,5 +63,54 @@ describe('UI primitives', () => {
     expect(screen.getByRole('dialog', { name: 'Details' })).toBeInTheDocument();
     await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  it('ModalShell closes on Escape and backdrop clicks', async () => {
+    const onclose = vi.fn();
+    render(ModalShell, {
+      props: { title: 'Details', children: textSnippet('Content'), onclose },
+    });
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    await fireEvent.click(screen.getByRole('presentation'));
+
+    expect(onclose).toHaveBeenCalledTimes(2);
+  });
+
+  it('ModalShell moves focus inside and restores it when unmounted', async () => {
+    const trigger = document.createElement('button');
+    document.body.append(trigger);
+    trigger.focus();
+
+    const view = render(ModalShell, {
+      props: { title: 'Details', children: textSnippet('Content'), onclose: vi.fn() },
+    });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
+    view.unmount();
+    expect(trigger).toHaveFocus();
+
+    trigger.remove();
+  });
+
+  it('ModalShell keeps keyboard focus inside the dialog', async () => {
+    render(ModalShell, {
+      props: {
+        title: 'Details',
+        actions: textSnippet('<button>Header action</button>'),
+        children: textSnippet('<button>Body action</button>'),
+        onclose: vi.fn(),
+      },
+    });
+
+    const headerAction = screen.getByRole('button', { name: 'Header action' });
+    const bodyAction = screen.getByRole('button', { name: 'Body action' });
+    await waitFor(() => expect(headerAction).toHaveFocus());
+
+    await fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+    expect(bodyAction).toHaveFocus();
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    expect(headerAction).toHaveFocus();
   });
 });

--- a/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
+++ b/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Track } from '@flows/shared';
+  import { AsyncState, Badge, Button, ModalShell } from '@lib/components';
   import { getLyrics, interpretLyrics } from '../api';
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';
@@ -10,6 +11,7 @@
   }
 
   let { track, onclose }: Props = $props();
+  const artistNames = $derived(track.artists.map((artist) => artist.name).join(', '));
 
   let lyrics = $state<{
     plainLyrics: string | null;
@@ -97,222 +99,189 @@
   }
 
   function handleRegenerate() {
-    // Clear cached state and re-interpret
     interpretContent = '';
     interpretDone = false;
     handleInterpret();
   }
-
-  function handleBackdropClick(event: MouseEvent) {
-    if (event.target === event.currentTarget) {
-      onclose();
-    }
-  }
-
-  function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      onclose();
-    }
-  }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
+{#snippet albumArt()}
+  {#if track.album.imageUrl}
+    <img src={track.album.imageUrl} alt={track.album.name} class="album-art" />
+  {/if}
+{/snippet}
 
-<!-- Backdrop -->
-<div
-  class="fixed inset-0 bg-void/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-  onclick={handleBackdropClick}
-  onkeydown={handleKeydown}
-  role="dialog"
-  aria-modal="true"
-  aria-labelledby="lyrics-title"
-  tabindex="-1"
+{#snippet modalActions()}
+  {#if lyrics?.plainLyrics && !showInterpretation}
+    <Button variant="secondary" size="sm" onclick={handleInterpret}>Interpret</Button>
+  {/if}
+{/snippet}
+
+<ModalShell
+  title={track.title}
+  subtitle={artistNames}
+  media={albumArt}
+  actions={modalActions}
+  size="lg"
+  {onclose}
 >
-  <!-- Modal -->
-  <div
-    class="glass rounded-2xl max-w-2xl w-full max-h-[85vh] flex flex-col overflow-hidden shadow-2xl shadow-aurora/20"
-  >
-    <!-- Header -->
-    <div class="p-4 border-b border-white/10 flex items-center gap-4">
-      {#if track.album.imageUrl}
-        <img
-          src={track.album.imageUrl}
-          alt={track.album.name}
-          class="w-12 h-12 rounded-lg object-cover"
-        />
-      {/if}
-      <div class="flex-grow min-w-0">
-        <h2 id="lyrics-title" class="text-lg font-bold text-cosmic truncate">
-          {track.title}
-        </h2>
-        <p class="text-sm text-pulsar truncate">
-          {track.artists.map((a) => a.name).join(', ')}
-        </p>
-      </div>
+  <div class="lyrics-modal-content">
+    {#if loading}
+      <AsyncState state="loading" title="Fetching lyrics" />
+    {:else if error}
+      {#snippet retryAction()}
+        <Button variant="danger" onclick={() => fetchLyrics(true)}>Retry</Button>
+      {/snippet}
+      <AsyncState
+        state="error"
+        title="Failed to load lyrics"
+        message={error}
+        action={retryAction}
+      />
+    {:else if lyrics?.status === 'not_found'}
+      {#snippet retryRetrievalAction()}
+        <Button variant="secondary" onclick={() => fetchLyrics(true)}>Retry Retrieval</Button>
+      {/snippet}
+      <AsyncState
+        state="empty"
+        title="No lyrics found"
+        message="Lyrics are not available for this track. It might be an instrumental song."
+        action={retryRetrievalAction}
+      />
+    {:else if lyrics?.plainLyrics}
+      <pre class="lyrics-text">{lyrics.plainLyrics}</pre>
 
-      <div class="flex items-center gap-2">
-        <!-- Interpret Button -->
-        {#if lyrics?.plainLyrics && !showInterpretation}
-          <button
-            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all
-                   bg-aurora/10 hover:bg-aurora/20 text-aurora border border-aurora/30
-                   hover:shadow-lg hover:shadow-aurora/10 active:scale-95"
-            onclick={handleInterpret}
-          >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="1.5"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
-              />
-            </svg>
-            Interpret
-          </button>
-        {/if}
-
-        <!-- Close Button -->
-        <button
-          class="p-2 hover:bg-white/10 rounded-lg transition-colors text-pulsar hover:text-cosmic"
-          onclick={onclose}
-          aria-label="Close"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-
-    <!-- Content -->
-    <div class="flex-grow overflow-y-auto p-6 space-y-6">
-      {#if loading}
-        <div class="flex flex-col items-center justify-center py-12 text-pulsar">
-          <div
-            class="w-8 h-8 border-2 border-aurora border-t-transparent rounded-full animate-spin mb-4"
-          ></div>
-          <p>Fetching lyrics...</p>
-        </div>
-      {:else if error}
-        <div class="text-center py-12">
-          <p class="text-red-400 mb-2">Failed to load lyrics</p>
-          <p class="text-pulsar text-sm">{error}</p>
-          <button
-            onclick={() => fetchLyrics(true)}
-            class="mt-4 px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-sm text-cosmic transition-colors"
-          >
-            Retry
-          </button>
-        </div>
-      {:else if lyrics?.status === 'not_found'}
-        <div class="text-center py-12">
-          <p class="text-pulsar text-lg mb-2">No lyrics found</p>
-          <p class="text-cosmic/80 text-sm mb-6">
-            Lyrics are not available for this track.<br />
-            It might be an instrumental song.
-          </p>
-          <button
-            onclick={() => fetchLyrics(true)}
-            class="px-4 py-2 bg-aurora/10 hover:bg-aurora/20 text-aurora rounded-lg text-sm font-medium transition-colors border border-aurora/30 hover:shadow-lg hover:shadow-aurora/10"
-          >
-            Retry Retrieval
-          </button>
-        </div>
-      {:else if lyrics?.plainLyrics}
-        <!-- Lyrics -->
-        <pre
-          class="whitespace-pre-wrap font-sans text-cosmic/90 leading-relaxed">{lyrics.plainLyrics}</pre>
-
-        <!-- AI Interpretation Panel -->
-        {#if showInterpretation}
-          <div class="border-t border-white/10 pt-4">
-            <div class="flex items-center justify-between mb-3">
-              <div class="flex items-center gap-2">
-                <svg
-                  class="w-4 h-4 text-aurora"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
-                  />
-                </svg>
-                <h3 class="text-sm font-semibold text-aurora uppercase tracking-wider">
-                  AI Interpretation
-                </h3>
-                {#if isInterpreting}
-                  <div
-                    class="w-3 h-3 border-2 border-aurora border-t-transparent rounded-full animate-spin"
-                  ></div>
-                {/if}
-              </div>
-              {#if interpretDone}
-                <button
-                  class="text-[10px] text-pulsar hover:text-cosmic transition-colors px-2 py-0.5 rounded border border-white/10 hover:bg-white/5"
-                  onclick={handleRegenerate}
-                >
-                  Regenerate
-                </button>
+      {#if showInterpretation}
+        <section class="interpretation-panel" aria-label="AI Interpretation">
+          <header class="interpretation-header">
+            <div class="interpretation-heading">
+              <Badge tone={interpretError ? 'danger' : interpretDone ? 'success' : 'info'}>
+                AI Interpretation
+              </Badge>
+              {#if isInterpreting && interpretContent}
+                <span class="interpretation-status" role="status">Streaming</span>
               {/if}
             </div>
-
-            {#if interpretError}
-              <div
-                class="text-red-400 text-sm bg-red-400/10 p-3 rounded-lg border border-red-400/20"
-              >
-                {interpretError}
-              </div>
-            {:else if interpretContent}
-              <div
-                class="prose prose-invert prose-sm max-w-none leading-relaxed
-                          prose-p:my-1.5 prose-pre:bg-black/30 prose-pre:border prose-pre:border-white/10
-                          prose-code:text-aurora prose-code:before:content-[''] prose-code:after:content-['']
-                          prose-headings:text-cosmic prose-strong:text-cosmic/90
-                          bg-white/[0.02] rounded-xl p-4 border border-white/5"
-              >
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                {@html renderMarkdown(interpretContent)}
-                {#if isInterpreting}
-                  <span
-                    class="inline-block w-0.5 h-4 bg-aurora animate-pulse ml-0.5 align-text-bottom"
-                  ></span>
-                {/if}
-              </div>
-            {:else if isInterpreting}
-              <div class="flex items-center gap-1.5 py-4 justify-center">
-                <div
-                  class="w-2 h-2 bg-aurora rounded-full animate-bounce"
-                  style="animation-delay: 0ms"
-                ></div>
-                <div
-                  class="w-2 h-2 bg-aurora rounded-full animate-bounce"
-                  style="animation-delay: 150ms"
-                ></div>
-                <div
-                  class="w-2 h-2 bg-aurora rounded-full animate-bounce"
-                  style="animation-delay: 300ms"
-                ></div>
-              </div>
+            {#if interpretDone}
+              <Button variant="ghost" size="sm" onclick={handleRegenerate}>Regenerate</Button>
             {/if}
-          </div>
-        {/if}
-      {:else}
-        <p class="text-pulsar text-center py-12">No lyrics content available.</p>
+          </header>
+
+          {#if interpretError}
+            {#snippet retryInterpretationAction()}
+              <Button variant="danger" size="sm" onclick={handleRegenerate}>Try Again</Button>
+            {/snippet}
+            <AsyncState
+              state="error"
+              title="Interpretation failed"
+              message={interpretError}
+              action={retryInterpretationAction}
+            />
+          {:else if interpretContent}
+            <div class="interpretation-content prose prose-invert prose-sm max-w-none">
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderMarkdown(interpretContent)}
+              {#if isInterpreting}<span class="stream-cursor" aria-hidden="true"></span>{/if}
+            </div>
+          {:else if isInterpreting}
+            <AsyncState state="loading" title="Interpreting lyrics" />
+          {/if}
+        </section>
       {/if}
-    </div>
+    {:else}
+      <AsyncState state="empty" title="No lyrics content available" />
+    {/if}
   </div>
-</div>
+</ModalShell>
+
+<style>
+  .album-art {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 0.5rem;
+    object-fit: cover;
+  }
+
+  .lyrics-modal-content {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .lyrics-text {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--ui-text);
+    font-family: inherit;
+    line-height: 1.75;
+    white-space: pre-wrap;
+  }
+
+  .interpretation-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--ui-border);
+  }
+
+  .interpretation-header,
+  .interpretation-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .interpretation-header {
+    justify-content: space-between;
+  }
+
+  .interpretation-status {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+  }
+
+  .interpretation-content {
+    min-width: 0;
+    padding: 1rem;
+    overflow-wrap: anywhere;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface-raised);
+    line-height: 1.65;
+  }
+
+  .stream-cursor {
+    display: inline-block;
+    width: 0.125rem;
+    height: 1rem;
+    margin-left: 0.125rem;
+    vertical-align: text-bottom;
+    background: var(--ui-accent);
+    animation: cursor-pulse 1s ease-in-out infinite;
+  }
+
+  @keyframes cursor-pulse {
+    50% {
+      opacity: 0.25;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stream-cursor {
+      animation: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .album-art {
+      width: 2.5rem;
+      height: 2.5rem;
+    }
+
+    .interpretation-header {
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte.test.ts
+++ b/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte.test.ts
@@ -50,8 +50,9 @@ describe('LyricsModal', () => {
 
     render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
 
-    expect(await screen.findByText('Bohemian Rhapsody')).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Bohemian Rhapsody' })).toBeInTheDocument();
     expect(screen.getByText('Queen')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'A Night at the Opera' })).toBeInTheDocument();
   });
 
   it('shows a loading state while lyrics are being fetched', () => {
@@ -59,7 +60,7 @@ describe('LyricsModal', () => {
 
     render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
 
-    expect(screen.getByText('Fetching lyrics...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Fetching lyrics');
   });
 
   it('renders the lyrics content on success', async () => {
@@ -76,6 +77,7 @@ describe('LyricsModal', () => {
     render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
 
     expect(await screen.findByText('No lyrics found')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('It might be an instrumental song');
     expect(screen.getByRole('button', { name: 'Retry Retrieval' })).toBeInTheDocument();
   });
 
@@ -84,9 +86,24 @@ describe('LyricsModal', () => {
 
     render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
 
-    expect(await screen.findByText('Failed to load lyrics')).toBeInTheDocument();
-    expect(screen.getByText('Network down')).toBeInTheDocument();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Failed to load lyrics');
+    expect(alert).toHaveTextContent('Network down');
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('retries a failed lyrics request with force enabled', async () => {
+    getLyrics
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockResolvedValueOnce({ plainLyrics: 'Recovered lyrics', status: 'found' });
+
+    render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
+    await fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(getLyrics).toHaveBeenNthCalledWith(2, 'track-1', { force: true });
+    });
+    expect(await screen.findByText('Recovered lyrics')).toBeInTheDocument();
   });
 
   it('does NOT render lyrics content while in the error state (negative space)', async () => {
@@ -171,6 +188,25 @@ describe('LyricsModal', () => {
     expect(screen.getByText('AI Interpretation')).toBeInTheDocument();
   });
 
+  it('regenerates a cached interpretation from its shared action', async () => {
+    getLyrics.mockResolvedValue({
+      plainLyrics: 'words',
+      status: 'found',
+      interpretation: 'Cached meaning text.',
+    });
+    interpretLyrics.mockImplementation(
+      async (_id: string, onEvent: (e: InterpretEvent) => void) => {
+        onEvent({ type: 'cached', interpretation: 'Regenerated meaning text.' });
+      }
+    );
+
+    render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
+    await fireEvent.click(await screen.findByRole('button', { name: 'Regenerate' }));
+
+    expect(interpretLyrics).toHaveBeenCalledWith('track-1', expect.any(Function));
+    expect(await screen.findByText('Regenerated meaning text.')).toBeInTheDocument();
+  });
+
   it('renders an interpretation error returned by the stream', async () => {
     getLyrics.mockResolvedValue({ plainLyrics: 'words', status: 'found' });
     interpretLyrics.mockImplementation(
@@ -182,6 +218,9 @@ describe('LyricsModal', () => {
     render(LyricsModal, { props: { track: makeTrack(), onclose: vi.fn() } });
     await fireEvent.click(await screen.findByRole('button', { name: 'Interpret' }));
 
-    expect(await screen.findByText('LLM unavailable')).toBeInTheDocument();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Interpretation failed');
+    expect(alert).toHaveTextContent('LLM unavailable');
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- harden `ModalShell` with Escape and backdrop dismissal, initial focus, focus restoration, keyboard focus wrapping, responsive sizes, and optional media/subtitle/actions
- migrate `LyricsModal` to `ModalShell`, `AsyncState`, `Button`, and `Badge`
- preserve lyrics retrieval, force retry, cached interpretation, streaming, regeneration, and sanitized Markdown behavior
- add semantic tests for dialog behavior and Lyrics actions
- update the design-system migration status

## User impact

Lyrics details now use the shared dialog system, remain usable at mobile sizes, and provide predictable keyboard focus and recovery actions.

## Areas touched

- `packages/ui/src/lib/components/ui/ModalShell.svelte`
- `packages/ui/src/app.css`
- `packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte`
- related UI tests
- `docs/design-system.md`

## Validation

- `pnpm verify`
- `pnpm build`
- 383 UI tests / 917 total tests
- browser validation at 1280x721 and 390x844
- button and Escape dismissal restore focus to the originating `View Lyrics` action
- focus wraps between modal controls
- no horizontal overflow or browser console errors

Closes #55
Refs #24