### PR TITLE
refactor(ui): migrate trading surfaces

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -10,17 +10,17 @@ not leak into component implementation.
 Base and Tailwind theme tokens live in `packages/ui/src/app.css`. Shared components consume
 semantic variables rather than palette names:
 
-| Token | Purpose |
-| --- | --- |
-| `--ui-accent` | primary action and selected state |
-| `--ui-accent-strong` | active/pressed accent |
-| `--ui-focus` | keyboard focus indicator |
-| `--ui-danger` | destructive/error action |
-| `--ui-surface` | base component surface |
-| `--ui-surface-raised` | elevated surface |
-| `--ui-border` | standard boundary |
-| `--ui-text` | primary text |
-| `--ui-text-muted` | secondary text |
+| Token                 | Purpose                           |
+| --------------------- | --------------------------------- |
+| `--ui-accent`         | primary action and selected state |
+| `--ui-accent-strong`  | active/pressed accent             |
+| `--ui-focus`          | keyboard focus indicator          |
+| `--ui-danger`         | destructive/error action          |
+| `--ui-surface`        | base component surface            |
+| `--ui-surface-raised` | elevated surface                  |
+| `--ui-border`         | standard boundary                 |
+| `--ui-text`           | primary text                      |
+| `--ui-text-muted`     | secondary text                    |
 
 Palette selection uses `data-theme` on an ancestor. The default galaxy palette is cyan;
 `data-theme="fire"` uses rose accents; `data-theme="organic"` uses lime accents. Palette
@@ -36,6 +36,8 @@ Shared primitives live in `packages/ui/src/lib/components/ui` and are exported t
 - `Field` for label, control, hint, and error relationships.
 - `Badge` for compact status/category metadata.
 - `AsyncState` for loading, empty, and error presentation.
+- `Panel` for bounded application surfaces with semantic element, padding, and elevation
+  options. It frames a single tool or repeated item; do not nest panels for decoration.
 - `ModalShell` for dialog structure, dismissal, and focus behavior.
 
 New UI composes these primitives before introducing a flow-local equivalent. A local
@@ -54,8 +56,9 @@ component is justified when it owns domain behavior, not merely different colors
 
 ## Migration Status
 
-The application shell, root flow dashboard, Canvas editor controls, Chat send/stop
-actions, Spotify controls, and the Lyrics list, analysis, and detail modal surfaces use
-semantic tokens and shared primitives. Remaining flow-local surfaces should migrate in
-small PRs under issue #24. Legacy cosmic/glass utilities remain in `app.css`; removing or
-consolidating them is part of that migration, not documentation housekeeping.
+The application shell, root flow dashboard, Trading dashboard and cascade wizard, Canvas
+editor controls, Chat send/stop actions, Spotify controls, and the Lyrics list, analysis,
+and detail modal surfaces use semantic tokens and shared primitives. Remaining flow-local
+surfaces should migrate in small PRs under issue #24. Legacy cosmic/glass utilities remain
+in `app.css`; removing or consolidating them is part of that migration, not documentation
+housekeeping.

--- a/packages/ui/src/lib/components/ui/Panel.svelte
+++ b/packages/ui/src/lib/components/ui/Panel.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type PanelElement = 'article' | 'div' | 'section';
+  type PanelPadding = 'none' | 'sm' | 'md' | 'lg';
+
+  interface Props {
+    children: Snippet;
+    element?: PanelElement;
+    padding?: PanelPadding;
+    raised?: boolean;
+    ariaLabel?: string;
+    class?: string;
+  }
+
+  let {
+    children,
+    element = 'div',
+    padding = 'md',
+    raised = false,
+    ariaLabel,
+    class: className = '',
+  }: Props = $props();
+
+  const classes = $derived(
+    `ui-panel ui-panel--${padding}${raised ? ' ui-panel--raised' : ''} ${className}`
+  );
+</script>
+
+{#if element === 'section'}
+  <section class={classes} aria-label={ariaLabel}>{@render children()}</section>
+{:else if element === 'article'}
+  <article class={classes} aria-label={ariaLabel}>{@render children()}</article>
+{:else}
+  <div class={classes} aria-label={ariaLabel}>{@render children()}</div>
+{/if}
+
+<style>
+  .ui-panel {
+    min-width: 0;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface);
+    color: var(--ui-text);
+  }
+
+  .ui-panel--raised {
+    background: var(--ui-surface-raised);
+  }
+
+  .ui-panel--none {
+    padding: 0;
+  }
+
+  .ui-panel--sm {
+    padding: 0.75rem;
+  }
+
+  .ui-panel--md {
+    padding: 1rem;
+  }
+
+  .ui-panel--lg {
+    padding: 1.5rem;
+  }
+</style>

--- a/packages/ui/src/lib/components/ui/index.ts
+++ b/packages/ui/src/lib/components/ui/index.ts
@@ -4,3 +4,4 @@ export { default as Button } from './Button.svelte';
 export { default as Field } from './Field.svelte';
 export { default as IconButton } from './IconButton.svelte';
 export { default as ModalShell } from './ModalShell.svelte';
+export { default as Panel } from './Panel.svelte';

--- a/packages/ui/src/lib/components/ui/ui.test.ts
+++ b/packages/ui/src/lib/components/ui/ui.test.ts
@@ -7,6 +7,7 @@ import Button from './Button.svelte';
 import Field from './Field.svelte';
 import IconButton from './IconButton.svelte';
 import ModalShell from './ModalShell.svelte';
+import Panel from './Panel.svelte';
 
 const textSnippet = (text: string) => createRawSnippet(() => ({ render: () => text }));
 
@@ -53,6 +54,23 @@ describe('UI primitives', () => {
   it('AsyncState uses alert semantics for failures', () => {
     render(AsyncState, { props: { state: 'error', title: 'Request failed' } });
     expect(screen.getByRole('alert')).toHaveTextContent('Request failed');
+  });
+
+  it('Panel exposes its semantic element, label, and surface variant', () => {
+    render(Panel, {
+      props: {
+        element: 'section',
+        ariaLabel: 'Market summary',
+        raised: true,
+        padding: 'sm',
+        children: textSnippet('Summary content'),
+      },
+    });
+
+    expect(screen.getByRole('region', { name: 'Market summary' })).toHaveClass(
+      'ui-panel--raised',
+      'ui-panel--sm'
+    );
   });
 
   it('ModalShell exposes dialog semantics and closes from its command', async () => {

--- a/packages/ui/src/lib/flows/trading/TradingFlow.svelte
+++ b/packages/ui/src/lib/flows/trading/TradingFlow.svelte
@@ -1,58 +1,68 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
-  import { FlowLayout } from '@lib/components';
+  import { onDestroy, onMount } from 'svelte';
+  import { AsyncState, Badge, Button, FlowLayout, Panel } from '@lib/components';
   import StepWizard from './components/StepWizard.svelte';
   import {
-    tradingStore,
-    startTrading,
-    stopTrading,
-    fetchKlines,
-    toggleAdvisor,
-    generateInsight,
-    generateWizardInsight,
     connectToStream,
     disconnectFromStream,
+    fetchKlines,
+    generateInsight,
+    generateWizardInsight,
+    startTrading,
+    stopTrading,
+    toggleAdvisor,
+    tradingStore,
     type AdvisorNote,
     type TradingPageData,
   } from './trading';
 
-  let { initialData }: { initialData: TradingPageData } = $props();
+  type BadgeTone = 'danger' | 'info' | 'neutral' | 'success' | 'warning';
 
-  // Local interface extension to bypass potential type-check caching issues
   interface EnhancedAdvisorNote extends AdvisorNote {
     _debugContext?: unknown;
   }
 
-  // Local derived state (from the runes store)
+  let { initialData }: { initialData: TradingPageData } = $props();
+
   let tradingData = $derived(tradingStore.tradingState);
   let advisor = $derived(tradingStore.advisorState);
   let insight = $derived(tradingStore.latestInsight) as EnhancedAdvisorNote | null;
   let candleList = $derived(tradingStore.candles);
   let loadingInsight = $derived(tradingStore.isLoadingInsight);
-
-  // View mode: 'dashboard' or 'wizard'
   let viewMode: 'dashboard' | 'wizard' = $state('dashboard');
 
-  // Format price with commas
   function formatPrice(price: number | undefined): string {
-    if (!price) return '—';
+    if (price === undefined) return 'N/A';
     return price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   }
 
-  // Format timestamp
-  function formatTime(ts: number | string | null): string {
-    if (!ts) return '—';
-    const date = typeof ts === 'string' ? new Date(ts) : new Date(ts);
-    return date.toLocaleTimeString('en-US', {
+  function formatTime(timestamp: number | string | null): string {
+    if (timestamp === null) return 'N/A';
+    return new Date(timestamp).toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
     });
   }
 
+  function getSentimentTone(bias: AdvisorNote['sentiment_bias']): BadgeTone {
+    if (bias === 'LONG') return 'success';
+    if (bias === 'SHORT') return 'danger';
+    return 'neutral';
+  }
+
+  function getSentimentLabel(bias: AdvisorNote['sentiment_bias']): string {
+    if (bias === 'LONG') return 'Bullish';
+    if (bias === 'SHORT') return 'Bearish';
+    return 'Neutral';
+  }
+
+  function getCandleChange(open: number, close: number): number {
+    if (open === 0) return 0;
+    return ((close - open) / open) * 100;
+  }
+
   onMount(() => {
-    // Hydrate the runes store from the data the universal loader fetched,
-    // then open the live stream. (The initial fetch used to live here.)
     if (initialData.trading) tradingStore.setTradingState(initialData.trading);
     if (initialData.advisor) tradingStore.setAdvisorState(initialData.advisor);
     tradingStore.setCandles(initialData.candles);
@@ -66,128 +76,78 @@
 </script>
 
 <FlowLayout>
-  <div class="text-white/90">
-    <!-- Header -->
-    <header class="text-center mb-8">
-      <h1 class="text-4xl md:text-5xl font-bold flex items-center justify-center gap-3">
-        <span>📈</span>
-        <span class="bg-gradient-to-r from-amber-400 to-orange-500 bg-clip-text text-transparent"
-          >Trading Bot</span
-        >
-      </h1>
-      <p class="text-white/40 mt-2">
-        Real-time BTC analysis with Hurst exponent, fractals, and AI insights
-      </p>
+  <div class="trading-flow">
+    <header class="page-header">
+      <div>
+        <h1>Trading Bot</h1>
+        <p>{tradingData.symbol} / {tradingData.interval.toUpperCase()}</p>
+      </div>
+      <Badge tone={tradingData.isRunning ? 'success' : 'neutral'}>
+        {tradingData.isRunning ? 'Stream connected' : 'Stream disconnected'}
+      </Badge>
     </header>
 
-    <!-- Status Panel -->
-    <section class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-      <div class="glass p-4 rounded-xl flex items-center gap-3">
-        <div
-          class="w-3 h-3 rounded-full transition-all duration-300 {tradingData.isRunning
-            ? 'bg-green-500 shadow-[0_0_10px_rgba(34,197,94,0.5)]'
-            : 'bg-white/20'}"
-        ></div>
-        <div class="flex-1">
-          <div class="text-xs text-white/40 uppercase tracking-wider">Stream</div>
-          <div class="text-sm font-semibold">
-            {tradingData.isRunning ? 'Connected' : 'Disconnected'}
-          </div>
+    <dl class="status-grid" aria-label="Market status">
+      <Panel padding="sm">
+        <div class="status-item">
+          <dt>Stream</dt>
+          <dd>{tradingData.isRunning ? 'Connected' : 'Disconnected'}</dd>
         </div>
-      </div>
-
-      <div class="glass p-4 rounded-xl flex items-center gap-3">
-        <span class="text-2xl">₿</span>
-        <div class="flex-1">
-          <div class="text-xs text-white/40 uppercase tracking-wider">{tradingData.symbol}</div>
-          <div class="text-sm font-semibold text-amber-400">
-            ${formatPrice(tradingData.lastCandle?.close)}
-          </div>
+      </Panel>
+      <Panel padding="sm">
+        <div class="status-item">
+          <dt>{tradingData.symbol}</dt>
+          <dd class="accent">${formatPrice(tradingData.lastCandle?.close)}</dd>
         </div>
-      </div>
-
-      <div class="glass p-4 rounded-xl flex items-center gap-3">
-        <span class="text-2xl">📊</span>
-        <div class="flex-1">
-          <div class="text-xs text-white/40 uppercase tracking-wider">Candles</div>
-          <div class="text-sm font-semibold">{tradingData.candleCount.toLocaleString()}</div>
+      </Panel>
+      <Panel padding="sm">
+        <div class="status-item">
+          <dt>Candles</dt>
+          <dd>{tradingData.candleCount.toLocaleString()}</dd>
         </div>
-      </div>
-
-      <div class="glass p-4 rounded-xl flex items-center gap-3">
-        <span class="text-2xl">⏱️</span>
-        <div class="flex-1">
-          <div class="text-xs text-white/40 uppercase tracking-wider">Last Update</div>
-          <div class="text-sm font-semibold">
-            {formatTime(tradingData.lastCandle?.closeTime || null)}
-          </div>
+      </Panel>
+      <Panel padding="sm">
+        <div class="status-item">
+          <dt>Last update</dt>
+          <dd>{formatTime(tradingData.lastCandle?.closeTime ?? null)}</dd>
         </div>
-      </div>
-    </section>
+      </Panel>
+    </dl>
 
-    <!-- Control Panel -->
-    <section class="glass p-6 rounded-xl mb-8">
-      <h2 class="text-sm font-semibold text-white/40 uppercase tracking-wider mb-4">Controls</h2>
-      <div class="flex flex-wrap gap-3">
+    <Panel element="section" ariaLabel="Trading controls">
+      <div class="panel-heading">
+        <h2>Controls</h2>
+      </div>
+      <div class="control-list">
         {#if tradingData.isRunning}
-          <button
-            onclick={stopTrading}
-            class="px-6 py-3 rounded-lg bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 transition-all font-medium"
-          >
-            ⏹️ Stop Stream
-          </button>
+          <Button variant="danger" onclick={stopTrading}>Stop stream</Button>
         {:else}
-          <button
-            onclick={startTrading}
-            class="px-6 py-3 rounded-lg bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 transition-all font-medium"
-          >
-            ▶️ Start Stream
-          </button>
+          <Button onclick={startTrading}>Start stream</Button>
         {/if}
-
-        <button
-          onclick={toggleAdvisor}
-          class="px-6 py-3 rounded-lg transition-all font-medium {advisor.isEnabled
-            ? 'bg-gradient-to-r from-amber-500 to-orange-600'
-            : 'bg-white/5 hover:bg-white/10 border border-white/20'}"
-        >
-          {advisor.isEnabled ? '🧠 Advisor ON' : '💤 Advisor OFF'}
-        </button>
-
-        <button
-          onclick={generateInsight}
-          disabled={loadingInsight}
-          class="px-6 py-3 rounded-lg bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {loadingInsight ? '⏳ Generating...' : '✨ Generate Insight'}
-        </button>
-
-        <!-- Wizard Toggle -->
-        <button
+        <Button variant={advisor.isEnabled ? 'primary' : 'secondary'} onclick={toggleAdvisor}>
+          Advisor {advisor.isEnabled ? 'on' : 'off'}
+        </Button>
+        <Button onclick={generateInsight} loading={loadingInsight}>Generate insight</Button>
+        <Button
+          variant={viewMode === 'wizard' ? 'primary' : 'secondary'}
           onclick={() => (viewMode = viewMode === 'dashboard' ? 'wizard' : 'dashboard')}
-          class="px-6 py-3 rounded-lg transition-all font-medium {viewMode === 'wizard'
-            ? 'bg-gradient-to-r from-cyan-500 to-blue-600'
-            : 'bg-white/5 hover:bg-white/10 border border-white/20'}"
         >
-          {viewMode === 'wizard' ? '🧙‍♂️ Wizard Mode' : '🧙‍♂️ Open Wizard'}
-        </button>
+          {viewMode === 'wizard' ? 'Wizard mode' : 'Open wizard'}
+        </Button>
       </div>
-    </section>
+    </Panel>
 
-    <!-- Wizard Mode -->
     {#if viewMode === 'wizard'}
-      <section class="glass p-6 rounded-xl mb-8">
-        <div class="flex items-center justify-between mb-6">
-          <h2 class="text-2xl font-bold text-cyan-400 flex items-center gap-2">
-            🧙‍♂️ Cascade Analysis Wizard
-          </h2>
-          <button
-            onclick={() => (viewMode = 'dashboard')}
-            class="px-4 py-2 text-sm bg-white/10 hover:bg-white/20 rounded-lg transition-colors"
-          >
-            ← Back to Dashboard
-          </button>
-        </div>
+      <section class="wizard-view" aria-labelledby="wizard-title">
+        <header class="mode-header">
+          <div>
+            <h2 id="wizard-title">Cascade analysis wizard</h2>
+            <p>Multi-timeframe market analysis</p>
+          </div>
+          <Button variant="ghost" size="sm" onclick={() => (viewMode = 'dashboard')}>
+            Back to dashboard
+          </Button>
+        </header>
         <StepWizard
           onFetchKlines={fetchKlines}
           onGenerateInsightForTimeframe={async (
@@ -205,173 +165,394 @@
               previousInsights,
             });
 
-            if (result) {
-              return { insight: result.insight, analysis: result.analysis };
-            }
+            if (result) return { insight: result.insight, analysis: result.analysis };
             return null;
           }}
         />
       </section>
     {:else}
-      <!-- Main Content Grid (Dashboard Mode) -->
-      <div class="grid md:grid-cols-2 gap-6">
-        <!-- Candle Feed -->
-        <section class="glass p-6 rounded-xl">
-          <h3 class="text-lg font-semibold mb-4 flex items-center gap-2">
-            📈 <span>Live Candles</span>
-          </h3>
-          <div class="max-h-96 overflow-y-auto space-y-2">
-            {#each candleList.slice(-20).reverse() as candle (candle.openTime)}
-              <div
-                class="flex justify-between items-center py-2 px-3 rounded-lg bg-white/5 border-b border-white/5 font-mono text-xs"
-              >
-                <span class="text-white/40">{formatTime(candle.openTime)}</span>
-                <span class="text-amber-400 font-semibold">${formatPrice(candle.close)}</span>
-                <span
-                  class="font-semibold {candle.close > candle.open
-                    ? 'text-green-500'
-                    : 'text-red-500'}"
-                >
-                  {candle.close > candle.open ? '↑' : '↓'}
-                  {Math.abs(((candle.close - candle.open) / candle.open) * 100).toFixed(3)}%
-                </span>
-              </div>
-            {:else}
-              <p class="text-center text-white/30 py-8">
-                No candles yet. Start the stream to collect data.
-              </p>
-            {/each}
+      <div class="dashboard-grid">
+        <Panel element="section" ariaLabel="Live candles">
+          <div class="panel-heading">
+            <div>
+              <h2>Live candles</h2>
+              <p>Latest {tradingData.interval} market updates</p>
+            </div>
+            <Badge tone="info">{candleList.length} loaded</Badge>
           </div>
-        </section>
 
-        <!-- Advisor Insight -->
-        <section class="glass p-6 rounded-xl">
-          <h3 class="text-lg font-semibold mb-4 flex items-center gap-2">
-            🧠 <span>Advisor Insight</span>
-          </h3>
-          {#if insight}
-            <div class="space-y-4 max-h-96 overflow-y-auto">
-              <div class="flex items-center justify-between gap-4">
-                <h4 class="text-xl font-bold text-amber-400">{insight.title}</h4>
-                {#if insight.sentiment_bias}
-                  <span
-                    class="px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wider {insight.sentiment_bias ===
-                    'LONG'
-                      ? 'bg-green-500/20 text-green-400 border border-green-500/50'
-                      : insight.sentiment_bias === 'SHORT'
-                        ? 'bg-red-500/20 text-red-400 border border-red-500/50'
-                        : 'bg-gray-500/20 text-gray-400 border border-gray-500/50'}"
-                  >
-                    {insight.sentiment_bias === 'LONG'
-                      ? '🐂 BULLISH'
-                      : insight.sentiment_bias === 'SHORT'
-                        ? '🐻 BEARISH'
-                        : '⚖️ NEUTRAL'}
+          {#if candleList.length > 0}
+            <ul class="candle-list" aria-label="Recent candles">
+              {#each candleList.slice(-20).reverse() as candle (candle.openTime)}
+                {@const change = getCandleChange(candle.open, candle.close)}
+                <li class="candle-row">
+                  <time datetime={new Date(candle.openTime).toISOString()}>
+                    {formatTime(candle.openTime)}
+                  </time>
+                  <strong>${formatPrice(candle.close)}</strong>
+                  <span class:positive={change > 0} class:negative={change < 0}>
+                    {change > 0 ? '+' : ''}{change.toFixed(3)}%
                   </span>
-                {/if}
-              </div>
+                </li>
+              {/each}
+            </ul>
+          {:else}
+            <AsyncState
+              state="empty"
+              title="No candles yet"
+              message="Start the stream to collect market data."
+            />
+          {/if}
+        </Panel>
+
+        <Panel element="section" ariaLabel="Advisor insight">
+          <div class="panel-heading">
+            <div>
+              <h2>Advisor insight</h2>
+              <p>Current market interpretation</p>
+            </div>
+            {#if insight?.sentiment_bias}
+              <Badge tone={getSentimentTone(insight.sentiment_bias)}>
+                {getSentimentLabel(insight.sentiment_bias)}
+              </Badge>
+            {/if}
+          </div>
+
+          {#if insight}
+            <div class="insight-content">
+              <h3>{insight.title}</h3>
 
               {#if insight.regime_context}
-                <div class="p-4 rounded-lg bg-white/5">
-                  <div class="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2">
-                    📊 Regime Context
-                  </div>
-                  <p class="text-sm leading-relaxed">{insight.regime_context}</p>
-                </div>
+                <section class="insight-block" aria-labelledby="regime-heading">
+                  <h4 id="regime-heading">Regime context</h4>
+                  <p>{insight.regime_context}</p>
+                </section>
               {/if}
 
               {#if insight.scenario_bullish}
-                <div class="p-4 rounded-lg bg-white/5 border-l-4 border-green-500">
-                  <div class="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2">
-                    🟢 Bullish Scenario
-                  </div>
-                  <p class="text-sm leading-relaxed">{insight.scenario_bullish}</p>
-                </div>
+                <section class="insight-block positive-block" aria-labelledby="bullish-heading">
+                  <h4 id="bullish-heading">Bullish scenario</h4>
+                  <p>{insight.scenario_bullish}</p>
+                </section>
               {/if}
 
               {#if insight.scenario_bearish}
-                <div class="p-4 rounded-lg bg-white/5 border-l-4 border-red-500">
-                  <div class="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2">
-                    🔴 Bearish Scenario
-                  </div>
-                  <p class="text-sm leading-relaxed">{insight.scenario_bearish}</p>
-                </div>
+                <section class="insight-block negative-block" aria-labelledby="bearish-heading">
+                  <h4 id="bearish-heading">Bearish scenario</h4>
+                  <p>{insight.scenario_bearish}</p>
+                </section>
               {/if}
 
               {#if insight.risk_management}
-                <div class="p-4 rounded-lg bg-orange-500/10 border-l-4 border-orange-500">
-                  <div class="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2">
-                    🛡️ Risk Management
-                  </div>
-                  <div class="grid grid-cols-2 gap-4 text-sm">
+                <section class="insight-block warning-block" aria-labelledby="risk-heading">
+                  <h4 id="risk-heading">Risk management</h4>
+                  <dl class="risk-grid">
                     <div>
-                      <span class="text-white/50">Stop Loss:</span>
-                      <span class="font-bold text-orange-400">
-                        ${formatPrice(insight.risk_management.recommended_sl)}
-                      </span>
+                      <dt>Stop loss</dt>
+                      <dd>${formatPrice(insight.risk_management.recommended_sl)}</dd>
                     </div>
                     <div>
-                      <span class="text-white/50">Reason:</span>
-                      <span class="text-white/80"
-                        >{insight.risk_management.invalidation_reason}</span
-                      >
+                      <dt>Invalidation</dt>
+                      <dd>{insight.risk_management.invalidation_reason}</dd>
                     </div>
-                  </div>
-                </div>
+                  </dl>
+                </section>
               {/if}
 
               {#if insight.mentor_tip}
-                <div class="p-4 rounded-lg bg-indigo-500/10 border-l-4 border-indigo-500">
-                  <div class="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2">
-                    💡 Mentor Tip
-                  </div>
-                  <p class="text-sm leading-relaxed">{insight.mentor_tip}</p>
-                </div>
+                <section class="insight-block info-block" aria-labelledby="mentor-heading">
+                  <h4 id="mentor-heading">Mentor tip</h4>
+                  <p>{insight.mentor_tip}</p>
+                </section>
               {/if}
 
-              <!-- New: Reasoning & Confidence (Iteration 2) -->
               {#if insight.reasoning_key_factors && insight.reasoning_key_factors.length > 0}
-                <div class="p-4 rounded-lg bg-blue-500/10 border-l-4 border-blue-500">
-                  <div
-                    class="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2 flex justify-between"
-                  >
-                    <span>Logic Trace</span>
-                    {#if insight.confidence_score}
-                      <span class="text-blue-300">Confidence: {insight.confidence_score}%</span>
+                <section class="insight-block info-block" aria-labelledby="logic-heading">
+                  <div class="insight-block-heading">
+                    <h4 id="logic-heading">Logic trace</h4>
+                    {#if insight.confidence_score !== undefined}
+                      <Badge tone="info">Confidence: {insight.confidence_score}%</Badge>
                     {/if}
                   </div>
-                  <ul class="list-disc list-inside space-y-1 text-sm text-white/80">
+                  <ul class="factor-list">
                     {#each insight.reasoning_key_factors as factor (factor)}
                       <li>{factor}</li>
                     {/each}
                   </ul>
-                </div>
+                </section>
               {/if}
 
-              <!-- New: Glass Box Debug (Iteration 2) -->
               {#if insight._debugContext}
-                <div class="pt-2">
-                  <details class="group">
-                    <summary
-                      class="cursor-pointer text-[10px] text-white/20 hover:text-white/40 uppercase tracking-wider transition-colors select-none"
-                    >
-                      Show Glass Box Data (Debug)
-                    </summary>
-                    <pre
-                      class="mt-2 text-[10px] text-green-400/80 bg-black/40 p-3 rounded-lg overflow-x-auto font-mono max-h-60">
-{JSON.stringify(insight._debugContext, null, 2)}
-                  </pre>
-                  </details>
-                </div>
+                <details class="debug-details">
+                  <summary>Show analysis context</summary>
+                  <pre>{JSON.stringify(insight._debugContext, null, 2)}</pre>
+                </details>
               {/if}
             </div>
           {:else}
-            <p class="text-center text-white/30 py-8">
-              No insights available yet. Collect some data and click "Generate Insight".
-            </p>
+            <AsyncState
+              state="empty"
+              title="No insight available"
+              message="Collect market data, then generate an insight."
+            />
           {/if}
-        </section>
+        </Panel>
       </div>
     {/if}
   </div>
 </FlowLayout>
+
+<style>
+  .trading-flow {
+    display: grid;
+    min-width: 0;
+    gap: 1rem;
+    color: var(--ui-text);
+  }
+
+  .page-header,
+  .mode-header,
+  .panel-heading,
+  .insight-block-heading {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .page-header h1,
+  .mode-header h2,
+  .panel-heading h2,
+  .insight-content h3,
+  .insight-block h4 {
+    margin: 0;
+    letter-spacing: 0;
+  }
+
+  .page-header h1 {
+    font-size: 2.25rem;
+    line-height: 1.1;
+  }
+
+  .page-header p,
+  .mode-header p,
+  .panel-heading p {
+    margin: 0.25rem 0 0;
+    color: var(--ui-text-muted);
+    font-size: 0.875rem;
+  }
+
+  .status-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+  }
+
+  .status-item {
+    display: grid;
+    gap: 0.375rem;
+  }
+
+  .status-item dt,
+  .risk-grid dt {
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .status-item dd,
+  .risk-grid dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .status-item dd {
+    font-weight: 700;
+  }
+
+  .status-item .accent,
+  .candle-row strong {
+    color: var(--ui-focus);
+  }
+
+  .panel-heading {
+    margin-bottom: 1rem;
+  }
+
+  .panel-heading h2,
+  .mode-header h2 {
+    font-size: 1.125rem;
+  }
+
+  .control-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .wizard-view {
+    display: grid;
+    min-width: 0;
+    gap: 1rem;
+    padding: 0.5rem 0;
+  }
+
+  .dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .candle-list {
+    display: grid;
+    max-height: 24rem;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    list-style: none;
+  }
+
+  .candle-row {
+    display: grid;
+    grid-template-columns: minmax(6rem, 1fr) minmax(6rem, 1fr) minmax(5rem, auto);
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0;
+    border-bottom: 1px solid var(--ui-border);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+  }
+
+  .candle-row time {
+    color: var(--ui-text-muted);
+  }
+
+  .candle-row span {
+    justify-self: end;
+    font-weight: 700;
+  }
+
+  .positive {
+    color: #4ade80;
+  }
+
+  .negative {
+    color: var(--ui-danger);
+  }
+
+  .insight-content {
+    display: grid;
+    max-height: 30rem;
+    gap: 1rem;
+    overflow-y: auto;
+  }
+
+  .insight-content h3 {
+    color: var(--ui-focus);
+    font-size: 1.125rem;
+  }
+
+  .insight-block {
+    padding-left: 0.875rem;
+    border-left: 3px solid var(--ui-border);
+  }
+
+  .insight-block h4 {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+  }
+
+  .insight-block p {
+    margin: 0.375rem 0 0;
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+
+  .positive-block {
+    border-left-color: #4ade80;
+  }
+
+  .negative-block {
+    border-left-color: var(--ui-danger);
+  }
+
+  .warning-block {
+    border-left-color: #facc15;
+  }
+
+  .info-block {
+    border-left-color: var(--ui-focus);
+  }
+
+  .risk-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+    gap: 1rem;
+    margin: 0.75rem 0 0;
+  }
+
+  .risk-grid > div {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .factor-list {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+    color: var(--ui-text-muted);
+    font-size: 0.875rem;
+  }
+
+  .debug-details summary {
+    cursor: pointer;
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+  }
+
+  .debug-details pre {
+    max-height: 15rem;
+    margin: 0.5rem 0 0;
+    padding: 0.75rem;
+    overflow: auto;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: #020617;
+    color: #86efac;
+    font-size: 0.7rem;
+  }
+
+  @media (max-width: 48rem) {
+    .status-grid,
+    .dashboard-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .page-header,
+    .mode-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .page-header h1 {
+      font-size: 1.75rem;
+    }
+
+    .control-list :global(.ui-button) {
+      flex: 1 1 10rem;
+    }
+
+    .candle-row {
+      grid-template-columns: minmax(5rem, 1fr) minmax(5rem, 1fr) minmax(4.5rem, auto);
+      gap: 0.5rem;
+    }
+
+    .risk-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/trading/TradingFlow.svelte.test.ts
+++ b/packages/ui/src/lib/flows/trading/TradingFlow.svelte.test.ts
@@ -131,9 +131,9 @@ describe('TradingFlow — status panel', () => {
   it('shows Disconnected and a start button when not running', () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     expect(screen.getByText('Disconnected')).toBeInTheDocument();
-    expect(screen.getByText(/Start Stream/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Start stream/i })).toBeInTheDocument();
     // Negative space: no stop button in the stopped state.
-    expect(screen.queryByText(/Stop Stream/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Stop stream/i })).not.toBeInTheDocument();
   });
 
   it('shows Connected and a stop button when running', async () => {
@@ -148,8 +148,8 @@ describe('TradingFlow — status panel', () => {
     });
     await tick();
     expect(screen.getByText('Connected')).toBeInTheDocument();
-    expect(screen.getByText(/Stop Stream/)).toBeInTheDocument();
-    expect(screen.queryByText(/Start Stream/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Stop stream/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Start stream/i })).not.toBeInTheDocument();
   });
 
   it('renders the formatted last price and candle count', async () => {
@@ -169,16 +169,26 @@ describe('TradingFlow — status panel', () => {
     expect(screen.getByText(/1[.,]500/)).toBeInTheDocument();
   });
 
-  it('shows the em-dash placeholder for price when there is no candle', () => {
+  it('shows the unavailable placeholder for price when there is no candle', () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
-    expect(screen.getByText('$—')).toBeInTheDocument();
+    expect(screen.getByText('$N/A')).toBeInTheDocument();
+  });
+
+  it('renders a zero price instead of treating it as missing', async () => {
+    render(TradingFlow, { props: { initialData: emptyData() } });
+    tradingStore.updateTradingState((state) => ({
+      ...state,
+      lastCandle: makeCandle({ close: 0 }),
+    }));
+    await tick();
+    expect(screen.getByText('$0.00')).toBeInTheDocument();
   });
 });
 
 describe('TradingFlow — control buttons', () => {
   it('invokes startTrading when the start button is clicked', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
-    await fireEvent.click(screen.getByText(/Start Stream/));
+    await fireEvent.click(screen.getByRole('button', { name: /Start stream/i }));
     expect(actions.startTrading).toHaveBeenCalledOnce();
   });
 
@@ -186,34 +196,32 @@ describe('TradingFlow — control buttons', () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     tradingStore.updateTradingState((s) => ({ ...s, isRunning: true }));
     await tick();
-    await fireEvent.click(screen.getByText(/Stop Stream/));
+    await fireEvent.click(screen.getByRole('button', { name: /Stop stream/i }));
     expect(actions.stopTrading).toHaveBeenCalledOnce();
   });
 
   it('invokes toggleAdvisor and reflects advisor on/off label', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
-    expect(screen.getByText(/Advisor OFF/)).toBeInTheDocument();
-    await fireEvent.click(screen.getByText(/Advisor OFF/));
+    expect(screen.getByRole('button', { name: /Advisor off/i })).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: /Advisor off/i }));
     expect(actions.toggleAdvisor).toHaveBeenCalledOnce();
 
     tradingStore.updateAdvisorState((s) => ({ ...s, isEnabled: true }));
     await tick();
-    expect(screen.getByText(/Advisor ON/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Advisor on/i })).toBeInTheDocument();
   });
 
   it('invokes generateInsight and disables the button while loading', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
-    // Target the control button by role — the empty-state copy also mentions
-    // "Generate Insight", so a plain text query is ambiguous.
-    const btn = screen.getByRole('button', { name: /Generate Insight/ });
+    const btn = screen.getByRole('button', { name: /Generate insight/i });
     await fireEvent.click(btn);
     expect(actions.generateInsight).toHaveBeenCalledOnce();
 
     tradingStore.setLoadingInsight(true);
     await tick();
-    const loadingBtn = screen.getByRole('button', { name: /Generating/ });
-    expect(loadingBtn).toBeInTheDocument();
+    const loadingBtn = screen.getByRole('button', { name: /Generate insight/i });
     expect(loadingBtn).toBeDisabled();
+    expect(loadingBtn).toHaveAttribute('aria-busy', 'true');
   });
 });
 
@@ -223,22 +231,20 @@ describe('TradingFlow — candle feed', () => {
     expect(screen.getByText(/No candles yet/)).toBeInTheDocument();
   });
 
-  it('renders candle rows with an up arrow for a green candle', async () => {
+  it('renders a positive candle change with semantic styling', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     tradingStore.setCandles([makeCandle({ openTime: 1, open: 100, close: 105 })]);
     await tick();
     expect(screen.queryByText(/No candles yet/)).not.toBeInTheDocument();
     expect(screen.getByText('$105.00')).toBeInTheDocument();
-    // 5% gain -> up arrow + percentage to 3 decimals.
-    expect(screen.getByText(/↑/)).toBeInTheDocument();
-    expect(screen.getByText(/5\.000%/)).toBeInTheDocument();
+    expect(screen.getByText('+5.000%')).toHaveClass('positive');
   });
 
-  it('renders a down arrow for a red candle', async () => {
+  it('renders a negative candle change with semantic styling', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     tradingStore.setCandles([makeCandle({ openTime: 2, open: 100, close: 90 })]);
     await tick();
-    expect(screen.getByText(/↓/)).toBeInTheDocument();
+    expect(screen.getByText('-10.000%')).toHaveClass('negative');
   });
 
   it('renders candles supplied by the loader without a client-side fetch', async () => {
@@ -258,16 +264,16 @@ describe('TradingFlow — candle feed', () => {
 describe('TradingFlow — advisor insight panel', () => {
   it('shows the empty-state message when there is no insight', () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
-    expect(screen.getByText(/No insights available yet/)).toBeInTheDocument();
+    expect(screen.getByText('No insight available')).toBeInTheDocument();
   });
 
   it('renders insight title, bullish badge, scenarios and risk management', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     tradingStore.setLatestInsight(makeNote({ sentiment_bias: 'LONG' }));
     await tick();
-    expect(screen.queryByText(/No insights available yet/)).not.toBeInTheDocument();
+    expect(screen.queryByText('No insight available')).not.toBeInTheDocument();
     expect(screen.getByText('BTC Breakout Setup')).toBeInTheDocument();
-    expect(screen.getByText(/BULLISH/)).toBeInTheDocument();
+    expect(screen.getByText('Bullish')).toHaveClass('ui-badge--success');
     expect(screen.getByText('Strong trending regime')).toBeInTheDocument();
     expect(screen.getByText('Breaks above resistance')).toBeInTheDocument();
     expect(screen.getByText('Loses key support')).toBeInTheDocument();
@@ -281,7 +287,7 @@ describe('TradingFlow — advisor insight panel', () => {
       props: { initialData: emptyData({ insight: makeNote({ title: 'Loader Insight' }) }) },
     });
     await tick();
-    expect(screen.queryByText(/No insights available yet/)).not.toBeInTheDocument();
+    expect(screen.queryByText('No insight available')).not.toBeInTheDocument();
     expect(screen.getByText('Loader Insight')).toBeInTheDocument();
   });
 
@@ -289,14 +295,14 @@ describe('TradingFlow — advisor insight panel', () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     tradingStore.setLatestInsight(makeNote({ sentiment_bias: 'SHORT' }));
     await tick();
-    expect(screen.getByText(/BEARISH/)).toBeInTheDocument();
+    expect(screen.getByText('Bearish')).toHaveClass('ui-badge--danger');
   });
 
   it('renders a neutral badge for a NEUTRAL bias', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     tradingStore.setLatestInsight(makeNote({ sentiment_bias: 'NEUTRAL' }));
     await tick();
-    expect(screen.getByText(/NEUTRAL/)).toBeInTheDocument();
+    expect(screen.getByText('Neutral')).toHaveClass('ui-badge--neutral');
   });
 
   it('renders the logic trace factors and confidence score', async () => {
@@ -315,14 +321,24 @@ describe('TradingFlow — wizard toggle', () => {
   it('switches to wizard mode and back to dashboard', async () => {
     render(TradingFlow, { props: { initialData: emptyData() } });
     // Dashboard shows the live candle panel; wizard heading is absent.
-    expect(screen.getByText('Live Candles')).toBeInTheDocument();
-    expect(screen.queryByText(/Cascade Analysis Wizard/)).not.toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Live candles' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Cascade analysis wizard/i })
+    ).not.toBeInTheDocument();
 
-    await fireEvent.click(screen.getByText(/Open Wizard/));
-    expect(screen.getByText(/Cascade Analysis Wizard/)).toBeInTheDocument();
-    expect(screen.queryByText('Live Candles')).not.toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: /Open wizard/i }));
+    expect(screen.getByRole('heading', { name: /Cascade analysis wizard/i })).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Live candles' })).not.toBeInTheDocument();
 
-    await fireEvent.click(screen.getByText(/Back to Dashboard/));
-    expect(screen.getByText('Live Candles')).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: /Back to dashboard/i }));
+    expect(screen.getByRole('region', { name: 'Live candles' })).toBeInTheDocument();
+  });
+});
+
+describe('TradingFlow — semantic surfaces', () => {
+  it('uses shared panels without legacy glass utilities', () => {
+    const { container } = render(TradingFlow, { props: { initialData: emptyData() } });
+    expect(screen.getByRole('region', { name: 'Trading controls' })).toHaveClass('ui-panel');
+    expect(container.querySelector('.glass')).toBeNull();
   });
 });

--- a/packages/ui/src/lib/flows/trading/components/StepWizard.svelte
+++ b/packages/ui/src/lib/flows/trading/components/StepWizard.svelte
@@ -4,6 +4,9 @@
   import type { WizardAnalysis, WizardInsightViewModel } from '../types';
   import { calculateWizardMetrics, formatCompactVolume, TRADING_WIZARD_STEPS } from '../wizard';
   import { clientLogger } from '@lib/client-logger';
+  import { AsyncState, Badge, Button, Panel } from '@lib/components';
+
+  type BadgeTone = 'danger' | 'neutral' | 'success';
 
   interface Props {
     onFetchKlines: (interval: string, limit: number) => Promise<Candle[]>;
@@ -33,6 +36,18 @@
   const canGoPrev = $derived(currentStep > 0);
   const currentInsight = $derived(stepInsights[activeStep.label] || null);
   const metrics = $derived(calculateWizardMetrics(candles));
+
+  function getSentimentTone(bias: AdvisorNote['sentiment_bias']): BadgeTone {
+    if (bias === 'LONG') return 'success';
+    if (bias === 'SHORT') return 'danger';
+    return 'neutral';
+  }
+
+  function getSentimentLabel(bias: AdvisorNote['sentiment_bias']): string {
+    if (bias === 'LONG') return 'Bullish';
+    if (bias === 'SHORT') return 'Bearish';
+    return 'Neutral';
+  }
 
   async function loadStepData() {
     isLoadingCandles = true;
@@ -111,58 +126,49 @@
   });
 </script>
 
-<div class="space-y-6">
+<div class="wizard">
   <!-- Step Navigation -->
-  <div class="flex items-center justify-center gap-2 flex-wrap">
+  <nav class="step-navigation" aria-label="Analysis timeframes">
     {#each TRADING_WIZARD_STEPS as step, index (step.id)}
-      <button
+      <Button
+        size="sm"
+        variant={index === currentStep ? 'primary' : index < currentStep ? 'secondary' : 'ghost'}
+        class="wizard-step"
         onclick={() => goToStep(index)}
-        class="relative flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-300
-          {index === currentStep
-          ? 'bg-amber-500/20 text-amber-400 border border-amber-500/50 shadow-lg shadow-amber-500/20'
-          : index < currentStep
-            ? 'bg-green-500/10 text-green-400 border border-green-500/30'
-            : 'bg-white/5 text-white/40 border border-white/10 hover:bg-white/10'}"
+        aria-current={index === currentStep ? 'step' : undefined}
       >
-        <span class="text-lg">{step.icon}</span>
-        <span class="font-semibold">{step.label}</span>
+        <span aria-hidden="true">{step.icon}</span>
+        <span>{step.label}</span>
         {#if stepInsights[step.label]}
-          <span class="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full"></span>
+          <span class="step-complete" aria-hidden="true"></span>
         {/if}
-      </button>
-      {#if index < TRADING_WIZARD_STEPS.length - 1}
-        <span class="text-white/20 hidden md:inline">→</span>
-      {/if}
+      </Button>
     {/each}
-  </div>
+  </nav>
 
   <!-- Current Step Info -->
-  <div class="text-center">
-    <h3 class="text-xl font-bold text-amber-400">
+  <div class="step-heading">
+    <h3>
       {activeStep.icon} Step {activeStep.id}: {activeStep.focus}
     </h3>
-    <p class="text-white/40 text-sm">
-      Analyzing {activeStep.label} timeframe
-    </p>
+    <p>Analyzing {activeStep.label} timeframe</p>
   </div>
 
   <!-- Chart Area -->
-  <div class="glass p-4 rounded-xl">
+  <Panel padding="none" class="chart-panel">
     {#if isLoadingCandles}
-      <div class="flex items-center justify-center h-[400px]">
-        <div
-          class="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-amber-400"
-        ></div>
+      <div class="chart-state">
+        <AsyncState state="loading" title="Loading candles" />
       </div>
     {:else}
       <CandleChart {candles} height={400} />
     {/if}
-  </div>
+  </Panel>
 
   <!-- Step Info Panel -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <!-- Metrics -->
-    <div class="glass p-4 rounded-xl">
+    <Panel padding="md">
       <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider mb-3">
         📊 Metrics ({activeStep.label})
       </h4>
@@ -232,22 +238,19 @@
           </div>
         </div>
       {:else}
-        <p class="text-white/30">No data available</p>
+        <AsyncState state="empty" title="No data available" />
       {/if}
-    </div>
+    </Panel>
 
     <!-- Analysis Data (from backend computation) -->
     {#if stepAnalysis[activeStep.label]}
       {@const analysis = stepAnalysis[activeStep.label]}
-      <div class="glass p-4 rounded-xl">
+      <Panel padding="md">
         <div class="flex items-center gap-2 mb-3">
           <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider">
             🖥️ Análisis Técnico ({activeStep.label})
           </h4>
-          <span
-            class="px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-400 text-[10px] font-semibold"
-            >Backend</span
-          >
+          <Badge tone="success">Backend</Badge>
         </div>
         <div class="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
           {#if analysis.regime_analysis}
@@ -352,25 +355,24 @@
             </div>
           {/if}
         </div>
-      </div>
+      </Panel>
     {/if}
 
     <!-- Insight for this step -->
-    <div class="glass p-4 rounded-xl">
+    <Panel padding="md">
       <div class="flex items-center justify-between mb-3">
         <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider">
           🧠 {activeStep.label} Insight
         </h4>
-        <button
+        <Button
+          size="sm"
+          variant="secondary"
           onclick={generateInsightForCurrentStep}
           disabled={isLoadingInsight || !onGenerateInsightForTimeframe}
-          class="px-3 py-1 text-xs rounded-lg transition-all
-            {isLoadingInsight
-            ? 'bg-white/10 text-white/40 cursor-wait'
-            : 'bg-amber-500/20 text-amber-400 hover:bg-amber-500/30 border border-amber-500/50'}"
+          loading={isLoadingInsight}
         >
-          {isLoadingInsight ? '⏳ Generating...' : '✨ Generate'}
-        </button>
+          Generate
+        </Button>
       </div>
 
       {#if currentInsight}
@@ -378,20 +380,9 @@
           <p class="text-sm font-semibold text-amber-400">{currentInsight.title}</p>
           <p class="text-sm text-white/80">{currentInsight.mentor_tip}</p>
           {#if currentInsight.sentiment_bias}
-            <span
-              class="inline-block px-2 py-1 rounded text-xs font-bold
-                {currentInsight.sentiment_bias === 'LONG'
-                ? 'bg-green-500/20 text-green-400'
-                : currentInsight.sentiment_bias === 'SHORT'
-                  ? 'bg-red-500/20 text-red-400'
-                  : 'bg-gray-500/20 text-gray-400'}"
-            >
-              {currentInsight.sentiment_bias === 'LONG'
-                ? '🐂 BULLISH'
-                : currentInsight.sentiment_bias === 'SHORT'
-                  ? '🐻 BEARISH'
-                  : '⚖️ NEUTRAL'}
-            </span>
+            <Badge tone={getSentimentTone(currentInsight.sentiment_bias)}>
+              {getSentimentLabel(currentInsight.sentiment_bias)}
+            </Badge>
           {/if}
         </div>
       {:else}
@@ -399,35 +390,108 @@
           Click "Generate" to get AI insight for {activeStep.label} timeframe
         </p>
       {/if}
-    </div>
+    </Panel>
   </div>
 
   <!-- Navigation Buttons -->
-  <div class="flex items-center justify-between">
-    <button
-      onclick={goPrev}
-      disabled={!canGoPrev}
-      class="px-6 py-2 rounded-lg flex items-center gap-2 transition-all
-        {canGoPrev
-        ? 'bg-white/10 text-white hover:bg-white/20'
-        : 'bg-white/5 text-white/20 cursor-not-allowed'}"
-    >
-      ← Previous
-    </button>
+  <div class="step-actions">
+    <Button variant="secondary" onclick={goPrev} disabled={!canGoPrev}>Previous</Button>
 
     <span class="text-white/40 text-sm">
       Step {currentStep + 1} of {TRADING_WIZARD_STEPS.length}
     </span>
 
-    <button
-      onclick={goNext}
-      disabled={!canGoNext}
-      class="px-6 py-2 rounded-lg flex items-center gap-2 transition-all
-        {canGoNext
-        ? 'bg-amber-500/20 text-amber-400 hover:bg-amber-500/30 border border-amber-500/50'
-        : 'bg-white/5 text-white/20 cursor-not-allowed'}"
-    >
-      Next →
-    </button>
+    <Button onclick={goNext} disabled={!canGoNext}>Next</Button>
   </div>
 </div>
+
+<style>
+  .wizard {
+    display: grid;
+    min-width: 0;
+    gap: 1.25rem;
+  }
+
+  .step-navigation {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  .step-navigation :global(.wizard-step) {
+    position: relative;
+    gap: 0.5rem;
+  }
+
+  .step-complete {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: #4ade80;
+  }
+
+  .step-heading {
+    text-align: center;
+  }
+
+  .step-heading h3 {
+    margin: 0;
+    color: var(--ui-focus);
+    font-size: 1.125rem;
+    letter-spacing: 0;
+  }
+
+  .step-heading p {
+    margin: 0.25rem 0 0;
+    color: var(--ui-text-muted);
+    font-size: 0.875rem;
+  }
+
+  .wizard :global(.chart-panel) {
+    min-height: 25rem;
+    overflow: hidden;
+  }
+
+  .chart-state {
+    display: grid;
+    min-height: 25rem;
+    place-items: center;
+  }
+
+  .step-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .step-actions :global(.ui-button:first-child) {
+    justify-self: start;
+  }
+
+  .step-actions :global(.ui-button:last-child) {
+    justify-self: end;
+  }
+
+  @media (max-width: 35rem) {
+    .step-navigation :global(.wizard-step) {
+      flex: 1 1 calc(50% - 0.5rem);
+    }
+
+    .step-actions {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .step-actions > span {
+      grid-column: 1 / -1;
+      grid-row: 1;
+      justify-self: center;
+    }
+
+    .step-actions :global(.ui-button) {
+      grid-row: 2;
+      width: 100%;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/trading/components/StepWizard.svelte.test.ts
+++ b/packages/ui/src/lib/flows/trading/components/StepWizard.svelte.test.ts
@@ -84,11 +84,13 @@ describe('StepWizard — initial render & first step', () => {
 
   it('renders the four timeframe step buttons', async () => {
     const onFetchKlines = defaultFetch();
-    render(StepWizard, { props: { onFetchKlines } });
+    const { container } = render(StepWizard, { props: { onFetchKlines } });
     await tick();
     for (const label of ['1D', '4H', '1H', '15m']) {
       expect(screen.getByRole('button', { name: new RegExp(label) })).toBeInTheDocument();
     }
+    expect(screen.getByRole('button', { name: '1D' })).toHaveAttribute('aria-current', 'step');
+    expect(container.querySelector('.glass')).toBeNull();
   });
 
   it('disables Previous on the first step and enables Next', async () => {
@@ -190,7 +192,7 @@ describe('StepWizard — insight generation', () => {
     // Insight renders for the active step.
     await waitFor(() => expect(screen.getByText('Daily Macro Bias')).toBeInTheDocument());
     expect(screen.getByText('Respect the daily trend')).toBeInTheDocument();
-    expect(screen.getByText(/BULLISH/)).toBeInTheDocument();
+    expect(screen.getByText('Bullish')).toHaveClass('ui-badge--success');
   });
 
   it('passes previously generated insights forward (matrioshka cascade)', async () => {


### PR DESCRIPTION
## What changed

- added a shared semantic `Panel` primitive with element, padding, and raised-surface options
- migrated the Trading dashboard and cascade wizard from legacy `glass` surfaces to `Panel`, `Button`, `Badge`, and `AsyncState`
- replaced decorative control styling with accessible names, busy/disabled state, and semantic status tones
- made candle changes explicit signed values and fixed zero-price formatting
- updated component contracts and design-system migration documentation

## User-visible impact

Trading now uses a compact operational layout consistent with the application shell and root flow dashboard. The dashboard and wizard collapse cleanly on mobile without horizontal overflow.

## Areas touched

- `packages/ui/src/lib/components/ui`
- `packages/ui/src/lib/flows/trading`
- `docs/design-system.md`

## Validation

- `pnpm verify`
- `pnpm build`
- 49 UI files / 389 UI tests
- 923 tests across the workspace
- `svelte-check`: 0 errors, 0 warnings
- browser validation at 1280px and 390px, dashboard and wizard, with no overflow or console errors

Closes #61
Refs #24