### PR TITLE
refactor(ui): migrate root flow dashboard

### DIFF
--- a/docs/architecture/ui.md
+++ b/docs/architecture/ui.md
@@ -48,7 +48,11 @@ ui/
 │       ├── client.ts             # Eden Treaty client (typed against the backend App)
 │       ├── toast.ts              # svelte-5-french-toast wrapper (Toaster, showError…)
 │       ├── types.ts              # local UI types (domain types come from @flows/shared)
-│       ├── pages/Landing.svelte  # the board UI (flow cards + live stats)
+│       ├── pages/
+│       │   ├── Landing.svelte    # flow registry orchestration + live stats
+│       │   ├── types.ts          # root dashboard presentation model
+│       │   └── components/
+│       │       └── FlowCard.svelte # semantic board card presentation
 │       ├── components/
 │       │   ├── layout/           # Navbar, FlowLayout
 │       │   ├── common/           # InfiniteScroll, …
@@ -68,9 +72,10 @@ ui/
 ## Routing
 
 File-based. Each flow is a route under `src/routes/<flow>/+page.svelte` that renders the
-flow's page component from `lib/flows/<flow>/`. The home route renders the board
-(`Landing.svelte`), which links to each flow via `<a href="/spotify">` etc. (The old
-`#/`-hash router was removed in the SvelteKit migration.)
+flow's page component from `lib/flows/<flow>/`. The home route renders the flow index
+(`Landing.svelte`), which resolves registry stats and delegates each item to a semantic
+`FlowCard`. Available flows are links; unavailable and failed flows are non-interactive
+articles. (The old `#/`-hash router was removed in the SvelteKit migration.)
 
 ## Flows registry
 
@@ -97,9 +102,11 @@ the flow's `api.ts` and be covered by a contract test.
 
 ## Styling
 
-Tailwind v4, CSS-first: `app.css` does `@import 'tailwindcss'` and declares brand tokens
-in `@theme { … }` ("cosmic" dark theme + glassmorphism). Component-scoped `<style>` for
-the rest; inline `style` only for dynamic values. There is no `tailwind.config.js` (v4).
+Tailwind v4, CSS-first: `app.css` does `@import 'tailwindcss'` and declares brand and
+semantic UI tokens. Shared and migrated components consume `--ui-*` variables through
+component-scoped styles; inline `style` is reserved for dynamic values. Legacy
+`glass`/`cosmic` utilities remain only for flow-local surfaces awaiting migration. There
+is no `tailwind.config.js` (v4).
 
 ## Testing
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -54,8 +54,8 @@ component is justified when it owns domain behavior, not merely different colors
 
 ## Migration Status
 
-The application shell, Canvas editor controls, Chat send/stop actions, Spotify controls,
-and the Lyrics list, analysis, and detail modal surfaces use semantic tokens and shared
-primitives. Remaining flow-local surfaces should migrate in small PRs under issue #24.
-Legacy cosmic/glass utilities remain in `app.css`; removing or consolidating them is part
-of that migration, not documentation housekeeping.
+The application shell, root flow dashboard, Canvas editor controls, Chat send/stop
+actions, Spotify controls, and the Lyrics list, analysis, and detail modal surfaces use
+semantic tokens and shared primitives. Remaining flow-local surfaces should migrate in
+small PRs under issue #24. Legacy cosmic/glass utilities remain in `app.css`; removing or
+consolidating them is part of that migration, not documentation housekeeping.

--- a/packages/ui/src/lib/pages/Landing.svelte
+++ b/packages/ui/src/lib/pages/Landing.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { AsyncState, Badge, FlowLayout } from '@lib/components';
   import { getFlows, type FlowDefinition, type FlowStats } from '@lib/flows';
-  import { FlowLayout } from '@lib/components';
+  import FlowCard from './components/FlowCard.svelte';
+  import type { FlowCardModel } from './types';
 
-  // Page title
   const pageTitle = 'Cosmic Flow - Data Exploration Hub';
 
-  interface FlowCard extends FlowDefinition {
-    stats?: FlowStats;
-  }
-
-  // Placeholder flows for "coming soon" features
-  const placeholderFlows: FlowCard[] = [
+  const placeholderFlows: FlowCardModel[] = [
     {
       id: 'youtube',
       name: 'YouTube Flow',
@@ -24,53 +20,26 @@
     },
   ];
 
-  let flows: FlowCard[] = $state([]);
+  let flows = $state<FlowCardModel[]>([]);
   let isLoading = $state(true);
+  const readyFlowCount = $derived(
+    flows.filter((flow) => ['active', 'configured'].includes(flow.stats.status)).length
+  );
+
+  async function resolveFlow(flow: FlowDefinition): Promise<FlowCardModel> {
+    try {
+      return { ...flow, stats: await flow.getStats() };
+    } catch {
+      const stats: FlowStats = { count: 0, status: 'error' };
+      return { ...flow, stats };
+    }
+  }
 
   onMount(async () => {
-    const registeredFlows = getFlows();
-
-    const flowsWithStats = await Promise.all(
-      registeredFlows.map(async (flow) => {
-        try {
-          const stats = await flow.getStats();
-          return { ...flow, stats };
-        } catch {
-          return { ...flow, stats: { count: 0, status: 'error' as const } };
-        }
-      })
-    );
-
+    const flowsWithStats = await Promise.all(getFlows().map(resolveFlow));
     flows = [...flowsWithStats, ...placeholderFlows];
     isLoading = false;
   });
-
-  function getStatusClass(status: FlowStats['status']): string {
-    switch (status) {
-      case 'active':
-        return 'text-aurora bg-aurora/10 border border-aurora/20';
-      case 'configured':
-        return 'text-pulsar bg-pulsar/10 border border-pulsar/20';
-      case 'error':
-        return 'text-red-400 bg-red-400/10 border border-red-400/20';
-      default:
-        return 'text-white/30 bg-white/5 border border-white/10';
-    }
-  }
-
-  function getStatusLabel(stats: FlowStats): string {
-    if (stats.statusMessage) return stats.statusMessage;
-    switch (stats.status) {
-      case 'active':
-        return 'Explore →';
-      case 'configured':
-        return 'Configured';
-      case 'error':
-        return 'Error';
-      default:
-        return 'Coming Soon';
-    }
-  }
 </script>
 
 <svelte:head>
@@ -78,74 +47,88 @@
 </svelte:head>
 
 <FlowLayout>
-  <div class="flex items-center justify-center min-h-[calc(100vh-8rem)]">
-    <div class="max-w-4xl w-full flex flex-col gap-10">
-      <!-- Header -->
-      <header class="text-center">
-        <div class="flex justify-center mb-4">
-          <img src="/favicon.png" alt="Cosmic Flow" class="w-16 h-16 rounded-2xl" />
+  <section class="flow-index" aria-labelledby="flow-index-title">
+    <header class="flow-index__header">
+      <h1 id="flow-index-title">Flows</h1>
+      {#if !isLoading}
+        <div class="flow-index__summary" aria-label="Flow availability">
+          <Badge tone="success">{readyFlowCount} ready</Badge>
+          <Badge tone="neutral">{flows.length} total</Badge>
         </div>
-        <h1 class="text-5xl md:text-6xl font-bold text-cosmic">Cosmic Flow</h1>
-        <p class="text-white/40 mt-4 text-lg">Your data flow playground</p>
-      </header>
+      {/if}
+    </header>
 
-      <!-- Flow Cards -->
-      <section class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {#if isLoading}
-          <!-- Loading Skeleton -->
-          {#each [0, 1, 2] as i (i)}
-            <div class="glass p-6 h-48 skeleton"></div>
-          {/each}
-        {:else}
+    <div class="flow-index__content">
+      {#if isLoading}
+        <AsyncState state="loading" title="Loading flow status" />
+      {:else}
+        <div class="flow-index__grid">
           {#each flows as flow (flow.id)}
-            {@const isClickable =
-              flow.stats?.status === 'active' || flow.stats?.status === 'configured'}
-            <a
-              href={isClickable ? flow.route : undefined}
-              class="glass glass-hover p-6 transition-all duration-300
-                   {isClickable
-                ? 'hover:scale-[1.02] cursor-pointer'
-                : 'opacity-40 cursor-not-allowed'}"
-            >
-              <div class="flex items-center gap-3 mb-4">
-                <span class="text-4xl">{flow.icon}</span>
-                <div
-                  class="w-2 h-2 rounded-full {flow.stats?.status === 'active'
-                    ? 'bg-aurora glow-pulse'
-                    : 'bg-white/10'}"
-                ></div>
-              </div>
-
-              <h2 class="text-xl font-semibold text-white">{flow.name}</h2>
-              <p class="text-white/40 text-sm mt-2 leading-relaxed">{flow.description}</p>
-
-              {#if flow.stats && flow.stats.count > 0}
-                <div class="flex gap-6 mt-5 pt-4 border-t border-white/5">
-                  <div>
-                    <div class="text-2xl font-bold text-aurora">{flow.stats.count}</div>
-                    <div class="text-xs text-white/30 uppercase tracking-wider">Items</div>
-                  </div>
-                </div>
-              {/if}
-
-              {#if flow.stats}
-                <div
-                  class="mt-4 text-xs {getStatusClass(
-                    flow.stats.status
-                  )} rounded-full px-3 py-1 inline-block font-medium"
-                >
-                  {getStatusLabel(flow.stats)}
-                </div>
-              {/if}
-            </a>
+            <FlowCard {flow} />
           {/each}
-        {/if}
-      </section>
-
-      <!-- Footer -->
-      <footer class="text-center text-white/20 text-sm">
-        Cosmic Flow — An improvisational data vignette
-      </footer>
+        </div>
+      {/if}
     </div>
-  </div>
+  </section>
 </FlowLayout>
+
+<style>
+  .flow-index {
+    display: flex;
+    min-height: calc(100dvh - var(--app-nav-height) - 3.5rem);
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .flow-index__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--ui-border);
+  }
+
+  .flow-index__header h1 {
+    margin: 0;
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+  }
+
+  .flow-index__summary {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .flow-index__content {
+    min-height: 24rem;
+    flex: 1 1 auto;
+  }
+
+  .flow-index__grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .flow-index__grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 640px) {
+    .flow-index {
+      gap: 1rem;
+    }
+
+    .flow-index__header {
+      align-items: flex-start;
+    }
+
+    .flow-index__grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/packages/ui/src/lib/pages/Landing.svelte.test.ts
+++ b/packages/ui/src/lib/pages/Landing.svelte.test.ts
@@ -1,10 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import type { FlowDefinition, FlowStats } from '@lib/flows';
 
-// Mock the board manifest edge: control exactly which flows exist and what
-// stats they resolve to, so we test Landing's rendering contract — not the
-// real registry or any flow's network call.
 const getFlows = vi.fn<() => FlowDefinition[]>();
 vi.mock('@lib/flows', () => ({
   getFlows: () => getFlows(),
@@ -28,7 +25,6 @@ function makeFlow(
   };
 }
 
-// Import after the mock is registered.
 const { default: Landing } = await import('./Landing.svelte');
 
 describe('Landing board', () => {
@@ -40,55 +36,44 @@ describe('Landing board', () => {
     expect(document.title).toBe('Cosmic Flow - Data Exploration Hub');
   });
 
-  it('shows three skeleton placeholders while stats load', () => {
-    // A never-resolving getStats keeps the page in its loading state.
+  it('uses the shared loading state while flow stats resolve', () => {
     getFlows.mockReturnValue([makeFlow('spotify', () => new Promise<FlowStats>(() => {}))]);
 
-    const { container } = render(Landing);
+    render(Landing);
 
-    expect(container.querySelectorAll('.skeleton')).toHaveLength(3);
+    expect(screen.getByRole('status')).toHaveTextContent('Loading flow status');
   });
 
-  it('renders a card per registered flow plus the YouTube placeholder', async () => {
+  it('renders every registered flow plus the YouTube placeholder', async () => {
     getFlows.mockReturnValue([
       makeFlow('spotify', { count: 12, status: 'active' }, { name: 'Spotify Flow' }),
     ]);
 
     render(Landing);
 
-    expect(await screen.findByText('Spotify Flow')).toBeInTheDocument();
-    // The hardcoded "coming soon" placeholder always appears.
+    expect(await screen.findByRole('link', { name: 'Open Spotify Flow' })).toBeInTheDocument();
     expect(screen.getByText('YouTube Flow')).toBeInTheDocument();
-    // Skeletons are gone once loaded.
-    expect(document.querySelectorAll('.skeleton')).toHaveLength(0);
   });
 
-  it('makes active flows clickable links to their route', async () => {
+  it('renders active and configured flows as route links', async () => {
     getFlows.mockReturnValue([
       makeFlow('spotify', { count: 5, status: 'active' }, { name: 'Spotify Flow' }),
-    ]);
-
-    render(Landing);
-
-    const card = (await screen.findByText('Spotify Flow')).closest('a');
-    expect(card).toHaveAttribute('href', '/spotify');
-    expect(card?.className).toContain('cursor-pointer');
-    expect(card?.className).not.toContain('cursor-not-allowed');
-  });
-
-  it('treats configured flows as clickable too', async () => {
-    getFlows.mockReturnValue([
       makeFlow('lyrics', { count: 0, status: 'configured' }, { name: 'Lyrics Flow' }),
     ]);
 
     render(Landing);
 
-    const card = (await screen.findByText('Lyrics Flow')).closest('a');
-    expect(card).toHaveAttribute('href', '/lyrics');
-    expect(card?.className).toContain('cursor-pointer');
+    expect(await screen.findByRole('link', { name: 'Open Spotify Flow' })).toHaveAttribute(
+      'href',
+      '/spotify'
+    );
+    expect(screen.getByRole('link', { name: 'Open Lyrics Flow' })).toHaveAttribute(
+      'href',
+      '/lyrics'
+    );
   });
 
-  it('renders disabled flows as non-clickable (no href, not-allowed cursor)', async () => {
+  it('renders disabled flows as non-interactive articles', async () => {
     getFlows.mockReturnValue([
       makeFlow(
         'trading',
@@ -99,12 +84,12 @@ describe('Landing board', () => {
 
     render(Landing);
 
-    const card = (await screen.findByText('Trading Flow')).closest('a');
-    expect(card).not.toHaveAttribute('href');
-    expect(card?.className).toContain('cursor-not-allowed');
+    const heading = await screen.findByText('Trading Flow');
+    expect(heading.closest('article')).toHaveAttribute('data-state', 'unavailable');
+    expect(screen.queryByRole('link', { name: 'Open Trading Flow' })).not.toBeInTheDocument();
   });
 
-  it('shows the item count only when greater than zero', async () => {
+  it('shows item counts only when they are positive', async () => {
     getFlows.mockReturnValue([
       makeFlow('spotify', { count: 42, status: 'active' }, { name: 'Spotify Flow' }),
       makeFlow('empty', { count: 0, status: 'active' }, { name: 'Empty Flow' }),
@@ -112,26 +97,24 @@ describe('Landing board', () => {
 
     render(Landing);
 
-    await screen.findByText('Spotify Flow');
+    await screen.findByRole('link', { name: 'Open Spotify Flow' });
     expect(screen.getByText('42')).toBeInTheDocument();
-    // Items label appears once, for the flow that has a positive count.
     expect(screen.getAllByText('Items')).toHaveLength(1);
   });
 
-  it('falls back to an error status when a flow getStats rejects', async () => {
+  it('isolates a stats failure to the affected flow card', async () => {
     getFlows.mockReturnValue([
       makeFlow('broken', () => Promise.reject(new Error('boom')), { name: 'Broken Flow' }),
     ]);
 
     render(Landing);
 
-    const card = (await screen.findByText('Broken Flow')).closest('a');
-    // An error flow is not clickable.
-    expect(card).not.toHaveAttribute('href');
-    expect(screen.getByText('Error')).toBeInTheDocument();
+    const heading = await screen.findByText('Broken Flow');
+    expect(heading.closest('article')).toHaveAttribute('data-state', 'unavailable');
+    expect(screen.getByText('Error')).toHaveClass('ui-badge--danger');
   });
 
-  it('uses the status message as the badge label when provided', async () => {
+  it('preserves custom status messages from the registry', async () => {
     getFlows.mockReturnValue([
       makeFlow(
         'spotify',
@@ -142,21 +125,18 @@ describe('Landing board', () => {
 
     render(Landing);
 
-    await screen.findByText('Spotify Flow');
-    expect(screen.getByText('8 genres')).toBeInTheDocument();
+    expect(await screen.findByText('8 genres')).toHaveClass('ui-badge--success');
   });
 
-  it('renders the board header and footer chrome', async () => {
+  it('summarizes ready and total flows in the compact header', async () => {
     getFlows.mockReturnValue([]);
 
     render(Landing);
 
-    // "Cosmic Flow" appears in the navbar brand too, so target the board heading.
-    expect(screen.getByRole('heading', { name: 'Cosmic Flow' })).toBeInTheDocument();
-    expect(screen.getByText('Your data flow playground')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Flows' })).toBeInTheDocument();
     await waitFor(() => {
-      // Even with no registered flows, the YouTube placeholder still shows.
-      expect(screen.getByText('YouTube Flow')).toBeInTheDocument();
+      expect(screen.getByText('0 ready')).toBeInTheDocument();
+      expect(screen.getByText('1 total')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/lib/pages/components/FlowCard.svelte
+++ b/packages/ui/src/lib/pages/components/FlowCard.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { Badge } from '@lib/components';
+  import type { FlowStats } from '@lib/flows';
+  import type { FlowCardModel } from '../types';
+
+  let { flow }: { flow: FlowCardModel } = $props();
+
+  const isClickable = $derived(
+    flow.stats.status === 'active' || flow.stats.status === 'configured'
+  );
+
+  function getStatusTone(status: FlowStats['status']): 'success' | 'info' | 'danger' | 'neutral' {
+    switch (status) {
+      case 'active':
+        return 'success';
+      case 'configured':
+        return 'info';
+      case 'error':
+        return 'danger';
+      default:
+        return 'neutral';
+    }
+  }
+
+  function getStatusLabel(stats: FlowStats): string {
+    if (stats.statusMessage) return stats.statusMessage;
+
+    switch (stats.status) {
+      case 'active':
+        return 'Active';
+      case 'configured':
+        return 'Configured';
+      case 'error':
+        return 'Error';
+      default:
+        return 'Unavailable';
+    }
+  }
+</script>
+
+{#snippet cardContent()}
+  <header class="flow-card__header">
+    <span class="flow-card__icon" aria-hidden="true">{flow.icon}</span>
+    <Badge tone={getStatusTone(flow.stats.status)}>{getStatusLabel(flow.stats)}</Badge>
+  </header>
+
+  <div class="flow-card__body">
+    <h2>{flow.name}</h2>
+    <p>{flow.description}</p>
+  </div>
+
+  <footer class="flow-card__footer">
+    {#if flow.stats.count > 0}
+      <span class="flow-card__count">
+        <strong>{flow.stats.count}</strong>
+        <span>Items</span>
+      </span>
+    {:else}
+      <span></span>
+    {/if}
+
+    {#if isClickable}
+      <span class="flow-card__action">Open flow <span aria-hidden="true">→</span></span>
+    {/if}
+  </footer>
+{/snippet}
+
+{#if isClickable}
+  <a class="flow-card flow-card--clickable" href={flow.route} aria-label={`Open ${flow.name}`}>
+    {@render cardContent()}
+  </a>
+{:else}
+  <article
+    class="flow-card flow-card--disabled"
+    data-state="unavailable"
+    aria-label={`${flow.name}: ${getStatusLabel(flow.stats)}`}
+  >
+    {@render cardContent()}
+  </article>
+{/if}
+
+<style>
+  .flow-card {
+    display: flex;
+    min-width: 0;
+    min-height: 13rem;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface);
+    color: var(--ui-text);
+    text-decoration: none;
+  }
+
+  .flow-card--clickable {
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease;
+  }
+
+  .flow-card--clickable:hover {
+    border-color: var(--ui-accent);
+    background: var(--ui-surface-raised);
+  }
+
+  .flow-card--clickable:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 3px;
+  }
+
+  .flow-card--disabled {
+    opacity: 0.68;
+  }
+
+  .flow-card__header,
+  .flow-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .flow-card__icon {
+    display: grid;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex: 0 0 auto;
+    place-items: center;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface-raised);
+    font-size: 1.25rem;
+  }
+
+  .flow-card__body {
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  .flow-card__body h2 {
+    margin: 0;
+    font-size: 1.125rem;
+  }
+
+  .flow-card__body p {
+    margin: 0.5rem 0 0;
+    color: var(--ui-text-muted);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  .flow-card__footer {
+    min-height: 2rem;
+    padding-top: 0.875rem;
+    border-top: 1px solid var(--ui-border);
+  }
+
+  .flow-card__count {
+    display: flex;
+    align-items: baseline;
+    gap: 0.375rem;
+  }
+
+  .flow-card__count strong {
+    font-size: 1.125rem;
+  }
+
+  .flow-card__count span,
+  .flow-card__action {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .flow-card__action {
+    color: var(--ui-accent);
+  }
+</style>

--- a/packages/ui/src/lib/pages/components/FlowCard.svelte.test.ts
+++ b/packages/ui/src/lib/pages/components/FlowCard.svelte.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { FlowCardModel } from '../types';
+import FlowCard from './FlowCard.svelte';
+
+function makeFlow(overrides: Partial<FlowCardModel> = {}): FlowCardModel {
+  return {
+    id: 'spotify',
+    name: 'Spotify Flow',
+    icon: '🎵',
+    description: 'Explore your music library.',
+    route: '/spotify',
+    color: 'from-green-400 to-emerald-500',
+    getStats: async () => ({ count: 12, status: 'active' }),
+    stats: { count: 12, status: 'active' },
+    ...overrides,
+  };
+}
+
+describe('FlowCard', () => {
+  it('renders available flows as named links', () => {
+    render(FlowCard, { props: { flow: makeFlow() } });
+
+    expect(screen.getByRole('link', { name: 'Open Spotify Flow' })).toHaveAttribute(
+      'href',
+      '/spotify'
+    );
+    expect(screen.getByText('Active')).toHaveClass('ui-badge--success');
+  });
+
+  it('renders unavailable flows as disabled articles', () => {
+    render(FlowCard, {
+      props: {
+        flow: makeFlow({ stats: { count: 0, status: 'disabled' } }),
+      },
+    });
+
+    expect(screen.queryByRole('link', { name: 'Open Spotify Flow' })).not.toBeInTheDocument();
+    expect(screen.getByRole('article', { name: 'Spotify Flow: Unavailable' })).toHaveAttribute(
+      'data-state',
+      'unavailable'
+    );
+    expect(screen.getByText('Unavailable')).toHaveClass('ui-badge--neutral');
+  });
+
+  it('shows custom status messages and positive item counts', () => {
+    render(FlowCard, {
+      props: {
+        flow: makeFlow({ stats: { count: 42, status: 'configured', statusMessage: 'Stopped' } }),
+      },
+    });
+
+    expect(screen.getByText('Stopped')).toHaveClass('ui-badge--info');
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Items')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/lib/pages/types.ts
+++ b/packages/ui/src/lib/pages/types.ts
@@ -1,0 +1,5 @@
+import type { FlowDefinition, FlowStats } from '@lib/flows';
+
+export interface FlowCardModel extends FlowDefinition {
+  stats: FlowStats;
+}


### PR DESCRIPTION
## Summary

- replace the root marketing-style hero and legacy glass cards with a compact operational flow index
- extract a page-local `FlowCard` domain component and presentation model
- render active/configured flows as accessible links and unavailable/error flows as named articles
- migrate loading and status display to shared `AsyncState` and `Badge` primitives
- preserve registry order, live stats, routes, item counts, custom status messages, and the YouTube placeholder
- update focused tests and UI architecture/design-system documentation

## User impact

The root page is denser and easier to scan, unavailable flows no longer masquerade as links, and each flow failure remains isolated to its own card.

## Areas touched

- `packages/ui/src/lib/pages/Landing.svelte`
- `packages/ui/src/lib/pages/components/FlowCard.svelte`
- root dashboard tests and presentation types
- `docs/architecture/ui.md`
- `docs/design-system.md`

## Validation

- `pnpm verify`
- `pnpm build`
- 386 UI tests / 920 total tests
- browser validation at 1280x721 and 390x844
- 5 available flow links and 1 named unavailable article verified
- no legacy `glass`/`text-cosmic` classes in the root dashboard
- no horizontal DOM overflow or browser console errors

Closes #59
Refs #24