### PR TITLE
feat(ui): complete design system migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ packages (`pnpm build:shared` or `pnpm --filter @flows/core build`).
 - Route handlers validate and map HTTP; services own orchestration.
 - Environment reads stay in composition roots or named env factories.
 - New Svelte code uses Svelte 5 runes and typed Eden access.
+- UI code composes shared primitives and semantic `--ui-*` tokens; theme state stays in
+  the application shell.
 
 Full details and justified exceptions live in [conventions](docs/conventions.md).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ independently testable bounded module hosted by one Elysia API and one SvelteKit
 The product direction is an accessible board where these flows become movable,
 expandable items while their dedicated routes remain available.
 
+The UI shares one semantic design system across all routes, with persistent galaxy,
+fire, and organic themes and responsive desktop/mobile workspaces.
+
 ## Architecture
 
 ```text

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,10 @@ follow-up polish.
 - SvelteKit loaders, typed Eden access, and centralized invalidation are established.
 - Runtime environment ownership is explicit and injected.
 - Architecture contracts enforce key package and layering rules.
-- Shared UI primitives and semantic theme tokens have their first production users.
+- Shared UI primitives and the galaxy/fire/organic theme system cover every production
+  flow, including browser-rendered charts and responsive workspaces.
+- Architecture contracts reject retired UI styles, gradients, and accessibility
+  suppressions.
 - CI builds the monorepo and runs lint, type checks, Svelte checks, and coverage.
 - Short-lived branches and PRs to `main` are the delivery contract.
 
@@ -30,15 +33,12 @@ longer import each other's internals.
 
 ## Execution Queue
 
-1. **UI design system
-   ([#24](https://github.com/jorgesalica/flow-sample/issues/24))**: migrate remaining
-   flows in small slices and complete accessibility/responsive coverage.
-2. **Board v1 ([#42](https://github.com/jorgesalica/flow-sample/issues/42))**: accessible
+1. **Board v1 ([#42](https://github.com/jorgesalica/flow-sample/issues/42))**: accessible
    reorder, collapse, size preferences, and versioned local persistence.
-3. **Board card contracts
+2. **Board card contracts
    ([#43](https://github.com/jorgesalica/flow-sample/issues/43))**: typed summaries,
    expansion, and async states without flow-specific renderer branches.
-4. **Named boards ([#44](https://github.com/jorgesalica/flow-sample/issues/44))**:
+3. **Named boards ([#44](https://github.com/jorgesalica/flow-sample/issues/44))**:
    repository-backed persistence, API, loader integration, and local migration.
 
 Relationships and graph edges get a separate issue only after the board and card

--- a/docs/architecture/abstract-architecture.md
+++ b/docs/architecture/abstract-architecture.md
@@ -29,10 +29,11 @@ A robust, distributed system implemented within a type-safe monorepo. The core p
 
 ### Product Instance (`flow-sample`)
 
-* **Identity:** A "Cosmic UI" playground.
+* **Identity:** A focused analysis playground with galaxy, fire, and organic themes.
 * **Function:** Syncs external personal data (Spotify) to a local environment.
 * **Experience:**
-  * **Immersion:** Dark mode, glassmorphism, and fluid animations create a premium feel.
+  * **Clarity:** Dark semantic surfaces, accessible contrast, and restrained motion keep dense tools readable.
+  * **Adaptability:** One global token contract supports palette choice, mobile layouts, and flow-specific data visualizations.
   * **Discovery:** Visualization tools (charts, decade analysis) allow users to *explore* their music, not just view a list.
   * **Performance:** Instantaneous interactions driven by smart caching and optimistic UI updates.
 

--- a/docs/architecture/ui.md
+++ b/docs/architecture/ui.md
@@ -102,18 +102,22 @@ the flow's `api.ts` and be covered by a contract test.
 
 ## Styling
 
-Tailwind v4, CSS-first: `app.css` does `@import 'tailwindcss'` and declares brand and
-semantic UI tokens. Shared and migrated components consume `--ui-*` variables through
-component-scoped styles; inline `style` is reserved for dynamic values. Legacy
-`glass`/`cosmic` utilities remain only for flow-local surfaces awaiting migration. There
-is no `tailwind.config.js` (v4).
+Tailwind v4, CSS-first: `app.css` does `@import 'tailwindcss'` and owns semantic `--ui-*`
+tokens plus their Tailwind aliases. `lib/theme.ts` and the navbar `ThemeSwitcher` apply
+galaxy, fire, or organic at the application root and persist the selection; flows never
+own palette state. Shared primitives live under `components/ui`, while component-scoped
+styles consume semantic tokens and reserve inline `style` for runtime values.
+
+Chart.js and Lightweight Charts receive computed colors through `lib/chart-theme.ts` and
+react to the global theme-change event. There is no `tailwind.config.js` (v4), legacy
+cosmic/glass utility layer, or gradient-based production UI.
 
 ## Testing
 
 Unit/component tests run under Vitest + `@testing-library/svelte` (jsdom), beside the code
 as `*.svelte.test.ts` / `*.test.ts`. Mock the Eden client (`@lib/client`) — never hit the
-network. Chart-heavy components (chart.js / lightweight-charts) are not unit-tested under
-jsdom. E2E lives in `e2e/` (Playwright).
+network. Pure chart-theme mapping is unit-tested; chart canvas rendering and responsive
+theme behavior are verified in a real browser. E2E lives in `e2e/` (Playwright).
 
 ## Tooling
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -115,6 +115,9 @@ from `lib/flows/<flow>/`. See [architecture/ui.md](architecture/ui.md).
   `<a href="/path">`. No hand-rolled routers.
 - **Tailwind v4** (CSS-first `@import 'tailwindcss'` + `@theme` tokens). Component-scoped
   `<style>` for the rest; inline `style` only for dynamic values. No `tailwind.config.js`.
+- **Shared design system first**: compose primitives from `@lib/components` and consume
+  semantic `--ui-*` tokens. Palette state belongs to the application root; flows do not
+  define themes, gradients, legacy cosmic/glass utilities, or accessibility suppressions.
 - **Data access** goes through the typed Eden client (`@lib/client`), wrapped per flow in
   `api.ts`. Preferred target: SvelteKit `+page.ts` loaders (universal load) over `onMount`.
 
@@ -181,8 +184,9 @@ branch: **PRs target `main`**. There is no `develop` branch here.
 `pnpm check:architecture` enforces the rules that can be detected reliably without a
 heavy static-analysis framework. It checks production sources for explicit `any`,
 hardcoded localhost origins in UI API modules, SQL calls outside persistence modules,
-environment reads outside named config factories, and direct imports between sibling flow packages. The command is part of `pnpm verify`,
-and its own behavior is covered by `pnpm test:architecture`.
+environment reads outside named config factories, direct imports between sibling flow
+packages, and retired UI styles or accessibility suppressions. The command is part of
+`pnpm verify`, and its own behavior is covered by `pnpm test:architecture`.
 
 `pnpm check:docs` validates local Markdown links. Both contract checks are part of
 `pnpm verify` and run in CI.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,64 +1,89 @@
 # Flow UI Design System
 
-This document describes the implemented shared UI foundation and the direction tracked by
-[issue #24](https://github.com/jorgesalica/flow-sample/issues/24). The system is dark,
-workable on mobile, accessible by keyboard, and uses semantic tokens so flow identity does
-not leak into component implementation.
+The Flow UI is a dark, responsive application system shared by Spotify, Lyrics, Trading,
+Chat, Canvas, and the root board. It uses semantic tokens and behavior-oriented Svelte
+components so palette identity does not leak into flow implementation.
 
-## Implemented Tokens
+## Theme Contract
 
-Base and Tailwind theme tokens live in `packages/ui/src/app.css`. Shared components consume
-semantic variables rather than palette names:
+Theme definitions live in `packages/ui/src/app.css`; theme state and persistence live in
+`packages/ui/src/lib/theme.ts`. The application root owns `data-theme` and the navbar
+`ThemeSwitcher` offers three palettes:
 
-| Token                 | Purpose                           |
-| --------------------- | --------------------------------- |
-| `--ui-accent`         | primary action and selected state |
-| `--ui-accent-strong`  | active/pressed accent             |
-| `--ui-focus`          | keyboard focus indicator          |
-| `--ui-danger`         | destructive/error action          |
-| `--ui-surface`        | base component surface            |
-| `--ui-surface-raised` | elevated surface                  |
-| `--ui-border`         | standard boundary                 |
-| `--ui-text`           | primary text                      |
-| `--ui-text-muted`     | secondary text                    |
+| Theme | Intent | Primary accent |
+| --- | --- | --- |
+| `galaxy` | cool analytical default | cyan |
+| `fire` | warm high-energy alternative | rose |
+| `organic` | natural exploratory alternative | lime |
 
-Palette selection uses `data-theme` on an ancestor. The default galaxy palette is cyan;
-`data-theme="fire"` uses rose accents; `data-theme="organic"` uses lime accents. Palette
-names configure semantic tokens but must not appear in generic component logic.
+The selected value is stored under `flow-sample:theme`. Applying a theme updates the root
+attribute and dispatches `flow-sample:theme-change`, allowing browser-rendered charts to
+reapply computed CSS colors without recreating flow state. A flow must not set its own
+`data-theme`; theme selection is an application-shell concern.
+
+## Semantic Tokens
+
+Components consume `--ui-*` variables or their Tailwind v4 semantic aliases. Palette
+names are valid only in the theme definitions and selector metadata.
+
+| Token group | Purpose |
+| --- | --- |
+| `--ui-background`, `--ui-nav` | page and persistent navigation surfaces |
+| `--ui-surface`, `--ui-surface-raised`, `--ui-surface-subtle` | component hierarchy |
+| `--ui-border`, `--ui-border-strong` | standard and emphasized boundaries |
+| `--ui-text`, `--ui-text-muted` | primary and secondary copy |
+| `--ui-accent`, `--ui-accent-strong` | selection and primary action |
+| `--ui-focus` | keyboard focus indicator |
+| `--ui-danger`, `--ui-success`, `--ui-warning` | semantic status feedback |
+| `--ui-chart-1` through `--ui-chart-6` | ordered visualization series |
+| `--ui-overlay`, `--ui-shadow` | modal/drawer layering and elevation |
+
+Tailwind aliases include `app`, `foreground`, `surface`, `surface-raised`,
+`surface-subtle`, `accent`, `border`, `muted`, `danger`, `success`, and `warning`.
+`packages/ui/src/lib/chart-theme.ts` is the shared adapter from computed CSS variables to
+Chart.js and Lightweight Charts configuration.
+
+Retired palette variables, flow-local cosmic utilities, glass surfaces, and CSS gradients
+are not part of the contract. Solid semantic surfaces provide hierarchy with predictable
+contrast across all themes.
 
 ## Shared Primitives
 
-Shared primitives live in `packages/ui/src/lib/components/ui` and are exported through
+Primitives live in `packages/ui/src/lib/components/ui` and are exported through
 `@lib/components`:
 
-- `Button` for text commands and variants.
-- `IconButton` for familiar compact actions with an accessible name.
-- `Field` for label, control, hint, and error relationships.
-- `Badge` for compact status/category metadata.
+- `Button` for explicit text commands and variants.
+- `IconButton` for familiar compact actions with a required accessible name.
+- `Field` for labels, controls, hints, and errors.
+- `Badge` for compact status or category metadata.
 - `AsyncState` for loading, empty, and error presentation.
-- `Panel` for bounded application surfaces with semantic element, padding, and elevation
-  options. It frames a single tool or repeated item; do not nest panels for decoration.
+- `Panel` for one bounded tool or repeated item; panels are not nested for decoration.
 - `ModalShell` for dialog structure, dismissal, and focus behavior.
 
-New UI composes these primitives before introducing a flow-local equivalent. A local
-component is justified when it owns domain behavior, not merely different colors or copy.
+`FlowLayout` owns the global navbar, skip link, and standard content bounds. Chat and
+Canvas use its `fullBleed` mode for dense workspaces while keeping the same shell and
+responsive drawer behavior.
+
+Compose these primitives before introducing a flow-local equivalent. A local component
+is justified when it owns domain behavior, not merely different colors or copy.
 
 ## Interaction Rules
 
-- Every control has an accessible name and visible keyboard focus.
-- Icon-only actions use a familiar icon and tooltip where meaning is not universal.
-- Loading disables duplicate submission without hiding current context.
-- Error and empty states explain the state and expose a recovery action when possible.
-- Motion respects reduced-motion preferences.
-- Layout is verified at desktop and mobile sizes without horizontal overflow.
-- Component tests assert roles, names, states, and callbacks; Playwright covers responsive
-  and browser-dependent interaction.
+- Every control has an accessible name, native keyboard behavior, and visible focus.
+- Icon-only actions use a familiar icon and an accessible tooltip/name.
+- Loading prevents duplicate submission without hiding current context.
+- Error and empty states explain the state and expose recovery when possible.
+- Motion respects `prefers-reduced-motion`.
+- Fixed-format controls have stable dimensions and do not shift on hover or loading.
+- Desktop and mobile layouts have no incoherent overlap or horizontal page overflow.
+- Component tests assert roles, names, states, and callbacks rather than CSS internals.
+- Browser verification covers global theme switching and every flow at desktop/mobile
+  viewports when the shared system changes.
 
-## Migration Status
+## Enforcement
 
-The application shell, root flow dashboard, Trading dashboard and cascade wizard, Canvas
-editor controls, Chat send/stop actions, Spotify controls, and the Lyrics list, analysis,
-and detail modal surfaces use semantic tokens and shared primitives. Remaining flow-local
-surfaces should migrate in small PRs under issue #24. Legacy cosmic/glass utilities remain
-in `app.css`; removing or consolidating them is part of that migration, not documentation
-housekeeping.
+`pnpm check:architecture` scans production UI sources, including CSS, and rejects legacy
+visual utilities, retired variables, gradients, and Svelte accessibility suppressions.
+`pnpm --filter @flows/ui check` must finish with zero errors and zero warnings. The full
+delivery gate remains `pnpm verify`, `pnpm build`, and applicable Playwright or documented
+desktop/mobile verification.

--- a/docs/flows/lyrics-canvas/use-case.md
+++ b/docs/flows/lyrics-canvas/use-case.md
@@ -35,7 +35,8 @@ Que quiero ser inmortal
 
 ## 2. Canvas View — Pre-Analysis
 
-User clicks "Open Canvas" on the track → navigates to `#/lyrics/canvas/4iV5W9uYEdYUVa79Axb7Rh`.
+User clicks "Open Canvas" on the track and the Lyrics route opens its embedded Canvas
+workspace for `4iV5W9uYEdYUVa79Axb7Rh`.
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐

--- a/docs/flows/spotify/getting-started.md
+++ b/docs/flows/spotify/getting-started.md
@@ -46,7 +46,7 @@ pnpm dev
 ## Connect (First Time)
 
 1. Open `http://localhost:5173`
-2. Navigate to **Spotify Flow** (`#/spotify`)
+2. Navigate to **Spotify Flow** (`/spotify`)
 3. Click **"Connect with Spotify"**
 4. Authorize in the Spotify popup
 5. You'll be redirected back — connection established

--- a/docs/history/ui.md
+++ b/docs/history/ui.md
@@ -2,6 +2,20 @@
 
 Changelog for the frontend (Svelte) application.
 
+## 2026-07-13 - Semantic Design System
+
+Issue #24 completed the migration from flow-local cosmic/glass styling to one global UI
+contract:
+
+- Added persistent galaxy, fire, and organic themes at the application shell.
+- Standardized buttons, icon actions, fields, badges, async states, panels, and dialogs.
+- Migrated Spotify, Lyrics, Trading, Chat, Canvas, and browser-rendered charts to semantic
+  tokens.
+- Reworked Chat and Canvas as responsive full-bleed workspaces with native controls.
+- Removed retired palette variables, gradients, accessibility suppressions, and legacy
+  visual utilities from production UI.
+- Added architecture checks to prevent those styles from returning.
+
 ---
 
 ## 2025-12-09 — Lyrics Flow (UI)

--- a/docs/refactor-proposals/B1-ordering.md
+++ b/docs/refactor-proposals/B1-ordering.md
@@ -1,6 +1,7 @@
 # B1 — Ordering Pass (order in place, don't change intent)
 
-> **Status:** active · **Companion:** B2 vision → [GitHub issue #18](https://github.com/jorgesalica/flow-sample/issues/18)
+> **Status:** historical audit; execution is superseded by the current roadmap and GitHub
+> issues. **Companion:** B2 vision → [GitHub issue #18](https://github.com/jorgesalica/flow-sample/issues/18)
 >
 > **The rule of B1:** clean and order what already exists **without moving modules
 > between packages and without changing behavior/intent**. The app must look and
@@ -186,7 +187,8 @@ URLs `#/spotify` → `/spotify`.
 - [ ] (d) Port **Spotify** end-to-end via `[flow]/+page.svelte` (the reference pattern).
 - [ ] (e) Port trading, lyrics, chat (verify SSE through the new proxy; chat is the risky one).
 - [ ] (f) Verify Eden + proxy parity; build static + serve via backend for prod parity.
-- [ ] (g) Re-point Playwright e2e (`#/spotify` → `/spotify`); text selectors unchanged.
+- [x] (g) Re-point Playwright e2e (`#/spotify` → `/spotify`) and replace stale text
+      selectors with role/name locators.
 - [ ] (h) Remove old `main.ts`/`App.svelte`/`index.html` + vestigial configs (last).
 
 ### Component decomposition + unit tests (vitest + @testing-library/svelte + jsdom)

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -41,6 +41,7 @@ journeys. Do not pursue coverage by duplicating implementation details in tests.
 | Shared DTO/package export | producer and consumer tests + full build |
 | Loader, invalidation, or API facade | focused UI tests + UI build |
 | Interactive/responsive UI | component tests + Playwright desktop/mobile |
+| Shared theme or UI contract | primitive/token tests + every flow at desktop/mobile |
 | Docs/workflow only | `pnpm check:docs` + relevant gate |
 
 SSE, browser-only charting, drag-and-drop, keyboard reordering, persistence migration, and

--- a/packages/ui/.prettierignore
+++ b/packages/ui/.prettierignore
@@ -1,0 +1,7 @@
+.svelte-kit/
+build/
+coverage/
+dist/
+node_modules/
+playwright-report/
+test-results/

--- a/packages/ui/e2e/design-system.spec.ts
+++ b/packages/ui/e2e/design-system.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+const routes = [
+  { path: '/', navigationName: null },
+  { path: '/spotify', navigationName: 'Spotify' },
+  { path: '/lyrics', navigationName: 'Lyrics' },
+  { path: '/trading', navigationName: 'Trading' },
+  { path: '/chat', navigationName: 'Chat' },
+  { path: '/canvas', navigationName: 'Canvas' },
+];
+
+test('theme selection persists across reloads', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Fire theme' }).click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'fire');
+  await expect(page.getByRole('button', { name: 'Fire theme' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'fire');
+});
+
+for (const viewport of [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 375, height: 667 },
+]) {
+  test(`shared shell fits every route on ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+    for (const route of routes) {
+      await page.goto(route.path);
+      await expect(page.getByRole('navigation', { name: 'Primary navigation' })).toBeVisible();
+      await expect(page.getByRole('main')).toBeVisible();
+
+      if (route.navigationName) {
+        const activeLink = page
+          .getByRole('navigation', { name: 'Primary navigation' })
+          .getByRole('link', { name: route.navigationName, exact: true });
+        await expect(activeLink).toHaveAttribute('aria-current', 'page');
+        const isVisibleInRail = await activeLink.evaluate((element) => {
+          const rail = element.closest('.app-navbar__scroll');
+          if (!rail) return false;
+          const linkRect = element.getBoundingClientRect();
+          const railRect = rail.getBoundingClientRect();
+          return linkRect.left >= railRect.left - 1 && linkRect.right <= railRect.right + 1;
+        });
+        expect(isVisibleInRail, `${route.path} should reveal its active navigation link`).toBe(
+          true
+        );
+      }
+
+      const hasPageOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+      );
+      expect(hasPageOverflow, `${route.path} should not overflow at ${viewport.name}`).toBe(false);
+      expect(
+        await page.evaluate(() => window.scrollY),
+        `${route.path} should open at the top`
+      ).toBe(0);
+    }
+  });
+}

--- a/packages/ui/e2e/mobile.spec.ts
+++ b/packages/ui/e2e/mobile.spec.ts
@@ -1,26 +1,20 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Mobile Viewport Tests', () => {
-  test.use({ viewport: { width: 375, height: 667 } }); // iPhone SE size
+  test.use({ viewport: { width: 375, height: 667 } });
 
   test('landing page is responsive on mobile', async ({ page }) => {
     await page.goto('/');
 
-    // Title should still be visible
-    await expect(page.locator('h1')).toBeVisible();
-
-    // Spotify Flow card should be visible
+    await expect(page.getByRole('heading', { name: 'Flows' })).toBeVisible();
     await expect(page.getByText('Spotify Flow')).toBeVisible();
   });
 
   test('Spotify Flow page works on mobile', async ({ page }) => {
-    await page.goto('/#/spotify');
+    await page.goto('/spotify');
     await page.waitForLoadState('networkidle');
 
-    // Header should be visible
-    await expect(page.locator('h1')).toBeVisible();
-
-    // Back link should be visible
-    await expect(page.getByText('Back to Flows')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Spotify Flow' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Back to flows' })).toBeVisible();
   });
 });

--- a/packages/ui/e2e/spotify.spec.ts
+++ b/packages/ui/e2e/spotify.spec.ts
@@ -4,60 +4,43 @@ test.describe('Spotify Flow Page', () => {
   test('can navigate to Spotify Flow page', async ({ page }) => {
     await page.goto('/');
 
-    // Click on Spotify Flow card/link
-    await page.getByText('Spotify Flow').click();
-
-    // Wait for navigation
-    await page.waitForURL('**/#/spotify');
-
-    // Verify we're on the Spotify Flow page
-    await expect(page.locator('h1')).toContainText('Spotify');
+    await page.getByRole('link', { name: 'Open Spotify Flow' }).click();
+    await page.waitForURL('**/spotify');
+    await expect(page.getByRole('heading', { name: 'Spotify Flow' })).toBeVisible();
   });
 
-  test('Spotify Flow page shows track grid or loading state', async ({ page }) => {
-    await page.goto('/#/spotify');
-
-    // Wait for the page to load
+  test('Spotify Flow page exposes the track region', async ({ page }) => {
+    await page.goto('/spotify');
     await page.waitForLoadState('networkidle');
 
-    // Should show either tracks or a "Sync" button
-    const hasContent = await page
-      .locator('[data-testid="track-card"], button:has-text("Sync")')
-      .first()
-      .isVisible()
-      .catch(() => false);
-
-    expect(hasContent || (await page.getByText('Sync').isVisible())).toBeTruthy();
+    await expect(page.getByRole('region', { name: 'Spotify tracks' })).toBeVisible();
   });
 
   test('can navigate back to landing from Spotify Flow', async ({ page }) => {
-    await page.goto('/#/spotify');
+    await page.goto('/spotify');
 
-    // Click back link
-    await page.getByText('Back to Flows').click();
-
-    // Should be on landing
-    await page.waitForURL('**/#/');
-    await expect(page.getByText('Spotify Flow')).toBeVisible();
+    await page.getByRole('link', { name: 'Back to flows' }).click();
+    await page.waitForURL('**/');
+    await expect(page.getByRole('heading', { name: 'Flows' })).toBeVisible();
   });
 });
 
 test.describe('Search', () => {
   test('search bar is visible on Spotify Flow page', async ({ page }) => {
-    await page.goto('/#/spotify');
+    await page.goto('/spotify');
     await page.waitForLoadState('networkidle');
 
     // Search input should be visible
-    const searchInput = page.locator('input[type="search"], input[placeholder*="Search"]');
+    const searchInput = page.getByRole('searchbox');
     await expect(searchInput).toBeVisible();
   });
 
   test('can type in search bar', async ({ page }) => {
-    await page.goto('/#/spotify');
+    await page.goto('/spotify');
     await page.waitForLoadState('networkidle');
 
     // Find and type in search
-    const searchInput = page.locator('input[type="search"], input[placeholder*="Search"]');
+    const searchInput = page.getByRole('searchbox');
     await searchInput.fill('rock');
 
     // Verify the input value

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -18,10 +18,18 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'pnpm run dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
-    timeout: 30000,
-  },
+  webServer: [
+    {
+      command: 'pnpm --dir ../.. --filter @flows/backend dev',
+      url: 'http://localhost:4173/api/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 45000,
+    },
+    {
+      command: 'pnpm run dev',
+      url: 'http://localhost:5173',
+      reuseExistingServer: !process.env.CI,
+      timeout: 45000,
+    },
+  ],
 });

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -1,197 +1,98 @@
 @import 'tailwindcss';
 
-@theme {
-  --color-void: #0a0e17;
-  --color-nebula: #111827;
-  --color-stardust: #1f2937;
-  --color-aurora: #10b981;
-  --color-pulsar: #06b6d4;
-  --color-cosmic: #8b5cf6;
-  --color-fire: #f43f5e;
-  --color-organic: #84cc16;
+@theme inline {
+  --color-app: var(--ui-background);
+  --color-surface: var(--ui-surface);
+  --color-surface-raised: var(--ui-surface-raised);
+  --color-surface-subtle: var(--ui-surface-subtle);
+  --color-accent: var(--ui-accent);
+  --color-accent-strong: var(--ui-accent-strong);
+  --color-border: var(--ui-border);
+  --color-foreground: var(--ui-text);
+  --color-muted: var(--ui-text-muted);
+  --color-danger: var(--ui-danger);
+  --color-success: var(--ui-success);
+  --color-warning: var(--ui-warning);
 }
 
-/* Cosmic Flow Design System variables (legacy/fallback if needed, or removed if @theme handles it) */
 :root {
-  /* Glass effect */
-  --glass-bg: rgba(17, 24, 39, 0.7);
-  --glass-border: rgba(255, 255, 255, 0.08);
-  --ui-accent: #06b6d4;
-  --ui-accent-strong: #0891b2;
-  --ui-focus: #22d3ee;
-  --ui-danger: #fb7185;
+  color-scheme: dark;
+  --ui-background: #090d16;
+  --ui-nav: rgba(9, 13, 22, 0.96);
   --ui-surface: #111827;
-  --ui-surface-raised: #1f2937;
-  --ui-border: rgba(148, 163, 184, 0.24);
+  --ui-surface-raised: #1e293b;
+  --ui-surface-subtle: #151f30;
+  --ui-border: rgba(148, 163, 184, 0.25);
   --ui-text: #f8fafc;
-  --ui-text-muted: #94a3b8;
+  --ui-text-muted: #9aa8bc;
+  --ui-accent: #22d3ee;
+  --ui-accent-strong: #0e7490;
+  --ui-focus: #67e8f9;
+  --ui-danger: #fb7185;
+  --ui-success: #4ade80;
+  --ui-warning: #facc15;
+  --ui-chart-1: #22d3ee;
+  --ui-chart-2: #818cf8;
+  --ui-chart-3: #f472b6;
+  --ui-chart-4: #4ade80;
+  --ui-chart-5: #facc15;
+  --ui-chart-6: #fb7185;
+  --ui-border-strong: color-mix(in srgb, var(--ui-text-muted) 48%, transparent);
+  --ui-accent-contrast: #ffffff;
+  --ui-accent-hover-contrast: #020617;
+  --ui-overlay: rgba(2, 6, 23, 0.72);
+  --ui-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.4);
   --app-nav-height: 4rem;
 }
 
 [data-theme='fire'] {
-  --ui-accent: #f43f5e;
-  --ui-accent-strong: #e11d48;
-  --ui-focus: #fb7185;
+  --ui-background: #120c12;
+  --ui-nav: rgba(18, 12, 18, 0.96);
+  --ui-surface: #1c121b;
+  --ui-surface-raised: #2b1825;
+  --ui-surface-subtle: #22151f;
+  --ui-border: rgba(251, 113, 133, 0.26);
+  --ui-text-muted: #b7a0aa;
+  --ui-accent: #fb7185;
+  --ui-accent-strong: #be123c;
+  --ui-focus: #fda4af;
+  --ui-chart-1: #fb7185;
+  --ui-chart-2: #f97316;
+  --ui-chart-3: #facc15;
+  --ui-chart-4: #22d3ee;
+  --ui-chart-5: #c084fc;
+  --ui-chart-6: #4ade80;
 }
 
 [data-theme='organic'] {
-  --ui-accent: #84cc16;
-  --ui-accent-strong: #65a30d;
-  --ui-focus: #a3e635;
+  --ui-background: #0b100d;
+  --ui-nav: rgba(11, 16, 13, 0.96);
+  --ui-surface: #121b16;
+  --ui-surface-raised: #1d2a21;
+  --ui-surface-subtle: #17221b;
+  --ui-border: rgba(163, 230, 53, 0.22);
+  --ui-text-muted: #a5b2a6;
+  --ui-accent: #a3e635;
+  --ui-accent-strong: #4d7c0f;
+  --ui-focus: #bef264;
+  --ui-chart-1: #a3e635;
+  --ui-chart-2: #34d399;
+  --ui-chart-3: #22d3ee;
+  --ui-chart-4: #facc15;
+  --ui-chart-5: #fb7185;
+  --ui-chart-6: #c084fc;
 }
 
-/* ========================================
-   Background Effects
-   ======================================== */
-
 body {
-  background: var(--color-void);
   min-height: 100vh;
-  color: white;
+  margin: 0;
+  overflow-x: hidden;
+  background: var(--ui-background);
+  color: var(--ui-text);
   font-family: 'Inter', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  position: relative;
-  overflow-x: hidden;
-}
-
-/* Animated gradient background */
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background:
-    radial-gradient(ellipse 80% 50% at 20% 40%, rgba(16, 185, 129, 0.15) 0%, transparent 50%),
-    radial-gradient(ellipse 60% 40% at 80% 20%, rgba(6, 182, 212, 0.12) 0%, transparent 50%),
-    radial-gradient(ellipse 50% 60% at 60% 80%, rgba(139, 92, 246, 0.1) 0%, transparent 50%);
-  animation: gradient-shift 15s ease-in-out infinite alternate;
-  pointer-events: none;
-  z-index: -2;
-}
-
-@keyframes gradient-shift {
-  0% {
-    transform: scale(1) rotate(0deg);
-    opacity: 0.7;
-  }
-
-  50% {
-    transform: scale(1.15) rotate(4deg);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(1) rotate(8deg);
-    opacity: 0.7;
-  }
-}
-
-/* Stars effect */
-body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background-image:
-    radial-gradient(2px 2px at 15% 25%, rgba(255, 255, 255, 0.8) 0%, transparent 100%),
-    radial-gradient(2px 2px at 35% 65%, rgba(255, 255, 255, 0.6) 0%, transparent 100%),
-    radial-gradient(1.5px 1.5px at 75% 15%, rgba(255, 255, 255, 0.7) 0%, transparent 100%),
-    radial-gradient(1.5px 1.5px at 25% 85%, rgba(255, 255, 255, 0.5) 0%, transparent 100%),
-    radial-gradient(2px 2px at 55% 45%, rgba(255, 255, 255, 0.9) 0%, transparent 100%),
-    radial-gradient(1px 1px at 85% 35%, rgba(255, 255, 255, 0.6) 0%, transparent 100%),
-    radial-gradient(2px 2px at 10% 55%, rgba(255, 255, 255, 0.5) 0%, transparent 100%),
-    radial-gradient(1.5px 1.5px at 65% 75%, rgba(255, 255, 255, 0.8) 0%, transparent 100%),
-    radial-gradient(2px 2px at 90% 10%, rgba(255, 255, 255, 0.7) 0%, transparent 100%),
-    radial-gradient(2px 2px at 45% 90%, rgba(255, 255, 255, 0.6) 0%, transparent 100%),
-    radial-gradient(2.5px 2.5px at 60% 20%, rgba(255, 255, 255, 0.8) 0%, transparent 100%),
-    radial-gradient(1.5px 1.5px at 20% 70%, rgba(255, 255, 255, 0.5) 0%, transparent 100%),
-    radial-gradient(2px 2px at 50% 10%, rgba(255, 255, 255, 0.9) 0%, transparent 100%),
-    radial-gradient(1.5px 1.5px at 80% 55%, rgba(255, 255, 255, 0.7) 0%, transparent 100%),
-    radial-gradient(2px 2px at 30% 95%, rgba(255, 255, 255, 0.6) 0%, transparent 100%),
-    radial-gradient(1px 1px at 95% 80%, rgba(255, 255, 255, 0.5) 0%, transparent 100%),
-    radial-gradient(2.5px 2.5px at 5% 5%, rgba(255, 255, 255, 0.8) 0%, transparent 100%),
-    radial-gradient(1.5px 1.5px at 40% 60%, rgba(255, 255, 255, 0.6) 0%, transparent 100%),
-    radial-gradient(2px 2px at 70% 30%, rgba(255, 255, 255, 0.7) 0%, transparent 100%),
-    radial-gradient(2px 2px at 15% 45%, rgba(255, 255, 255, 0.7) 0%, transparent 100%);
-  animation: stars-twinkle 6s ease-in-out infinite;
-  pointer-events: none;
-  z-index: -1;
-}
-
-@keyframes stars-twinkle {
-  0%,
-  100% {
-    opacity: 0.3;
-  }
-
-  25% {
-    opacity: 0.8;
-  }
-
-  50% {
-    opacity: 0.5;
-  }
-
-  75% {
-    opacity: 0.9;
-  }
-}
-
-/* ========================================
-   Glass Morphism
-   ======================================== */
-
-.glass {
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  border: 1px solid var(--glass-border);
-  border-radius: 16px;
-}
-
-.glass-hover {
-  transition: all 0.3s ease;
-}
-
-.glass-hover:hover {
-  border-color: rgba(16, 185, 129, 0.3);
-  box-shadow: 0 0 30px -10px rgba(16, 185, 129, 0.2);
-}
-
-/* ========================================
-   Typography
-   ======================================== */
-
-/* Gradient text - Aurora */
-.text-aurora {
-  background: linear-gradient(135deg, var(--color-aurora) 0%, var(--color-pulsar) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Gradient text - Cosmic */
-.text-cosmic {
-  background: linear-gradient(135deg, white 0%, var(--color-pulsar) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* ========================================
-   Utilities
-   ======================================== */
-
-.btn-primary {
-  @apply px-4 py-2 rounded-lg font-semibold text-white transition-all shadow-lg;
-  background: linear-gradient(135deg, var(--color-aurora) 0%, var(--color-pulsar) 100%);
-}
-
-.btn-primary:hover:not(:disabled) {
-  @apply brightness-110 -translate-y-0.5;
-  box-shadow: 0 4px 14px 0 rgba(16, 185, 129, 0.3);
-}
-
-.btn-primary:active:not(:disabled) {
-  @apply translate-y-0 scale-95;
+  transition: background-color 150ms ease;
 }
 
 .ui-button,
@@ -227,58 +128,71 @@ body::after {
   padding: 0.375rem 0.75rem;
   font-size: 0.75rem;
 }
+
 .ui-button--md {
   min-height: 2.5rem;
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
 }
+
 .ui-button--lg {
   min-height: 3rem;
   padding: 0.75rem 1.25rem;
   font-size: 1rem;
 }
+
 .ui-button--primary,
 .ui-icon-button--primary {
   background: var(--ui-accent-strong);
-  color: white;
+  color: var(--ui-accent-contrast);
 }
+
 .ui-button--primary:hover:not(:disabled),
 .ui-icon-button--primary:hover:not(:disabled) {
   background: var(--ui-accent);
+  color: var(--ui-accent-hover-contrast);
 }
+
 .ui-button--secondary,
 .ui-icon-button--secondary {
-  background: var(--ui-surface-raised);
   border-color: var(--ui-border);
+  background: var(--ui-surface-raised);
   color: var(--ui-text);
 }
+
 .ui-button--ghost,
 .ui-icon-button--ghost {
   background: transparent;
   color: var(--ui-text-muted);
 }
+
 .ui-button--ghost:hover:not(:disabled),
 .ui-icon-button--ghost:hover:not(:disabled) {
   background: var(--ui-surface-raised);
   color: var(--ui-text);
 }
+
 .ui-button--danger,
 .ui-icon-button--danger {
   background: color-mix(in srgb, var(--ui-danger) 16%, transparent);
   color: var(--ui-danger);
 }
+
 .ui-icon-button {
-  padding: 0;
   flex: 0 0 auto;
+  padding: 0;
 }
+
 .ui-icon-button--sm {
   width: 2rem;
   height: 2rem;
 }
+
 .ui-icon-button--md {
   width: 2.5rem;
   height: 2.5rem;
 }
+
 .ui-button__spinner,
 .ui-async-state__spinner {
   width: 1rem;
@@ -288,6 +202,7 @@ body::after {
   border-radius: 50%;
   animation: ui-spin 700ms linear infinite;
 }
+
 @keyframes ui-spin {
   to {
     transform: rotate(360deg);
@@ -300,29 +215,35 @@ body::after {
   flex-direction: column;
   gap: 0.375rem;
 }
+
 .ui-field__label {
   color: var(--ui-text-muted);
   font-size: 0.75rem;
   font-weight: 600;
 }
+
 .ui-field__control {
   width: 100%;
+  padding: 0.75rem;
   border: 1px solid var(--ui-border);
   border-radius: 0.5rem;
   background: var(--ui-surface);
   color: var(--ui-text);
-  padding: 0.75rem;
 }
+
 .ui-field__control::placeholder {
   color: var(--ui-text-muted);
 }
+
 .ui-select {
   cursor: pointer;
   appearance: auto;
 }
+
 .ui-field__control--mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
+
 .ui-field__textarea {
   resize: none;
 }
@@ -330,24 +251,29 @@ body::after {
 .ui-badge {
   display: inline-flex;
   align-items: center;
+  padding: 0.125rem 0.5rem;
   border: 1px solid var(--ui-border);
   border-radius: 999px;
-  padding: 0.125rem 0.5rem;
   font-size: 0.75rem;
   font-weight: 600;
 }
+
 .ui-badge--neutral {
   color: var(--ui-text-muted);
 }
+
 .ui-badge--info {
   color: var(--ui-focus);
 }
+
 .ui-badge--success {
-  color: #4ade80;
+  color: var(--ui-success);
 }
+
 .ui-badge--warning {
-  color: #facc15;
+  color: var(--ui-warning);
 }
+
 .ui-badge--danger {
   color: var(--ui-danger);
 }
@@ -360,24 +286,29 @@ body::after {
   color: var(--ui-text-muted);
   text-align: center;
 }
+
 .ui-async-state strong {
   color: var(--ui-text);
 }
+
 .ui-async-state p {
-  margin: 0;
   max-width: 32rem;
+  margin: 0;
 }
+
 .ui-modal-backdrop {
   position: fixed;
   inset: 0;
   z-index: 60;
   display: grid;
-  place-items: center;
   padding: 1rem;
-  background: rgba(2, 6, 23, 0.78);
+  place-items: center;
+  background: var(--ui-overlay);
 }
+
 .ui-modal {
   display: flex;
+  width: 100%;
   max-height: min(42rem, calc(100dvh - 2rem));
   min-height: 0;
   flex-direction: column;
@@ -385,17 +316,21 @@ body::after {
   border: 1px solid var(--ui-border);
   border-radius: 0.5rem;
   background: var(--ui-surface);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--ui-shadow);
 }
+
 .ui-modal--sm {
-  width: min(28rem, 100%);
+  max-width: 28rem;
 }
+
 .ui-modal--md {
-  width: min(36rem, 100%);
+  max-width: 36rem;
 }
+
 .ui-modal--lg {
-  width: min(48rem, 100%);
+  max-width: 48rem;
 }
+
 .ui-modal__header,
 .ui-modal__footer {
   display: flex;
@@ -404,16 +339,20 @@ body::after {
   gap: 1rem;
   padding: 1rem;
 }
+
 .ui-modal__header {
   border-bottom: 1px solid var(--ui-border);
 }
+
 .ui-modal__media {
   flex: 0 0 auto;
 }
+
 .ui-modal__heading {
   min-width: 0;
   flex: 1 1 auto;
 }
+
 .ui-modal__header h2 {
   margin: 0;
   overflow: hidden;
@@ -421,6 +360,7 @@ body::after {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
 .ui-modal__heading p {
   margin: 0.25rem 0 0;
   overflow: hidden;
@@ -429,24 +369,50 @@ body::after {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
 .ui-modal__actions {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
   gap: 0.5rem;
 }
+
 .ui-modal__body {
   min-height: 0;
   flex: 1 1 auto;
   overflow-y: auto;
   padding: 1rem;
 }
+
 .ui-modal__footer {
   justify-content: flex-end;
   border-top: 1px solid var(--ui-border);
 }
 
-@media (max-width: 640px) {
+::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--ui-background);
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 0.25rem;
+  background: var(--ui-surface-raised);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--ui-accent-strong);
+}
+
+select option {
+  background-color: var(--ui-surface);
+  color: var(--ui-text);
+}
+
+@media (max-width: 40rem) {
   .ui-modal-backdrop {
     align-items: stretch;
     padding: 0.5rem;
@@ -467,31 +433,25 @@ body::after {
   }
 }
 
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
-::-webkit-scrollbar-track {
-  background: var(--color-void);
-}
+@media (hover: none) {
+  .ui-button--sm {
+    min-height: 2.75rem;
+  }
 
-::-webkit-scrollbar-thumb {
-  background: var(--color-stardust);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-pulsar);
-}
-
-/* ========================================
-   Forms & Inputs
-   ======================================== */
-
-/* Dark Dropdown Options */
-select option {
-  background-color: var(--color-void) !important;
-  color: white !important;
-  padding: 8px;
+  .ui-icon-button--sm,
+  .ui-icon-button--md {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
 }

--- a/packages/ui/src/app.html
+++ b/packages/ui/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="galaxy">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />

--- a/packages/ui/src/lib/chart-theme.test.ts
+++ b/packages/ui/src/lib/chart-theme.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { readChartTheme } from './chart-theme';
+
+describe('readChartTheme', () => {
+  it('maps semantic CSS variables into the chart contract', () => {
+    const values = new Map([
+      ['--ui-surface', 'surface'],
+      ['--ui-text', 'text'],
+      ['--ui-text-muted', 'muted'],
+      ['--ui-border', 'border'],
+      ['--ui-success', 'success'],
+      ['--ui-danger', 'danger'],
+      ...[1, 2, 3, 4, 5, 6].map((index) => [`--ui-chart-${index}`, `chart-${index}`] as const),
+    ]);
+
+    const theme = readChartTheme({ getPropertyValue: (token) => ` ${values.get(token) ?? ''} ` });
+    expect(theme.colors).toEqual([
+      'chart-1',
+      'chart-2',
+      'chart-3',
+      'chart-4',
+      'chart-5',
+      'chart-6',
+    ]);
+    expect(theme).toMatchObject({
+      surface: 'surface',
+      text: 'text',
+      muted: 'muted',
+      border: 'border',
+      success: 'success',
+      danger: 'danger',
+    });
+  });
+});

--- a/packages/ui/src/lib/chart-theme.ts
+++ b/packages/ui/src/lib/chart-theme.ts
@@ -1,0 +1,25 @@
+export interface ChartTheme {
+  colors: string[];
+  surface: string;
+  text: string;
+  muted: string;
+  border: string;
+  success: string;
+  danger: string;
+}
+
+function readColor(styles: Pick<CSSStyleDeclaration, 'getPropertyValue'>, token: string): string {
+  return styles.getPropertyValue(token).trim();
+}
+
+export function readChartTheme(styles: Pick<CSSStyleDeclaration, 'getPropertyValue'>): ChartTheme {
+  return {
+    colors: [1, 2, 3, 4, 5, 6].map((index) => readColor(styles, `--ui-chart-${index}`)),
+    surface: readColor(styles, '--ui-surface'),
+    text: readColor(styles, '--ui-text'),
+    muted: readColor(styles, '--ui-text-muted'),
+    border: readColor(styles, '--ui-border'),
+    success: readColor(styles, '--ui-success'),
+    danger: readColor(styles, '--ui-danger'),
+  };
+}

--- a/packages/ui/src/lib/components/canvas/TokenRenderer.svelte
+++ b/packages/ui/src/lib/components/canvas/TokenRenderer.svelte
@@ -57,10 +57,32 @@
     ontokenhover?.(null);
   }
 
+  function getTokenLabel(text: string, anns: Annotation[]): string | undefined {
+    if (anns.length === 0) return undefined;
+    return `${text}. ${anns.map((ann) => `${ann.label}: ${ann.detail}`).join('. ')}`;
+  }
+
   function abbreviateVocal(label: string): string {
     return label.charAt(0).toUpperCase();
   }
 </script>
+
+{#snippet tokenContent(text: string, displayAnns: Annotation[])}
+  {#if displayAnns.length > 0}
+    <span class="badge-row">
+      {#each displayAnns as ann, i (`${ann.layerId}_${i}`)}
+        <span class="layer-badge layer-{ann.layerId}">
+          {ann.layerId === 'vocal' ? abbreviateVocal(ann.label) : ann.label}
+        </span>
+        {#if i < displayAnns.length - 1}
+          <span class="badge-separator" aria-hidden="true">&middot;</span>
+        {/if}
+      {/each}
+    </span>
+  {/if}
+
+  <span class="token-text">{text}</span>
+{/snippet}
 
 <div class="canvas-renderer" class:has-layers={activeLayers.length > 0}>
   {#each tokenAst.sections as section (section.id)}
@@ -89,32 +111,30 @@
               {@const displayAnns = activeAnns.filter((a) => a.layerId !== 'meaning')}
               {@const tokenHoverAnns = [...displayAnns, ...lineMeaningAnns]}
 
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <span
-                class="token"
-                class:annotated={displayAnns.length > 0}
-                class:has-meaning={lineHasMeaning}
-                data-id={token.id}
-                onmouseenter={(e) =>
-                  handleTokenMouseEnter(token.id, tokenHoverAnns, e.currentTarget, lineId)}
-                onmouseleave={handleTokenMouseLeave}
-              >
-                <!-- All badges inline ABOVE the text -->
-                {#if displayAnns.length > 0}
-                  <span class="badge-row">
-                    {#each displayAnns as ann, i (`${ann.layerId}_${i}`)}
-                      <span class="layer-badge layer-{ann.layerId}">
-                        {ann.layerId === 'vocal' ? abbreviateVocal(ann.label) : ann.label}
-                      </span>
-                      {#if i < displayAnns.length - 1}
-                        <span class="badge-separator">·</span>
-                      {/if}
-                    {/each}
-                  </span>
-                {/if}
-
-                <span class="token-text">{token.text}</span>
-              </span>
+              {#if tokenHoverAnns.length > 0}
+                <button
+                  type="button"
+                  class="token"
+                  class:annotated={displayAnns.length > 0}
+                  class:has-meaning={lineHasMeaning}
+                  data-id={token.id}
+                  aria-label={getTokenLabel(token.text, tokenHoverAnns)}
+                  onmouseenter={(event) =>
+                    handleTokenMouseEnter(token.id, tokenHoverAnns, event.currentTarget, lineId)}
+                  onmouseleave={handleTokenMouseLeave}
+                  onfocus={(event) =>
+                    handleTokenMouseEnter(token.id, tokenHoverAnns, event.currentTarget, lineId)}
+                  onblur={handleTokenMouseLeave}
+                  onclick={(event) =>
+                    handleTokenMouseEnter(token.id, tokenHoverAnns, event.currentTarget, lineId)}
+                >
+                  {@render tokenContent(token.text, displayAnns)}
+                </button>
+              {:else}
+                <span class="token" class:has-meaning={lineHasMeaning} data-id={token.id}>
+                  {@render tokenContent(token.text, displayAnns)}
+                </span>
+              {/if}
             {/each}
           </div>
         {/each}
@@ -129,7 +149,7 @@
     flex-direction: column;
     gap: 2rem;
     font-family: var(--font-mono);
-    color: var(--surface-100);
+    color: var(--ui-text);
     padding: 1rem;
   }
 
@@ -140,7 +160,7 @@
   }
 
   .section-header {
-    border-bottom: 1px solid var(--surface-800);
+    border-bottom: 1px solid var(--ui-border);
     padding-bottom: 0.25rem;
     margin-bottom: 0.5rem;
   }
@@ -148,13 +168,13 @@
   .section-type {
     font-size: 0.8rem;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: 0;
     font-weight: 800;
-    color: var(--primary-400);
-    background: rgba(30, 41, 59, 0.5);
+    color: var(--ui-accent);
+    background: var(--ui-surface-subtle);
     padding: 0.3rem 0.85rem;
     border-radius: 1rem;
-    border: 1px solid var(--surface-700);
+    border: 1px solid var(--ui-border);
     display: inline-block;
   }
 
@@ -177,8 +197,8 @@
   }
 
   .canvas-line.line-highlighted {
-    background: rgba(34, 211, 238, 0.08);
-    box-shadow: inset 2px 0 0 rgba(34, 211, 238, 0.5);
+    background: color-mix(in srgb, var(--ui-accent) 10%, transparent);
+    box-shadow: inset 2px 0 0 var(--ui-accent);
   }
 
   /* ── Token layout: flex column ── */
@@ -187,17 +207,26 @@
     flex-direction: column;
     align-items: center;
     justify-content: flex-end; /* Push text to bottom */
-    cursor: pointer;
+    cursor: default;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    font: inherit;
     transition: color 0.2s;
     gap: 0.15rem;
   }
 
   .token.annotated {
-    color: var(--primary-400);
+    cursor: pointer;
+    color: var(--ui-accent);
   }
 
-  .token:hover .token-text {
-    text-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+  .token:focus-visible {
+    border-radius: 0.25rem;
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
   }
 
   .token-text {
@@ -215,7 +244,7 @@
   }
 
   .badge-separator {
-    color: var(--surface-500);
+    color: var(--ui-text-muted);
     font-size: 0.6rem;
   }
 
@@ -229,28 +258,27 @@
   }
 
   .layer-chords {
-    color: #4ade80;
+    color: var(--ui-success);
     font-size: 0.75rem;
   }
 
   .layer-vocal {
     font-size: 0.65rem;
-    color: #f59e0b;
+    color: var(--ui-warning);
   }
 
   .layer-production {
-    color: #818cf8;
+    color: var(--ui-chart-4);
     font-size: 0.65rem;
   }
 
   /* ── Meaning: visual-only (underline) ── */
   .token.has-meaning .token-text {
-    border-bottom: 2px dashed rgba(34, 211, 238, 0.4);
+    border-bottom: 2px dashed color-mix(in srgb, var(--ui-accent) 45%, transparent);
     padding-bottom: 2px;
   }
 
   .canvas-line.line-highlighted .token.has-meaning .token-text {
-    border-bottom-color: rgba(34, 211, 238, 1);
-    text-shadow: 0 0 12px rgba(34, 211, 238, 0.5);
+    border-bottom-color: var(--ui-accent);
   }
 </style>

--- a/packages/ui/src/lib/components/canvas/TokenRenderer.svelte.test.ts
+++ b/packages/ui/src/lib/components/canvas/TokenRenderer.svelte.test.ts
@@ -117,6 +117,21 @@ describe('TokenRenderer', () => {
     expect(line.className).toContain('line-highlighted');
   });
 
+  it('exposes annotated tokens as named native controls', async () => {
+    render(TokenRenderer, {
+      props: { tokenAst: AST, annotations: ANNOTATIONS, activeLayers: ['meaning'] },
+    });
+
+    const annotatedToken = screen.getByRole('button', {
+      name: 'Hello. theme: Opening greeting.',
+    });
+    expect(annotatedToken).toBe(tokenSpan('t_001'));
+    expect(tokenSpan('t_003').tagName).toBe('SPAN');
+
+    await fireEvent.focus(annotatedToken);
+    expect(lineOf('t_001').className).toContain('line-highlighted');
+  });
+
   it('does not react when hovering a token with no active annotations', async () => {
     render(TokenRenderer, {
       props: { tokenAst: AST, annotations: ANNOTATIONS, activeLayers: ['meaning'] },

--- a/packages/ui/src/lib/components/canvas/TokenTooltip.svelte
+++ b/packages/ui/src/lib/components/canvas/TokenTooltip.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if visible && annotations.length > 0}
-  <div class="tooltip-container" style="left: {x}px; top: {y}px;">
+  <div class="tooltip-container" role="tooltip" style="left: {x}px; top: {y}px;">
     <div class="tooltip-content">
       {#each annotations as ann, i (`${ann.layerId}_${i}`)}
         {@const layerInfo = getLayerInfo(ann.layerId)}
@@ -46,19 +46,16 @@
   }
 
   .tooltip-content {
-    background: rgba(15, 23, 42, 0.95);
-    backdrop-filter: blur(8px);
-    border: 1px solid var(--aurora);
-    border-radius: 0.5rem;
-    padding: 1rem;
-    width: max-content;
-    max-width: 450px;
-    box-shadow:
-      0 10px 25px -5px rgba(0, 0, 0, 0.8),
-      0 8px 10px -6px rgba(0, 0, 0, 0.8);
     display: flex;
+    width: max-content;
+    max-width: min(28rem, calc(100vw - 2rem));
     flex-direction: column;
     gap: 0.75rem;
+    border: 1px solid var(--ui-border-strong);
+    border-radius: 0.5rem;
+    background: var(--ui-surface-raised);
+    padding: 1rem;
+    box-shadow: var(--ui-shadow);
   }
 
   .annotation-detail {
@@ -68,7 +65,7 @@
   }
 
   .annotation-detail:not(:last-child) {
-    border-bottom: 1px solid var(--surface-800);
+    border-bottom: 1px solid var(--ui-border);
     padding-bottom: 0.75rem;
   }
 
@@ -82,21 +79,21 @@
   .layer-name {
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0;
   }
 
   .label {
-    color: var(--surface-100);
+    color: var(--ui-text);
     font-weight: 600;
     margin-left: auto;
-    background: var(--surface-800);
+    background: var(--ui-surface-subtle);
     padding: 0.2rem 0.5rem;
     border-radius: 0.25rem;
   }
 
   .detail {
     font-size: 0.95rem;
-    color: var(--surface-200);
+    color: var(--ui-text-muted);
     line-height: 1.5;
   }
 </style>

--- a/packages/ui/src/lib/components/layout/FlowLayout.svelte
+++ b/packages/ui/src/lib/components/layout/FlowLayout.svelte
@@ -5,17 +5,23 @@
   interface Props {
     children: Snippet;
     currentPath?: string;
+    fullBleed?: boolean;
   }
 
-  let { children, currentPath }: Props = $props();
+  let { children, currentPath, fullBleed = false }: Props = $props();
 </script>
 
 <div class="app-shell">
   <a class="app-shell__skip-link" href="#main-content">Skip to content</a>
   <Navbar {currentPath} />
 
-  <main id="main-content" class="app-shell__main" tabindex="-1">
-    <div class="app-shell__content">
+  <main
+    id="main-content"
+    class="app-shell__main"
+    class:app-shell__main--flush={fullBleed}
+    tabindex="-1"
+  >
+    <div class="app-shell__content" class:app-shell__content--full={fullBleed}>
       {@render children()}
     </div>
   </main>
@@ -34,7 +40,7 @@
     padding: 0.5rem 0.75rem;
     border-radius: 0.375rem;
     background: var(--ui-accent-strong);
-    color: white;
+    color: var(--ui-accent-contrast);
     font-weight: 700;
     text-decoration: none;
     transform: translateY(calc(-100% - 1rem));
@@ -56,15 +62,28 @@
     outline: none;
   }
 
+  .app-shell__main--flush {
+    padding: var(--app-nav-height) 0 0;
+  }
+
   .app-shell__content {
     width: min(80rem, 100%);
     margin: 0 auto;
   }
 
-  @media (max-width: 640px) {
+  .app-shell__content--full {
+    width: 100%;
+    height: calc(100dvh - var(--app-nav-height));
+  }
+
+  @media (max-width: 40rem) {
     .app-shell__main {
       padding-top: calc(var(--app-nav-height) + 1rem);
       padding-bottom: 1.5rem;
+    }
+
+    .app-shell__main--flush {
+      padding: var(--app-nav-height) 0 0;
     }
   }
 </style>

--- a/packages/ui/src/lib/components/layout/FlowLayout.svelte.test.ts
+++ b/packages/ui/src/lib/components/layout/FlowLayout.svelte.test.ts
@@ -35,4 +35,11 @@ describe('FlowLayout', () => {
     expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content');
     expect(screen.getByRole('main')).toHaveAttribute('tabindex', '-1');
   });
+
+  it('exposes the full-bleed workspace contract without removing the main landmark', () => {
+    render(FlowLayout, { props: { children: childContent, fullBleed: true } });
+
+    expect(screen.getByRole('main')).toHaveClass('app-shell__main--flush');
+    expect(screen.getByTestId('child').parentElement).toHaveClass('app-shell__content--full');
+  });
 });

--- a/packages/ui/src/lib/components/layout/Navbar.svelte
+++ b/packages/ui/src/lib/components/layout/Navbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import ThemeSwitcher from './ThemeSwitcher.svelte';
 
   interface Props {
     currentPath?: string;
@@ -15,10 +16,28 @@
 
   let { currentPath }: Props = $props();
   let browserPath = $state('');
+  let scrollContainer: HTMLDivElement;
   const activePath = $derived(currentPath ?? browserPath);
 
   onMount(() => {
     browserPath = window.location.pathname;
+  });
+
+  $effect(() => {
+    void activePath;
+    queueMicrotask(() => {
+      const activeLink = scrollContainer?.querySelector<HTMLElement>('[aria-current="page"]');
+      if (!activeLink) return;
+
+      const visibleLeft = scrollContainer.scrollLeft;
+      const visibleRight = visibleLeft + scrollContainer.clientWidth;
+      const linkLeft = activeLink.offsetLeft;
+      const linkRight = linkLeft + activeLink.offsetWidth;
+
+      if (linkLeft < visibleLeft) scrollContainer.scrollLeft = linkLeft;
+      else if (linkRight > visibleRight)
+        scrollContainer.scrollLeft = linkRight - scrollContainer.clientWidth;
+    });
   });
 
   function isActive(href: string): boolean {
@@ -38,7 +57,7 @@
       <span class="app-navbar__wordmark">Cosmic Flow</span>
     </a>
 
-    <div class="app-navbar__scroll">
+    <div class="app-navbar__scroll" bind:this={scrollContainer}>
       <div class="app-navbar__links">
         {#each navigationItems as item (item.href)}
           <a
@@ -52,6 +71,7 @@
         {/each}
       </div>
     </div>
+    <ThemeSwitcher />
   </div>
 </nav>
 
@@ -62,8 +82,7 @@
     z-index: 50;
     height: var(--app-nav-height);
     border-bottom: 1px solid var(--ui-border);
-    background: rgba(10, 14, 23, 0.94);
-    backdrop-filter: blur(14px);
+    background: var(--ui-nav);
   }
 
   .app-navbar__inner {
@@ -73,7 +92,7 @@
     margin: 0 auto;
     align-items: center;
     gap: 1.5rem;
-    padding: 0 clamp(1rem, 3vw, 2rem);
+    padding: 0 2rem;
   }
 
   .app-navbar__brand {
@@ -163,7 +182,13 @@
     transform: scaleX(1);
   }
 
-  @media (max-width: 640px) {
+  @media (max-width: 80rem) {
+    .app-navbar__inner {
+      padding: 0 1rem;
+    }
+  }
+
+  @media (max-width: 40rem) {
     .app-navbar__inner {
       gap: 0.5rem;
       padding: 0 0.75rem;

--- a/packages/ui/src/lib/components/layout/ThemeSwitcher.svelte
+++ b/packages/ui/src/lib/components/layout/ThemeSwitcher.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    AppTheme,
+    applyTheme,
+    readStoredTheme,
+    THEME_CHANGE_EVENT,
+    THEME_STORAGE_KEY,
+    themeOptions,
+  } from '@lib/theme';
+
+  let activeTheme: AppTheme = $state(AppTheme.GALAXY);
+
+  onMount(() => {
+    activeTheme = readStoredTheme(window.localStorage);
+    applyTheme(document.documentElement, activeTheme);
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+  });
+
+  function selectTheme(theme: AppTheme): void {
+    activeTheme = theme;
+    applyTheme(document.documentElement, theme);
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+  }
+</script>
+
+<div class="theme-switcher" role="group" aria-label="Color theme">
+  {#each themeOptions as option (option.value)}
+    <button
+      type="button"
+      class="theme-switcher__option"
+      class:theme-switcher__option--active={activeTheme === option.value}
+      aria-label={`${option.label} theme`}
+      aria-pressed={activeTheme === option.value}
+      title={`${option.label} theme`}
+      onclick={() => selectTheme(option.value)}
+    >
+      <span class="theme-switcher__swatch" style={`--theme-swatch: ${option.color}`}></span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .theme-switcher {
+    display: inline-flex;
+    flex: 0 0 auto;
+    gap: 0.125rem;
+    padding: 0.125rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface);
+  }
+
+  .theme-switcher__option {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    cursor: pointer;
+    place-items: center;
+    border: 0;
+    border-radius: 0.375rem;
+    background: transparent;
+  }
+
+  .theme-switcher__option:hover,
+  .theme-switcher__option--active {
+    background: var(--ui-surface-raised);
+  }
+
+  .theme-switcher__option:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+
+  .theme-switcher__swatch {
+    width: 0.75rem;
+    height: 0.75rem;
+    border: 2px solid color-mix(in srgb, var(--theme-swatch) 65%, white);
+    border-radius: 50%;
+    background: var(--theme-swatch);
+  }
+
+  .theme-switcher__option--active .theme-switcher__swatch {
+    box-shadow:
+      0 0 0 2px var(--ui-surface-raised),
+      0 0 0 3px var(--theme-swatch);
+  }
+
+  @media (max-width: 40rem) {
+    .theme-switcher__option {
+      width: 2.75rem;
+      height: 2.75rem;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/components/layout/ThemeSwitcher.svelte.test.ts
+++ b/packages/ui/src/lib/components/layout/ThemeSwitcher.svelte.test.ts
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppTheme, THEME_CHANGE_EVENT, THEME_STORAGE_KEY } from '@lib/theme';
+import ThemeSwitcher from './ThemeSwitcher.svelte';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.dataset.theme = AppTheme.GALAXY;
+});
+
+describe('ThemeSwitcher', () => {
+  it('exposes all themes as a single-choice accessible control', () => {
+    render(ThemeSwitcher);
+    expect(screen.getByRole('group', { name: 'Color theme' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Galaxy theme' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Fire theme' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(screen.getByRole('button', { name: 'Organic theme' })).toBeInTheDocument();
+  });
+
+  it('applies and persists the selected theme', async () => {
+    render(ThemeSwitcher);
+    await fireEvent.click(screen.getByRole('button', { name: 'Fire theme' }));
+    expect(document.documentElement).toHaveAttribute('data-theme', AppTheme.FIRE);
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe(AppTheme.FIRE);
+    expect(screen.getByRole('button', { name: 'Fire theme' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('restores a supported persisted theme on mount', () => {
+    const themeChangeListener = vi.fn();
+    window.addEventListener(THEME_CHANGE_EVENT, themeChangeListener, { once: true });
+    window.localStorage.setItem(THEME_STORAGE_KEY, AppTheme.ORGANIC);
+    render(ThemeSwitcher);
+    expect(document.documentElement).toHaveAttribute('data-theme', AppTheme.ORGANIC);
+    expect(themeChangeListener).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/lib/components/ui/Field.svelte
+++ b/packages/ui/src/lib/components/ui/Field.svelte
@@ -14,7 +14,7 @@
     class: className = '',
   }: {
     value?: string;
-    label?: string;
+    label: string;
     labelHidden?: boolean;
     placeholder?: string;
     type?: 'text' | 'search';
@@ -31,7 +31,7 @@
 </script>
 
 <label class="ui-field {className}" for={id}>
-  {#if label}<span class:sr-only={labelHidden} class="ui-field__label">{label}</span>{/if}
+  <span class:sr-only={labelHidden} class="ui-field__label">{label}</span>
   {#if multiline}
     <textarea
       {id}

--- a/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { canvasStore } from './stores.svelte';
   import { Button, Field } from '@lib/components';
+  import { canvasStore } from './stores.svelte';
 
   let title = $state('');
   let author = $state('');
   let text = $state('');
 
-  function handleSubmit() {
+  function handleSubmit(): void {
     if (!text.trim()) return;
     canvasStore.createAndAnalyze(text, title, author);
     title = '';
@@ -15,40 +15,44 @@
   }
 </script>
 
-<div class="h-full flex flex-col max-w-4xl mx-auto p-6 lg:p-12 w-full">
-  <div class="mb-8">
-    <h2 class="text-3xl font-bold text-slate-100">New Canvas</h2>
-    <p class="text-slate-400 mt-2">
-      Paste any text (poetry, prose, lyrics) to get a dense literary analysis.
-    </p>
-  </div>
+<section class="canvas-editor" aria-labelledby="canvas-editor-title">
+  <header>
+    <h2 id="canvas-editor-title">New Canvas</h2>
+    <p>Paste any text (poetry, prose, lyrics) to get a dense literary analysis.</p>
+  </header>
 
-  <div class="flex flex-col gap-4 flex-1">
-    <div class="flex flex-col gap-4 sm:flex-row">
+  <div class="canvas-editor__form">
+    <div class="canvas-editor__metadata">
       <Field
+        label="Canvas title"
+        labelHidden
         placeholder="Title (optional)"
         bind:value={title}
-        class="flex-1"
+        class="canvas-editor__field"
         disabled={canvasStore.isAnalyzing}
       />
       <Field
+        label="Canvas author"
+        labelHidden
         placeholder="Author (optional)"
         bind:value={author}
-        class="flex-1"
+        class="canvas-editor__field"
         disabled={canvasStore.isAnalyzing}
       />
     </div>
 
     <Field
+      label="Text to analyze"
+      labelHidden
       placeholder="Paste your text here..."
       bind:value={text}
       multiline
       mono
-      class="flex-1"
+      class="canvas-editor__body"
       disabled={canvasStore.isAnalyzing}
     />
 
-    <div class="flex justify-end pt-2">
+    <div class="canvas-editor__actions">
       <Button
         size="lg"
         onclick={handleSubmit}
@@ -58,21 +62,86 @@
         {#if canvasStore.isAnalyzing}
           Analyzing...
         {:else}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path
               fill-rule="evenodd"
-              d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z"
+              d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.7-8.7-3-3a1 1 0 0 0-1.4 1.4L10.6 9H7a1 1 0 1 0 0 2h3.6l-1.3 1.3a1 1 0 1 0 1.4 1.4l3-3a1 1 0 0 0 0-1.4Z"
               clip-rule="evenodd"
             />
           </svg>
-          Analyze Text
+          Analyze text
         {/if}
       </Button>
     </div>
   </div>
-</div>
+</section>
+
+<style>
+  .canvas-editor {
+    display: flex;
+    width: min(56rem, 100%);
+    min-height: 100%;
+    margin: 0 auto;
+    flex-direction: column;
+    padding: 2rem;
+  }
+
+  header {
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    margin: 0;
+    color: var(--ui-text);
+    font-size: 1.75rem;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 0.5rem 0 0;
+    color: var(--ui-text-muted);
+  }
+
+  .canvas-editor__form {
+    display: flex;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .canvas-editor__metadata {
+    display: flex;
+    gap: 1rem;
+  }
+
+  .canvas-editor__metadata :global(.canvas-editor__field) {
+    flex: 1 1 0;
+  }
+
+  .canvas-editor__form :global(.canvas-editor__body) {
+    min-height: 15rem;
+    flex: 1 1 auto;
+  }
+
+  .canvas-editor__actions {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 0.5rem;
+  }
+
+  .canvas-editor svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  @media (max-width: 40rem) {
+    .canvas-editor {
+      padding: 1rem;
+    }
+
+    .canvas-editor__metadata {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte.test.ts
+++ b/packages/ui/src/lib/flows/canvas/CanvasEditor.svelte.test.ts
@@ -18,9 +18,9 @@ describe('CanvasEditor', () => {
     render(CanvasEditor);
 
     expect(screen.getByRole('heading', { name: 'New Canvas' })).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Title (optional)')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Author (optional)')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Paste your text here...')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Canvas title' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Canvas author' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Text to analyze' })).toBeInTheDocument();
   });
 
   it('disables the analyze button while text is empty', () => {

--- a/packages/ui/src/lib/flows/canvas/CanvasFlow.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasFlow.svelte
@@ -1,147 +1,103 @@
 <script lang="ts">
-  import CanvasSidebar from './CanvasSidebar.svelte';
-  import CanvasEditor from './CanvasEditor.svelte';
-  import TokenRenderer from '@components/canvas/TokenRenderer.svelte';
-  import LayerToggle from '@components/canvas/LayerToggle.svelte';
-  import TokenTooltip from '@components/canvas/TokenTooltip.svelte';
-  import FlowLayout from '../../components/layout/FlowLayout.svelte';
-  import { canvasStore } from './stores.svelte';
   import type { Annotation, CanvasAnalysis } from '@flows/shared';
+  import LayerToggle from '@components/canvas/LayerToggle.svelte';
+  import TokenRenderer from '@components/canvas/TokenRenderer.svelte';
+  import TokenTooltip from '@components/canvas/TokenTooltip.svelte';
+  import { FlowLayout, IconButton, Panel } from '@lib/components';
+  import CanvasEditor from './CanvasEditor.svelte';
+  import CanvasSidebar from './CanvasSidebar.svelte';
+  import { canvasStore } from './stores.svelte';
 
-  // Initial canvas list comes from the route loader (+page.ts).
   let { canvases = [] }: { canvases?: CanvasAnalysis[] } = $props();
 
-  // Keep the store aligned when a mutation invalidates and reruns the loader.
   $effect(() => canvasStore.setCanvases(canvases));
 
   let isMobileMenuOpen = $state(false);
-
-  // UI State for viewer
   let activeLayers: string[] = $state(['meaning']);
-
-  // Tooltip State
   let tooltipX = $state(0);
   let tooltipY = $state(0);
   let tooltipVisible = $state(false);
   let tooltipAnnotations: Annotation[] = $state([]);
 
-  function toggleMobileMenu() {
-    isMobileMenuOpen = !isMobileMenuOpen;
-  }
-
-  function handleTokenHover(detail: { tokenId: string; el: HTMLElement } | null) {
+  function handleTokenHover(detail: { tokenId: string; el: HTMLElement } | null): void {
     const analysis = canvasStore.activeCanvas;
-
     if (!detail || !analysis) {
       tooltipVisible = false;
       return;
     }
 
-    const { tokenId, el } = detail;
-
-    // Find active annotations for this token
-    const anns = analysis.annotations.filter(
-      (a) => a.tokenId === tokenId && activeLayers.includes(a.layerId)
+    const annotations = analysis.annotations.filter(
+      (annotation) =>
+        annotation.tokenId === detail.tokenId && activeLayers.includes(annotation.layerId)
     );
-
-    if (anns.length > 0) {
-      const rect = el.getBoundingClientRect();
-      tooltipX = rect.left + rect.width / 2;
-      tooltipY = rect.bottom + 10;
-      tooltipAnnotations = anns;
-      tooltipVisible = true;
-    } else {
+    if (annotations.length === 0) {
       tooltipVisible = false;
+      return;
     }
+
+    const rect = detail.el.getBoundingClientRect();
+    tooltipX = rect.left + rect.width / 2;
+    tooltipY = rect.bottom + 10;
+    tooltipAnnotations = annotations;
+    tooltipVisible = true;
   }
 </script>
 
-<FlowLayout>
-  <div class="fixed inset-0 pt-16 flex bg-slate-950 overflow-hidden text-slate-100">
-    <!-- Sidebar -->
+<FlowLayout fullBleed>
+  <div class="canvas-flow">
     <CanvasSidebar bind:isMobileMenuOpen />
 
-    <!-- Main Area -->
-    <main
-      class="flex-1 flex flex-col h-full bg-slate-950 relative custom-scrollbar overflow-y-auto"
-    >
-      <!-- Header -->
-      <header
-        class="h-14 flex items-center justify-between px-4 border-b border-cosmic-800/50 bg-slate-900/80 backdrop-blur-md sticky top-0 z-10 shrink-0"
-      >
-        <div class="flex items-center gap-3">
-          <button
-            class="md:hidden text-slate-400 hover:text-white"
-            aria-label="Toggle mobile menu"
-            onclick={toggleMobileMenu}
+    <section class="canvas-workspace" aria-label="Canvas workspace">
+      <header class="canvas-toolbar">
+        <div class="canvas-toolbar__identity">
+          <IconButton
+            class="canvas-toolbar__menu"
+            label="Toggle canvas menu"
+            onclick={() => (isMobileMenuOpen = !isMobileMenuOpen)}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="w-6 h-6"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-              />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-width="1.5" d="M4 7h16M4 12h16M4 17h16" />
             </svg>
-          </button>
+          </IconButton>
 
           {#if canvasStore.activeCanvas}
-            <div class="flex flex-col">
-              <h1 class="text-sm font-semibold text-slate-200">
-                {canvasStore.activeCanvas.meta?.title || 'Untitled'}
-              </h1>
-              <span class="text-xs text-slate-500">
-                {canvasStore.activeCanvas.meta?.author || 'User'}
-              </span>
+            <div>
+              <h1>{canvasStore.activeCanvas.meta?.title || 'Untitled'}</h1>
+              <span>{canvasStore.activeCanvas.meta?.author || 'User'}</span>
             </div>
           {:else}
-            <h1 class="text-lg font-semibold text-slate-200">Text Analysis Canvas</h1>
+            <h1>Text Analysis Canvas</h1>
           {/if}
         </div>
 
         {#if canvasStore.activeCanvas}
-          <!-- Layer Toggles -->
-          <div class="flex gap-2">
-            <LayerToggle layers={canvasStore.activeCanvas.layers} bind:activeLayers />
-          </div>
+          <LayerToggle layers={canvasStore.activeCanvas.layers} bind:activeLayers />
         {/if}
       </header>
 
-      <div class="flex-1">
+      <div class="canvas-workspace__content">
         {#if canvasStore.activeCanvas}
-          <div class="max-w-4xl mx-auto p-4 md:p-8 relative min-h-full">
-            <!-- Meta summary if exists -->
+          <div class="canvas-document">
             {#if canvasStore.activeCanvas.meta?.summary}
-              <div class="mb-8 p-6 bg-slate-900/50 border border-cosmic-800/50 rounded-xl">
-                <h3 class="text-lg font-semibold text-white mb-2">Overview</h3>
-                <p class="text-slate-300">{canvasStore.activeCanvas.meta.summary}</p>
+              <Panel element="section" ariaLabel="Overview">
+                <h2>Overview</h2>
+                <p>{canvasStore.activeCanvas.meta.summary}</p>
 
-                <div class="flex gap-4 mt-4 pt-4 border-t border-slate-800">
+                <dl class="canvas-overview__meta">
                   {#if canvasStore.activeCanvas.meta.theme}
                     <div>
-                      <span class="text-xs text-slate-500 uppercase tracking-wider block"
-                        >Theme</span
-                      >
-                      <span class="text-sm text-primary-300"
-                        >{canvasStore.activeCanvas.meta.theme}</span
-                      >
+                      <dt>Theme</dt>
+                      <dd>{canvasStore.activeCanvas.meta.theme}</dd>
                     </div>
                   {/if}
                   {#if canvasStore.activeCanvas.meta.tone}
                     <div>
-                      <span class="text-xs text-slate-500 uppercase tracking-wider block">Tone</span
-                      >
-                      <span class="text-sm text-aurora">{canvasStore.activeCanvas.meta.tone}</span>
+                      <dt>Tone</dt>
+                      <dd>{canvasStore.activeCanvas.meta.tone}</dd>
                     </div>
                   {/if}
-                </div>
-              </div>
+                </dl>
+              </Panel>
             {/if}
 
             <TokenRenderer
@@ -162,32 +118,159 @@
           <CanvasEditor />
         {/if}
       </div>
-    </main>
+    </section>
 
-    <!-- Overlay for mobile when sidebar is open -->
     {#if isMobileMenuOpen}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="fixed inset-0 bg-black/60 z-10 md:hidden"
+      <button
+        class="canvas-overlay"
+        aria-label="Close canvas menu"
         onclick={() => (isMobileMenuOpen = false)}
-      ></div>
+      ></button>
     {/if}
   </div>
 </FlowLayout>
 
 <style>
-  .custom-scrollbar::-webkit-scrollbar {
-    width: 6px;
+  .canvas-flow {
+    position: relative;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    overflow: hidden;
+    background: var(--ui-background);
+    color: var(--ui-text);
   }
-  .custom-scrollbar::-webkit-scrollbar-track {
-    background: transparent;
+
+  .canvas-workspace {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
   }
-  .custom-scrollbar::-webkit-scrollbar-thumb {
-    background: var(--surface-800);
-    border-radius: 4px;
+
+  .canvas-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    min-height: 3.5rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--ui-border);
+    background: var(--ui-nav);
   }
-  .custom-scrollbar:hover::-webkit-scrollbar-thumb {
-    background: var(--surface-700);
+
+  .canvas-toolbar__identity {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .canvas-toolbar__identity div {
+    min-width: 0;
+  }
+
+  .canvas-toolbar h1 {
+    margin: 0;
+    overflow: hidden;
+    font-size: 0.875rem;
+    letter-spacing: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .canvas-toolbar span {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+  }
+
+  .canvas-toolbar__identity :global(.canvas-toolbar__menu) {
+    display: none;
+  }
+
+  .canvas-toolbar svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .canvas-workspace__content {
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow-y: auto;
+  }
+
+  .canvas-document {
+    position: relative;
+    width: min(56rem, 100%);
+    min-height: 100%;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+
+  .canvas-document :global(.ui-panel) {
+    margin-bottom: 2rem;
+  }
+
+  .canvas-document h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.125rem;
+    letter-spacing: 0;
+  }
+
+  .canvas-document p {
+    margin: 0;
+    color: var(--ui-text-muted);
+  }
+
+  .canvas-overview__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin: 1rem 0 0;
+    padding-top: 1rem;
+    border-top: 1px solid var(--ui-border);
+  }
+
+  .canvas-overview__meta div {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .canvas-overview__meta dt {
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+  }
+
+  .canvas-overview__meta dd {
+    margin: 0;
+    color: var(--ui-accent);
+    font-size: 0.875rem;
+  }
+
+  .canvas-overlay {
+    position: fixed;
+    inset: var(--app-nav-height) 0 0;
+    z-index: 15;
+    display: none;
+    border: 0;
+    background: var(--ui-overlay);
+  }
+
+  @media (max-width: 48rem) {
+    .canvas-toolbar__identity :global(.canvas-toolbar__menu),
+    .canvas-overlay {
+      display: grid;
+    }
+
+    .canvas-document {
+      padding: 1rem;
+    }
   }
 </style>

--- a/packages/ui/src/lib/flows/canvas/CanvasSidebar.svelte
+++ b/packages/ui/src/lib/flows/canvas/CanvasSidebar.svelte
@@ -1,111 +1,191 @@
 <script lang="ts">
+  import { AsyncState, Button, IconButton } from '@lib/components';
   import { canvasStore } from './stores.svelte';
 
   let { isMobileMenuOpen = $bindable(false) }: { isMobileMenuOpen?: boolean } = $props();
 
-  function handleSelect(id: string) {
+  function handleSelect(id: string): void {
     canvasStore.loadCanvas(id);
     isMobileMenuOpen = false;
   }
 
-  function handleNew() {
+  function handleNew(): void {
     canvasStore.clearActive();
     isMobileMenuOpen = false;
   }
 </script>
 
-<aside
-  class="w-64 border-r border-cosmic-800/50 bg-slate-900/95 flex flex-col absolute inset-y-0 left-0 z-20 transform transition-transform duration-300 md:relative md:transform-none"
-  class:-translate-x-full={!isMobileMenuOpen}
->
-  <!-- Header / New Button -->
-  <div class="p-4 border-b border-cosmic-800/50 flex-shrink-0">
-    <button
-      class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-500 text-white rounded-lg font-medium transition-colors"
-      onclick={handleNew}
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-5 w-5"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-      >
-        <path
-          fill-rule="evenodd"
-          d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-          clip-rule="evenodd"
-        />
+<aside class="canvas-sidebar" class:canvas-sidebar--open={isMobileMenuOpen} aria-label="Canvases">
+  <div class="canvas-sidebar__header">
+    <Button onclick={handleNew} class="canvas-sidebar__new">
+      <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path d="M9 3a1 1 0 0 1 2 0v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H3a1 1 0 1 1 0-2h6V3Z" />
       </svg>
-      New Canvas
-    </button>
+      New canvas
+    </Button>
   </div>
 
-  <!-- Canvas List -->
-  <div class="flex-1 overflow-y-auto overflow-x-hidden p-2 custom-scrollbar">
+  <div class="canvas-sidebar__content">
     {#if canvasStore.isLoading}
-      <div class="flex items-center justify-center p-8">
-        <div
-          class="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin"
-        ></div>
-      </div>
+      <AsyncState state="loading" title="Loading canvases" />
     {:else if canvasStore.canvases.length === 0}
-      <div class="p-4 text-center text-sm text-slate-500">
-        No canvases yet.<br />Create one to start analyzing text!
-      </div>
+      <AsyncState state="empty" title="No canvases yet" message="Create one to begin." />
     {:else}
-      <div class="space-y-1">
+      <ul>
         {#each canvasStore.canvases as canvas (canvas.sourceId)}
           {@const isActive = canvasStore.activeCanvas?.sourceId === canvas.sourceId}
-          <div class="group flex items-center gap-1">
+          <li>
             <button
-              class="flex-1 text-left px-3 py-2 rounded-md text-sm transition-colors truncate
-                                   {isActive
-                ? 'bg-primary-500/20 text-primary-300 font-medium'
-                : 'text-slate-300 hover:bg-slate-800 hover:text-white'}"
+              class="canvas-sidebar__item"
+              class:canvas-sidebar__item--active={isActive}
+              aria-current={isActive ? 'page' : undefined}
               onclick={() => handleSelect(canvas.sourceId)}
             >
-              <div class="truncate text-sm font-medium">{canvas.meta?.title || 'Untitled'}</div>
-              <div class="text-xs text-slate-500 truncate">{canvas.meta?.author || 'User'}</div>
+              <strong>{canvas.meta?.title || 'Untitled'}</strong>
+              <span>{canvas.meta?.author || 'User'}</span>
             </button>
 
-            <button
-              class="p-2 text-slate-500 hover:text-red-400 hover:bg-red-400/10 rounded-md opacity-0 group-hover:opacity-100 transition-all focus:opacity-100 flex-shrink-0"
-              title="Delete Canvas"
+            <IconButton
+              label={`Delete canvas ${canvas.meta?.title || 'Untitled'}`}
+              variant="danger"
+              size="sm"
+              class="canvas-sidebar__delete"
               onclick={() => canvasStore.deleteCanvas(canvas.sourceId)}
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path
-                  fill-rule="evenodd"
-                  d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                  clip-rule="evenodd"
+                  d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3a1 1 0 1 1 0 2h-1v10a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6H4a1 1 0 0 1 0-2h3V3Zm2 4a1 1 0 0 0-2 0v7a1 1 0 1 0 2 0V7Zm4 0a1 1 0 1 0-2 0v7a1 1 0 1 0 2 0V7Z"
                 />
               </svg>
-            </button>
-          </div>
+            </IconButton>
+          </li>
         {/each}
-      </div>
+      </ul>
     {/if}
   </div>
 </aside>
 
 <style>
-  /* Add custom scrollbar styling if desired */
-  .custom-scrollbar::-webkit-scrollbar {
-    width: 4px;
+  .canvas-sidebar {
+    z-index: 20;
+    display: flex;
+    width: 16rem;
+    min-width: 16rem;
+    height: 100%;
+    flex-direction: column;
+    border-right: 1px solid var(--ui-border);
+    background: var(--ui-surface);
   }
-  .custom-scrollbar::-webkit-scrollbar-track {
+
+  .canvas-sidebar__header {
+    flex: 0 0 auto;
+    padding: 1rem;
+    border-bottom: 1px solid var(--ui-border);
+  }
+
+  .canvas-sidebar__header :global(.canvas-sidebar__new) {
+    width: 100%;
+  }
+
+  .canvas-sidebar svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .canvas-sidebar__content {
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0.5rem;
+  }
+
+  ul {
+    display: grid;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .canvas-sidebar__item {
+    display: grid;
+    min-width: 0;
+    min-height: 2.75rem;
+    flex: 1 1 auto;
+    gap: 0.125rem;
+    cursor: pointer;
+    border: 1px solid transparent;
+    border-radius: 0.375rem;
     background: transparent;
+    color: var(--ui-text-muted);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
   }
-  .custom-scrollbar::-webkit-scrollbar-thumb {
-    background: var(--surface-800);
-    border-radius: 4px;
+
+  .canvas-sidebar__item:hover,
+  .canvas-sidebar__item--active {
+    border-color: var(--ui-border);
+    background: var(--ui-surface-raised);
+    color: var(--ui-text);
   }
-  .custom-scrollbar:hover::-webkit-scrollbar-thumb {
-    background: var(--surface-700);
+
+  .canvas-sidebar__item--active {
+    border-left-color: var(--ui-accent);
+  }
+
+  .canvas-sidebar__item:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+
+  .canvas-sidebar__item strong,
+  .canvas-sidebar__item span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .canvas-sidebar__item strong {
+    font-size: 0.875rem;
+  }
+
+  .canvas-sidebar__item span {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+  }
+
+  .canvas-sidebar__content :global(.canvas-sidebar__delete) {
+    opacity: 0;
+  }
+
+  li:hover :global(.canvas-sidebar__delete),
+  :global(.canvas-sidebar__delete:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (max-width: 48rem) {
+    .canvas-sidebar {
+      position: absolute;
+      inset: 0 auto 0 0;
+      transform: translateX(-100%);
+      transition: transform 150ms ease;
+    }
+
+    .canvas-sidebar--open {
+      transform: translateX(0);
+    }
+  }
+
+  @media (hover: none) {
+    .canvas-sidebar__content :global(.canvas-sidebar__delete) {
+      opacity: 1;
+    }
   }
 </style>

--- a/packages/ui/src/lib/flows/canvas/CanvasSidebar.svelte.test.ts
+++ b/packages/ui/src/lib/flows/canvas/CanvasSidebar.svelte.test.ts
@@ -48,12 +48,12 @@ describe('CanvasSidebar', () => {
     expect(screen.getByText(/No canvases yet/i)).toBeInTheDocument();
   });
 
-  it('shows a loading spinner instead of the empty/list state while loading', () => {
+  it('shows the shared loading state instead of the empty/list state while loading', () => {
     mockCanvasStore.isLoading = true;
     render(CanvasSidebar);
 
     expect(screen.queryByText(/No canvases yet/i)).not.toBeInTheDocument();
-    expect(document.querySelector('.animate-spin')).not.toBeNull();
+    expect(screen.getByRole('status')).toHaveTextContent('Loading canvases');
   });
 
   it('lists canvases with title and author', () => {
@@ -91,7 +91,7 @@ describe('CanvasSidebar', () => {
     mockCanvasStore.canvases = [makeCanvas({ sourceId: 'del-me', meta: { title: 'Delete Me' } })];
     render(CanvasSidebar);
 
-    await fireEvent.click(screen.getByTitle('Delete Canvas'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete canvas Delete Me' }));
 
     expect(mockCanvasStore.deleteCanvas).toHaveBeenCalledWith('del-me');
   });
@@ -102,13 +102,13 @@ describe('CanvasSidebar', () => {
     expect(mockCanvasStore.clearActive).toHaveBeenCalledOnce();
   });
 
-  it('highlights the active canvas row', () => {
+  it('marks the active canvas row semantically', () => {
     const active = makeCanvas({ sourceId: 'active', meta: { title: 'Active One' } });
     mockCanvasStore.canvases = [active];
     mockCanvasStore.activeCanvas = active;
     render(CanvasSidebar);
 
     const row = screen.getByText('Active One').closest('button') as HTMLElement;
-    expect(row.className).toContain('text-primary-300');
+    expect(row).toHaveAttribute('aria-current', 'page');
   });
 });

--- a/packages/ui/src/lib/flows/chat/ChatFlow.svelte
+++ b/packages/ui/src/lib/flows/chat/ChatFlow.svelte
@@ -1,60 +1,40 @@
 <script lang="ts">
-  import Sidebar from './components/Sidebar.svelte';
-  import MessageList from './components/MessageList.svelte';
-  import ChatInput from './components/ChatInput.svelte';
-  import ModelSelector from './components/ModelSelector.svelte';
-  import FlowLayout from '../../components/layout/FlowLayout.svelte';
+  import { FlowLayout, IconButton } from '@lib/components';
   import { onMount } from 'svelte';
+  import ChatInput from './components/ChatInput.svelte';
+  import MessageList from './components/MessageList.svelte';
+  import ModelSelector from './components/ModelSelector.svelte';
+  import Sidebar from './components/Sidebar.svelte';
   import { chatStore, type ChatInitialData } from './stores.svelte';
 
   let { initialData }: { initialData: ChatInitialData } = $props();
+  let isMobileMenuOpen = $state(false);
 
-  // Seed the store with the data fetched by the route loader.
   onMount(() => {
     chatStore.hydrate(initialData);
   });
-
-  let isMobileMenuOpen = $state(false);
-
-  function toggleMobileMenu() {
-    isMobileMenuOpen = !isMobileMenuOpen;
-  }
 </script>
 
-<!-- Using absolute positioning override for the inner layout to maximize screen real estate, over the nav if possible -->
-<FlowLayout>
-  <div class="fixed inset-0 pt-16 flex bg-slate-950 overflow-hidden">
-    <!-- Sidebar -->
+<FlowLayout fullBleed>
+  <div class="chat-flow">
     <Sidebar bind:isMobileMenuOpen />
 
-    <!-- Main Chat Area -->
-    <main class="flex-1 flex flex-col h-full bg-slate-950 relative">
-      <!-- Sticky Header inside Chat Area -->
-      <header
-        class="h-14 flex items-center justify-between px-4 border-b border-cosmic-800/50 bg-slate-900/80 backdrop-blur-md z-10 shrink-0"
-      >
-        <div class="flex items-center gap-3">
-          <button
-            class="md:hidden text-slate-400 hover:text-white"
-            aria-label="Toggle mobile menu"
-            onclick={toggleMobileMenu}
+    <section class="chat-workspace" aria-label="Chat workspace">
+      <header class="chat-toolbar">
+        <div class="chat-toolbar__identity">
+          <IconButton
+            class="chat-toolbar__menu"
+            label="Toggle conversation menu"
+            onclick={() => (isMobileMenuOpen = !isMobileMenuOpen)}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="w-6 h-6"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-              />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-width="1.5" d="M4 7h16M4 12h16M4 17h16" />
             </svg>
-          </button>
-          <h1 class="text-lg font-semibold text-slate-200">Chat</h1>
+          </IconButton>
+          <div>
+            <h1>Chat</h1>
+            <span>AI workspace</span>
+          </div>
         </div>
 
         <ModelSelector />
@@ -62,16 +42,106 @@
 
       <MessageList />
       <ChatInput />
-    </main>
+    </section>
 
-    <!-- Overlay for mobile when sidebar is open -->
     {#if isMobileMenuOpen}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="fixed inset-0 bg-black/60 z-10 md:hidden"
+      <button
+        class="chat-overlay"
+        aria-label="Close conversation menu"
         onclick={() => (isMobileMenuOpen = false)}
-      ></div>
+      ></button>
     {/if}
   </div>
 </FlowLayout>
+
+<style>
+  .chat-flow {
+    position: relative;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    overflow: hidden;
+    background: var(--ui-background);
+    color: var(--ui-text);
+  }
+
+  .chat-workspace {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+
+  .chat-toolbar {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    min-height: 3.5rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--ui-border);
+    background: var(--ui-nav);
+  }
+
+  .chat-toolbar__identity {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .chat-toolbar__identity div {
+    display: grid;
+    min-width: 0;
+    gap: 0.125rem;
+  }
+
+  .chat-toolbar h1 {
+    margin: 0;
+    font-size: 0.875rem;
+    letter-spacing: 0;
+  }
+
+  .chat-toolbar span {
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+  }
+
+  .chat-toolbar__identity :global(.chat-toolbar__menu) {
+    display: none;
+  }
+
+  .chat-toolbar svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .chat-overlay {
+    position: fixed;
+    inset: var(--app-nav-height) 0 0;
+    z-index: 15;
+    display: none;
+    border: 0;
+    background: var(--ui-overlay);
+  }
+
+  @media (max-width: 48rem) {
+    .chat-toolbar__identity :global(.chat-toolbar__menu),
+    .chat-overlay {
+      display: grid;
+    }
+
+    .chat-toolbar {
+      padding-inline: 0.75rem;
+    }
+
+    .chat-toolbar__identity span {
+      display: none;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/chat/ChatFlow.svelte.test.ts
+++ b/packages/ui/src/lib/flows/chat/ChatFlow.svelte.test.ts
@@ -77,7 +77,8 @@ describe('ChatFlow', () => {
   it('shows the sidebar empty-history placeholder when there are no conversations', () => {
     renderFlow(makeInitialData());
 
-    expect(screen.getByText('No history yet. Start a conversation!')).toBeInTheDocument();
+    expect(screen.getByText('No history yet')).toBeInTheDocument();
+    expect(screen.getByText('Start a conversation.')).toBeInTheDocument();
   });
 
   it('renders loaded conversations in the sidebar (data state)', () => {
@@ -90,16 +91,20 @@ describe('ChatFlow', () => {
     );
 
     expect(screen.getByText('Astronomy questions')).toBeInTheDocument();
-    expect(screen.queryByText('No history yet. Start a conversation!')).not.toBeInTheDocument();
+    expect(screen.queryByText('No history yet')).not.toBeInTheDocument();
   });
 
-  it('exposes a mobile menu toggle button', async () => {
+  it('opens and closes the mobile conversation menu', async () => {
     renderFlow();
-    const toggle = screen.getByLabelText('Toggle mobile menu');
-    expect(toggle).toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: 'Toggle conversation menu' });
 
-    // Clicking opens the overlay without throwing.
     await fireEvent.click(toggle);
-    expect(toggle).toBeInTheDocument();
+    const close = screen.getByRole('button', { name: 'Close conversation menu' });
+    expect(close).toBeInTheDocument();
+
+    await fireEvent.click(close);
+    expect(
+      screen.queryByRole('button', { name: 'Close conversation menu' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte
@@ -1,48 +1,45 @@
 <script lang="ts">
-  import { chatStore } from '../stores.svelte';
   import { IconButton } from '@lib/components';
+  import { chatStore } from '../stores.svelte';
 
   let inputContent = $state('');
   let textareaEl: HTMLTextAreaElement;
 
-  // Auto-resize textarea
-  function handleInput() {
+  function handleInput(): void {
     if (!textareaEl) return;
     textareaEl.style.height = 'auto';
-    textareaEl.style.height = Math.min(textareaEl.scrollHeight, 200) + 'px';
+    textareaEl.style.height = `${Math.min(textareaEl.scrollHeight, 200)}px`;
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
       submit();
     }
   }
 
-  function submit() {
+  function submit(): void {
     if (!inputContent.trim() || chatStore.isLoading) return;
 
     chatStore.sendMessage(inputContent.trim());
     inputContent = '';
 
-    // Reset textarea height instantly
     setTimeout(() => {
       if (textareaEl) textareaEl.style.height = 'auto';
     }, 0);
   }
 </script>
 
-<div class="p-4 bg-slate-900 border-t border-cosmic-800">
-  <div
-    class="max-w-4xl mx-auto relative flex items-end bg-slate-800 rounded-xl border border-slate-700 focus-within:border-cosmic-500 focus-within:shadow-glow transition-all"
-  >
+<footer class="chat-composer">
+  <div class="chat-composer__field">
+    <label class="chat-composer__label" for="chat-message">Message</label>
     <textarea
+      id="chat-message"
       bind:this={textareaEl}
       bind:value={inputContent}
       oninput={handleInput}
       onkeydown={handleKeydown}
       placeholder="Send a message..."
-      class="w-full bg-transparent text-slate-200 resize-none outline-none py-3.5 pl-4 pr-12 max-h-[200px] overflow-y-auto scrollbar-thin text-sm leading-relaxed"
       rows="1"
       disabled={chatStore.isLoading}
     ></textarea>
@@ -53,14 +50,9 @@
         variant="secondary"
         size="sm"
         onclick={() => chatStore.stopStreaming()}
-        class="absolute right-2 bottom-2"
+        class="chat-composer__action"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          class="w-3.5 h-3.5"
-        >
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <rect x="6" y="6" width="12" height="12" rx="1.5" />
         </svg>
       </IconButton>
@@ -71,14 +63,9 @@
         size="sm"
         onclick={submit}
         disabled={!inputContent.trim() || chatStore.isLoading}
-        class="absolute right-2 bottom-2"
+        class="chat-composer__action"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          class="w-4 h-4"
-        >
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path
             d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z"
           />
@@ -86,7 +73,90 @@
       </IconButton>
     {/if}
   </div>
-  <p class="text-center mt-2 text-[11px] text-slate-500 cursor-default select-none">
-    AI can make mistakes. Consider verifying important information.
-  </p>
-</div>
+
+  <p>AI can make mistakes. Consider verifying important information.</p>
+</footer>
+
+<style>
+  .chat-composer {
+    flex: 0 0 auto;
+    padding: 1rem;
+    border-top: 1px solid var(--ui-border);
+    background: var(--ui-nav);
+  }
+
+  .chat-composer__field {
+    position: relative;
+    display: flex;
+    width: min(56rem, 100%);
+    min-height: 3rem;
+    margin: 0 auto;
+    align-items: flex-end;
+    border: 1px solid var(--ui-border-strong);
+    border-radius: 0.5rem;
+    background: var(--ui-surface-raised);
+  }
+
+  .chat-composer__field:focus-within {
+    border-color: var(--ui-focus);
+    outline: 2px solid color-mix(in srgb, var(--ui-focus) 25%, transparent);
+    outline-offset: 1px;
+  }
+
+  .chat-composer__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+
+  textarea {
+    width: 100%;
+    max-height: 12.5rem;
+    resize: none;
+    overflow-y: auto;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--ui-text);
+    padding: 0.875rem 3.25rem 0.875rem 1rem;
+    font: inherit;
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  textarea::placeholder {
+    color: var(--ui-text-muted);
+  }
+
+  textarea:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+
+  .chat-composer__field :global(.chat-composer__action) {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+  }
+
+  .chat-composer svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .chat-composer p {
+    margin: 0.5rem 0 0;
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+    text-align: center;
+  }
+
+  @media (max-width: 40rem) {
+    .chat-composer {
+      padding: 0.75rem;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/chat/components/ChatInput.svelte.test.ts
+++ b/packages/ui/src/lib/flows/chat/components/ChatInput.svelte.test.ts
@@ -63,7 +63,7 @@ describe('ChatInput', () => {
   it('renders the textarea and a disabled send button while empty', () => {
     render(ChatInput);
 
-    const textarea = screen.getByPlaceholderText('Send a message...');
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
     expect(textarea).toBeInTheDocument();
     expect(textarea).toBeEnabled();
     expect(screen.getByTitle('Send message')).toBeDisabled();

--- a/packages/ui/src/lib/flows/chat/components/MessageList.svelte
+++ b/packages/ui/src/lib/flows/chat/components/MessageList.svelte
@@ -1,33 +1,24 @@
 <script lang="ts">
-  import { chatStore } from '../stores.svelte';
-  import { marked } from 'marked';
+  import { AsyncState, Badge } from '@lib/components';
   import DOMPurify from 'dompurify';
+  import { marked } from 'marked';
+  import { chatStore } from '../stores.svelte';
 
   let listContainer: HTMLDivElement;
 
-  // Auto-scroll to bottom whenever messages / streaming content update.
   $effect(() => {
-    // Track the reactive values that should trigger a scroll.
     void chatStore.messages;
     void chatStore.streamingContent;
-    if (listContainer) {
-      listContainer.scrollTop = listContainer.scrollHeight;
-    }
+    if (listContainer) listContainer.scrollTop = listContainer.scrollHeight;
   });
 
-  // Configure marked for clean output
-  marked.setOptions({
-    breaks: true,
-    gfm: true,
-  });
+  marked.setOptions({ breaks: true, gfm: true });
 
-  /** Render markdown → sanitized HTML. */
   function renderMarkdown(text: string): string {
-    // Transform <think> tags into a collapsible details block
     const processedText = text
       .replace(
         /<think>/g,
-        '\n<details class="mb-3 border border-slate-700 rounded-md bg-slate-800/40 overflow-hidden"><summary class="px-3 py-2 cursor-pointer text-[10px] uppercase tracking-wider font-semibold text-slate-400 hover:text-slate-300 bg-slate-800/80 select-none flex items-center gap-2"><svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg> Thought Process</summary><div class="px-4 py-3 text-sm text-slate-400 border-t border-slate-700/50 italic">\n\n'
+        '\n<details class="chat-thought"><summary>Thought process</summary><div>\n\n'
       )
       .replace(/<\/think>/g, '\n\n</div></details>\n');
 
@@ -38,149 +29,294 @@
     });
   }
 
-  function getModelDisplayName(msg: { modelUsed?: string; providerUsed?: string }): string {
-    if (!msg.modelUsed) return '';
-    const provider = msg.providerUsed || '';
-    const model = msg.modelUsed || '';
+  function getModelDisplayName(message: { modelUsed?: string; providerUsed?: string }): string {
+    if (!message.modelUsed) return '';
 
-    // Try to find human-readable name from catalog
+    const provider = message.providerUsed || '';
+    const model = message.modelUsed;
     for (const group of chatStore.catalog) {
-      if (group.provider === provider) {
-        const found = group.models.find((m) => m.id === model);
-        if (found) return `${provider} / ${found.name}`;
-      }
+      if (group.provider !== provider) continue;
+      const match = group.models.find((candidate) => candidate.id === model);
+      if (match) return `${provider} / ${match.name}`;
     }
-    // Fallback: clean ID
+
     const cleaned = model
       .replace(/:free$/, '')
       .split(/[-/]/)
-      .filter((w) => w !== '')
-      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
 
     return provider ? `${provider} / ${cleaned}` : cleaned;
   }
 </script>
 
-<div
-  bind:this={listContainer}
-  class="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 scrollbar-thin scroll-smooth"
->
+<div bind:this={listContainer} class="message-list" aria-live="polite">
   {#if chatStore.messages.length === 0 && !chatStore.isStreaming}
-    <div class="h-full flex flex-col items-center justify-center text-slate-500 space-y-4">
-      <div
-        class="w-16 h-16 rounded-full bg-cosmic-900/50 flex items-center justify-center border border-cosmic-500/30"
-      >
-        <span class="text-3xl">✨</span>
-      </div>
-      <h3 class="text-xl font-medium text-slate-300">How can I help you today?</h3>
-      <p class="max-w-md text-center text-sm">
-        Select a model from the top menu and send a message to begin.
-      </p>
+    <div class="message-list__empty">
+      <AsyncState
+        state="empty"
+        title="How can I help you today?"
+        message="Select a model from the top menu and send a message to begin."
+      />
     </div>
   {/if}
 
-  {#each chatStore.messages as msg (msg.id)}
-    <div class={`flex w-full ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-      <!-- Avatar for assistant -->
-      {#if msg.role === 'assistant'}
-        <div
-          class="w-8 h-8 rounded-full bg-cosmic-700 flex-shrink-0 flex items-center justify-center mr-3 mt-1 shadow-glow-sm"
-        >
-          <svg
-            class="w-4 h-4 text-cosmic-300"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            stroke-width="1.5"
-          >
+  {#each chatStore.messages as message (message.id)}
+    <article class="message" class:message--user={message.role === 'user'}>
+      {#if message.role === 'assistant'}
+        <span class="message__avatar" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
-              d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
+              stroke-width="1.5"
+              d="M9.8 15.9 9 18.8l-.8-2.9a4.5 4.5 0 0 0-3.1-3.1L2.3 12l2.8-.8a4.5 4.5 0 0 0 3.1-3.1L9 5.3l.8 2.8a4.5 4.5 0 0 0 3.1 3.1l2.9.8-2.9.8a4.5 4.5 0 0 0-3.1 3.1Z"
             />
           </svg>
-        </div>
+        </span>
       {/if}
 
-      <div
-        class={`max-w-[85%] md:max-w-[75%] rounded-2xl px-5 py-3 ${
-          msg.role === 'user'
-            ? 'bg-slate-700 text-white rounded-tr-sm shadow-md'
-            : 'bg-transparent border border-cosmic-800 text-slate-200 rounded-tl-sm shadow-sm'
-        }`}
-      >
-        {#if msg.role === 'user'}
-          <p class="text-sm leading-relaxed whitespace-pre-wrap">{msg.content}</p>
+      <div class="message__bubble">
+        {#if message.role === 'user'}
+          <p class="message__plain">{message.content}</p>
         {:else}
-          <div
-            class="prose prose-invert prose-sm max-w-none leading-relaxed prose-p:my-1 prose-pre:bg-slate-900 prose-pre:border prose-pre:border-slate-700 prose-code:text-cosmic-300 prose-code:before:content-[''] prose-code:after:content-['']"
-          >
+          <div class="message__markdown">
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            {@html renderMarkdown(msg.content)}
+            {@html renderMarkdown(message.content)}
           </div>
         {/if}
 
-        {#if msg.role === 'assistant' && msg.modelUsed}
-          <div class="mt-2 text-[10px] text-slate-500 flex justify-end">
-            <span class="bg-slate-800 px-2 py-0.5 rounded-full border border-slate-700 capitalize">
-              {getModelDisplayName(msg)}
-            </span>
+        {#if message.role === 'assistant' && message.modelUsed}
+          <div class="message__model">
+            <Badge>{getModelDisplayName(message)}</Badge>
           </div>
         {/if}
       </div>
-    </div>
+    </article>
   {/each}
 
-  <!-- Streaming message (in progress) -->
   {#if chatStore.isStreaming}
-    <div class="flex w-full justify-start">
-      <div
-        class="w-8 h-8 rounded-full bg-cosmic-700 flex-shrink-0 flex items-center justify-center mr-3 mt-1 shadow-glow-sm"
-      >
-        <svg
-          class="w-4 h-4 text-cosmic-300 animate-pulse"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="1.5"
-        >
+    <article class="message">
+      <span class="message__avatar message__avatar--active" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
           <path
             stroke-linecap="round"
             stroke-linejoin="round"
-            d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
+            stroke-width="1.5"
+            d="M9.8 15.9 9 18.8l-.8-2.9a4.5 4.5 0 0 0-3.1-3.1L2.3 12l2.8-.8a4.5 4.5 0 0 0 3.1-3.1L9 5.3l.8 2.8a4.5 4.5 0 0 0 3.1 3.1l2.9.8-2.9.8a4.5 4.5 0 0 0-3.1 3.1Z"
           />
         </svg>
-      </div>
-      <div
-        class="max-w-[85%] md:max-w-[75%] bg-transparent border border-cosmic-800 rounded-2xl rounded-tl-sm px-5 py-3 shadow-sm"
-      >
+      </span>
+
+      <div class="message__bubble">
         {#if chatStore.streamingContent}
-          <div
-            class="prose prose-invert prose-sm max-w-none leading-relaxed prose-p:my-1 prose-pre:bg-slate-900 prose-pre:border prose-pre:border-slate-700 prose-code:text-cosmic-300 prose-code:before:content-[''] prose-code:after:content-['']"
-          >
+          <div class="message__markdown">
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             {@html renderMarkdown(chatStore.streamingContent)}
           </div>
-          <span class="inline-block w-0.5 h-4 bg-cosmic-400 animate-pulse ml-0.5 align-text-bottom"
-          ></span>
+          <span class="message__caret" aria-hidden="true"></span>
         {:else}
-          <div class="flex items-center gap-1.5 py-1">
-            <div
-              class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
-              style="animation-delay: 0ms"
-            ></div>
-            <div
-              class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
-              style="animation-delay: 150ms"
-            ></div>
-            <div
-              class="w-2 h-2 bg-cosmic-400 rounded-full animate-bounce"
-              style="animation-delay: 300ms"
-            ></div>
+          <div class="typing-indicator" role="status" aria-label="Generating response">
+            <span></span><span></span><span></span>
           </div>
         {/if}
       </div>
-    </div>
+    </article>
   {/if}
 </div>
+
+<style>
+  .message-list {
+    display: grid;
+    min-height: 0;
+    flex: 1 1 auto;
+    align-content: start;
+    gap: 1.5rem;
+    overflow-y: auto;
+    padding: 1.5rem;
+    scroll-behavior: smooth;
+  }
+
+  .message-list__empty {
+    display: grid;
+    min-height: 100%;
+    place-items: center;
+  }
+
+  .message {
+    display: flex;
+    width: min(56rem, 100%);
+    margin: 0 auto;
+    align-items: flex-start;
+  }
+
+  .message--user {
+    justify-content: flex-end;
+  }
+
+  .message__avatar {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    flex: 0 0 2rem;
+    margin: 0.25rem 0.75rem 0 0;
+    place-items: center;
+    border: 1px solid var(--ui-border-strong);
+    border-radius: 50%;
+    background: var(--ui-surface-raised);
+    color: var(--ui-accent);
+  }
+
+  .message__avatar svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .message__avatar--active {
+    animation: chat-pulse 1.5s ease-in-out infinite;
+  }
+
+  .message__bubble {
+    max-width: min(75%, 46rem);
+    padding: 0.875rem 1rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
+    background: var(--ui-surface);
+    color: var(--ui-text);
+  }
+
+  .message--user .message__bubble {
+    border-color: color-mix(in srgb, var(--ui-accent) 45%, var(--ui-border));
+    background: var(--ui-accent-strong);
+    color: var(--ui-accent-contrast);
+  }
+
+  .message__plain {
+    margin: 0;
+    white-space: pre-wrap;
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+
+  .message__markdown {
+    overflow-wrap: anywhere;
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+
+  .message__markdown :global(:first-child) {
+    margin-top: 0;
+  }
+
+  .message__markdown :global(:last-child) {
+    margin-bottom: 0;
+  }
+
+  .message__markdown :global(pre) {
+    max-width: 100%;
+    overflow-x: auto;
+    padding: 0.875rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+    background: var(--ui-background);
+  }
+
+  .message__markdown :global(code) {
+    color: var(--ui-accent);
+  }
+
+  .message__markdown :global(.chat-thought) {
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+    background: var(--ui-surface-subtle);
+  }
+
+  .message__markdown :global(.chat-thought summary) {
+    cursor: pointer;
+    padding: 0.625rem 0.75rem;
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .message__markdown :global(.chat-thought > div) {
+    padding: 0.75rem;
+    border-top: 1px solid var(--ui-border);
+    color: var(--ui-text-muted);
+    font-style: italic;
+  }
+
+  .message__model {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+  }
+
+  .message__caret {
+    display: inline-block;
+    width: 2px;
+    height: 1rem;
+    margin-left: 0.25rem;
+    vertical-align: text-bottom;
+    background: var(--ui-accent);
+    animation: chat-pulse 1s ease-in-out infinite;
+  }
+
+  .typing-indicator {
+    display: flex;
+    min-width: 3.75rem;
+    min-height: 1.5rem;
+    align-items: center;
+    gap: 0.375rem;
+  }
+
+  .typing-indicator span {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--ui-accent);
+    animation: chat-bounce 900ms ease-in-out infinite;
+  }
+
+  .typing-indicator span:nth-child(2) {
+    animation-delay: 150ms;
+  }
+
+  .typing-indicator span:nth-child(3) {
+    animation-delay: 300ms;
+  }
+
+  @keyframes chat-pulse {
+    50% {
+      opacity: 0.45;
+    }
+  }
+
+  @keyframes chat-bounce {
+    50% {
+      transform: translateY(-0.25rem);
+    }
+  }
+
+  @media (max-width: 40rem) {
+    .message-list {
+      gap: 1rem;
+      padding: 1rem 0.75rem;
+    }
+
+    .message__bubble {
+      max-width: calc(100% - 2.75rem);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .message__avatar--active,
+    .message__caret,
+    .typing-indicator span {
+      animation: none;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/chat/components/MessageList.svelte.test.ts
+++ b/packages/ui/src/lib/flows/chat/components/MessageList.svelte.test.ts
@@ -137,8 +137,7 @@ describe('MessageList', () => {
 
     render(MessageList);
 
-    // Bouncing dots use animate-bounce; assert at least one is present.
-    expect(document.querySelector('.animate-bounce')).not.toBeNull();
+    expect(screen.getByRole('status', { name: 'Generating response' })).toBeInTheDocument();
     // Empty placeholder must be hidden while streaming.
     expect(screen.queryByText('How can I help you today?')).not.toBeInTheDocument();
 

--- a/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
+++ b/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte
@@ -1,72 +1,71 @@
 <script lang="ts">
-  import { chatStore } from '../stores.svelte';
   import type { ChatProviderGroup } from '@flows/shared';
+  import { Badge } from '@lib/components';
   import { slide } from 'svelte/transition';
+  import { chatStore } from '../stores.svelte';
+
+  type BadgeTone = 'neutral' | 'info' | 'success' | 'warning';
 
   let dropdownOpen = $state(false);
 
-  function setMode(mode: 'rotation' | 'specific') {
+  function setMode(mode: 'rotation' | 'specific'): void {
     chatStore.setMode(mode);
-    if (mode === 'rotation') {
-      dropdownOpen = false;
-    }
+    if (mode === 'rotation') dropdownOpen = false;
   }
 
-  function selectModel(provider: string, modelId: string) {
+  function selectModel(provider: string, modelId: string): void {
     chatStore.setModel(`${provider}:${modelId}`);
     dropdownOpen = false;
   }
 
-  function toggleDropdown() {
-    if (chatStore.chatMode === 'specific') {
-      dropdownOpen = !dropdownOpen;
-    }
+  function toggleDropdown(): void {
+    if (chatStore.chatMode === 'specific') dropdownOpen = !dropdownOpen;
   }
 
-  function handleClickOutside(e: MouseEvent) {
-    const target = e.target as HTMLElement;
-    if (!target.closest('.model-selector-container')) {
-      dropdownOpen = false;
-    }
+  function handleClickOutside(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+    if (!target.closest('.model-selector')) dropdownOpen = false;
   }
 
-  function parseSelected(sel: string): { provider: string; model: string } {
-    const idx = sel.indexOf(':');
-    if (idx === -1) return { provider: '', model: sel };
-    return { provider: sel.slice(0, idx), model: sel.slice(idx + 1) };
+  function parseSelected(selection: string): { provider: string; model: string } {
+    const separator = selection.indexOf(':');
+    if (separator === -1) return { provider: '', model: selection };
+    return {
+      provider: selection.slice(0, separator),
+      model: selection.slice(separator + 1),
+    };
   }
 
   function getModelDisplayName(modelId: string, catalog: ChatProviderGroup[]): string {
     for (const group of catalog) {
-      const found = group.models.find((m) => m.id === modelId);
-      if (found) return found.name;
+      const match = group.models.find((model) => model.id === modelId);
+      if (match) return match.name;
     }
+
     return modelId
       .split(/[-/]/)
-      .filter((w) => w !== 'free' && w !== '')
-      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .filter((word) => word !== 'free' && word !== '')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
   }
 
-  function tierColor(tier: string): string {
+  function tierTone(tier: string): BadgeTone {
     switch (tier) {
       case 'very_high':
-        return 'text-amber-400 bg-amber-400/10 border-amber-400/20';
+        return 'warning';
       case 'high':
-        return 'text-emerald-400 bg-emerald-400/10 border-emerald-400/20';
+        return 'success';
       case 'medium':
-        return 'text-blue-400 bg-blue-400/10 border-blue-400/20';
-      case 'low':
-        return 'text-slate-400 bg-slate-400/10 border-slate-400/20';
+        return 'info';
       default:
-        return 'text-slate-500 bg-slate-500/10 border-slate-500/20';
+        return 'neutral';
     }
   }
 
   function tierLabel(tier: string): string {
     switch (tier) {
       case 'very_high':
-        return '★';
+        return 'VH';
       case 'high':
         return 'H';
       case 'medium':
@@ -84,147 +83,312 @@
 
 <svelte:window onclick={handleClickOutside} />
 
-<div class="model-selector-container relative flex items-center gap-1.5">
-  <!-- Mode Toggle (labeled) -->
-  <div
-    class="flex bg-slate-800 rounded-lg border border-slate-700 overflow-hidden text-xs font-medium"
-  >
+<div class="model-selector">
+  <div class="model-selector__modes" role="group" aria-label="Chat mode">
     <button
-      class="flex items-center gap-1 px-3 py-1.5 transition-all"
-      class:bg-cosmic-600={chatStore.chatMode === 'rotation'}
-      class:text-white={chatStore.chatMode === 'rotation'}
-      class:text-slate-400={chatStore.chatMode !== 'rotation'}
-      class:hover:text-slate-200={chatStore.chatMode !== 'rotation'}
+      class:active={chatStore.chatMode === 'rotation'}
+      aria-pressed={chatStore.chatMode === 'rotation'}
       onclick={() => setMode('rotation')}
       title="Round-robin across free providers"
     >
-      <svg
-        class="w-3.5 h-3.5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        stroke-width="2"
-      >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
         <path
           stroke-linecap="round"
           stroke-linejoin="round"
-          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+          stroke-width="2"
+          d="M4 4v5h5m11 11v-5h-5M5 9a8 8 0 0 1 13-3m1 9a8 8 0 0 1-13 3"
         />
       </svg>
-      <span class="hidden sm:inline">Rotate</span>
+      <span>Rotate</span>
     </button>
     <button
-      class="flex items-center gap-1 px-3 py-1.5 transition-all"
-      class:bg-cosmic-600={chatStore.chatMode === 'specific'}
-      class:text-white={chatStore.chatMode === 'specific'}
-      class:text-slate-400={chatStore.chatMode !== 'specific'}
-      class:hover:text-slate-200={chatStore.chatMode !== 'specific'}
+      class:active={chatStore.chatMode === 'specific'}
+      aria-pressed={chatStore.chatMode === 'specific'}
       onclick={() => setMode('specific')}
       title="Choose a specific provider and model"
     >
-      <svg
-        class="w-3.5 h-3.5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        stroke-width="2"
-      >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
         <path
           stroke-linecap="round"
           stroke-linejoin="round"
-          d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"
+          stroke-width="2"
+          d="m5 4 14 7-6 2-2 6L5 4Z"
         />
       </svg>
-      <span class="hidden sm:inline">Specific</span>
+      <span>Specific</span>
     </button>
   </div>
 
-  <!-- Badge / Selector -->
   {#if chatStore.chatMode === 'rotation'}
-    <div
-      class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800/50 rounded-lg border border-slate-700/50 text-xs"
-    >
+    <div class="model-selector__summary" aria-live="polite">
       {#if chatStore.lastProvider}
-        <span class="text-cosmic-400 font-medium capitalize">{chatStore.lastProvider}</span>
-        <span class="text-slate-600">/</span>
-        <span class="text-slate-300 truncate max-w-[140px]">
-          {getModelDisplayName(chatStore.lastModel, chatStore.catalog)}
-        </span>
+        <strong>{chatStore.lastProvider}</strong>
+        <span aria-hidden="true">/</span>
+        <span>{getModelDisplayName(chatStore.lastModel, chatStore.catalog)}</span>
       {:else}
-        <span class="text-slate-400 italic">Auto-rotate</span>
+        <span>Auto-rotate</span>
       {/if}
     </div>
   {:else}
     <button
-      class="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-800 rounded-lg border border-slate-700 hover:border-cosmic-600 transition-colors text-xs cursor-pointer"
+      class="model-selector__trigger"
+      aria-expanded={dropdownOpen}
+      aria-controls="chat-model-menu"
+      aria-haspopup="menu"
       onclick={toggleDropdown}
     >
-      <span class="text-cosmic-400 font-medium capitalize">{selected.provider}</span>
-      <span class="text-slate-600">/</span>
-      <span class="text-slate-200 truncate max-w-[140px]">{selectedDisplayName}</span>
-      <svg
-        class="w-3 h-3 text-slate-400 ml-0.5 transition-transform"
-        class:rotate-180={dropdownOpen}
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        stroke-width="2"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+      <strong>{selected.provider || 'Model'}</strong>
+      <span aria-hidden="true">/</span>
+      <span>{selectedDisplayName || 'Select'}</span>
+      <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class:open={dropdownOpen}>
+        <path
+          fill-rule="evenodd"
+          d="M5.2 7.2a.75.75 0 0 1 1.1 0l3.7 3.7 3.7-3.7a.75.75 0 1 1 1.1 1.1l-4.3 4.2a.75.75 0 0 1-1 0L5.2 8.3a.75.75 0 0 1 0-1.1Z"
+          clip-rule="evenodd"
+        />
       </svg>
     </button>
   {/if}
 
-  <!-- Dropdown -->
   {#if dropdownOpen}
     <div
+      id="chat-model-menu"
+      class="model-selector__menu"
+      role="menu"
       transition:slide={{ duration: 150 }}
-      class="absolute top-full right-0 mt-1.5 w-72 bg-slate-800 border border-slate-700 rounded-xl shadow-2xl shadow-black/40 z-50 overflow-hidden"
     >
-      <div class="max-h-[360px] overflow-y-auto scrollbar-thin">
-        {#each chatStore.catalog as group (group.provider)}
-          {#if group.models.length > 0}
-            <div
-              class="sticky top-0 px-3 py-2 bg-slate-800/95 backdrop-blur-sm border-b border-slate-700/50"
+      {#each chatStore.catalog as group (group.provider)}
+        {#if group.models.length > 0}
+          <div class="model-selector__group-label">{group.provider}</div>
+          {#each group.models as model (model.id)}
+            {@const fullId = `${group.provider}:${model.id}`}
+            {@const isSelected = chatStore.selectedModel === fullId}
+            <button
+              class="model-selector__option"
+              class:selected={isSelected}
+              role="menuitemradio"
+              aria-checked={isSelected}
+              onclick={() => selectModel(group.provider, model.id)}
             >
-              <span class="text-xs font-semibold text-slate-400 uppercase tracking-wider"
-                >{group.provider}</span
+              <span class="model-selector__option-copy">
+                <strong>{model.name}</strong>
+                {#if model.description}<small>{model.description}</small>{/if}
+              </span>
+              <span title={model.tier}
+                ><Badge tone={tierTone(model.tier)}>{tierLabel(model.tier)}</Badge></span
               >
-            </div>
-
-            {#each group.models as model (model.id)}
-              {@const fullId = `${group.provider}:${model.id}`}
-              {@const isSelected = chatStore.selectedModel === fullId}
-              <button
-                class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-slate-700/50 transition-colors {isSelected
-                  ? 'bg-cosmic-600/10'
-                  : ''}"
-                onclick={() => selectModel(group.provider, model.id)}
-              >
-                <span
-                  class="w-1.5 h-1.5 rounded-full shrink-0 {isSelected
-                    ? 'bg-cosmic-500'
-                    : 'bg-transparent'}"
-                ></span>
-
-                <div class="flex-1 min-w-0">
-                  <div class="text-sm text-slate-200 truncate">{model.name}</div>
-                  {#if model.description}
-                    <div class="text-[10px] text-slate-500 truncate">{model.description}</div>
-                  {/if}
-                </div>
-
-                <span
-                  class="text-[10px] font-bold px-1.5 py-0.5 rounded border {tierColor(model.tier)}"
-                  title={model.tier}
-                >
-                  {tierLabel(model.tier)}
-                </span>
-              </button>
-            {/each}
-          {/if}
-        {/each}
-      </div>
+            </button>
+          {/each}
+        {/if}
+      {/each}
     </div>
   {/if}
 </div>
+
+<style>
+  .model-selector {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .model-selector__modes {
+    display: flex;
+    flex: 0 0 auto;
+    overflow: hidden;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+    background: var(--ui-surface);
+  }
+
+  .model-selector__modes button {
+    display: flex;
+    min-height: 2rem;
+    align-items: center;
+    gap: 0.375rem;
+    cursor: pointer;
+    border: 0;
+    background: transparent;
+    color: var(--ui-text-muted);
+    padding: 0.375rem 0.625rem;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .model-selector__modes button + button {
+    border-left: 1px solid var(--ui-border);
+  }
+
+  .model-selector__modes button:hover,
+  .model-selector__modes button.active {
+    background: var(--ui-accent-strong);
+    color: var(--ui-accent-contrast);
+  }
+
+  .model-selector button:focus-visible {
+    position: relative;
+    z-index: 1;
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+
+  .model-selector__modes svg,
+  .model-selector__trigger svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex: 0 0 auto;
+  }
+
+  .model-selector__summary,
+  .model-selector__trigger {
+    display: flex;
+    min-width: 0;
+    min-height: 2rem;
+    align-items: center;
+    gap: 0.375rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+    background: var(--ui-surface);
+    color: var(--ui-text-muted);
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
+  }
+
+  .model-selector__summary strong,
+  .model-selector__trigger strong {
+    color: var(--ui-accent);
+    text-transform: capitalize;
+  }
+
+  .model-selector__summary > span:last-child,
+  .model-selector__trigger > span:not([aria-hidden]) {
+    max-width: 9rem;
+    overflow: hidden;
+    color: var(--ui-text);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .model-selector__trigger {
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.75rem;
+  }
+
+  .model-selector__trigger:hover {
+    border-color: var(--ui-border-strong);
+  }
+
+  .model-selector__trigger svg {
+    transition: transform 150ms ease;
+  }
+
+  .model-selector__trigger svg.open {
+    transform: rotate(180deg);
+  }
+
+  .model-selector__menu {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    z-index: 50;
+    width: min(18rem, calc(100vw - 1.5rem));
+    max-height: 22.5rem;
+    overflow-y: auto;
+    border: 1px solid var(--ui-border-strong);
+    border-radius: 0.5rem;
+    background: var(--ui-surface-raised);
+    box-shadow: var(--ui-shadow);
+  }
+
+  .model-selector__group-label {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--ui-border);
+    background: var(--ui-surface-raised);
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .model-selector__option {
+    display: flex;
+    width: 100%;
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    border: 0;
+    border-bottom: 1px solid var(--ui-border);
+    background: transparent;
+    color: var(--ui-text);
+    padding: 0.625rem 0.75rem;
+    text-align: left;
+  }
+
+  .model-selector__option:hover,
+  .model-selector__option.selected {
+    background: var(--ui-surface-subtle);
+  }
+
+  .model-selector__option.selected {
+    box-shadow: inset 3px 0 var(--ui-accent);
+  }
+
+  .model-selector__option-copy {
+    display: grid;
+    min-width: 0;
+    flex: 1 1 auto;
+    gap: 0.125rem;
+  }
+
+  .model-selector__option-copy strong,
+  .model-selector__option-copy small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .model-selector__option-copy strong {
+    font-size: 0.8rem;
+  }
+
+  .model-selector__option-copy small {
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+  }
+
+  @media (max-width: 40rem) {
+    .model-selector__modes span {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+    }
+
+    .model-selector__modes button {
+      width: 2.25rem;
+      justify-content: center;
+      padding-inline: 0.5rem;
+    }
+
+    .model-selector__summary > span:last-child,
+    .model-selector__trigger > span:not([aria-hidden]) {
+      max-width: 5rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .model-selector__trigger svg {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte.test.ts
+++ b/packages/ui/src/lib/flows/chat/components/ModelSelector.svelte.test.ts
@@ -68,8 +68,11 @@ describe('ModelSelector', () => {
 
   it('renders both mode toggle buttons', () => {
     render(ModelSelector);
-    expect(screen.getByText('Rotate')).toBeInTheDocument();
-    expect(screen.getByText('Specific')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rotate' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Specific' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('shows the selected provider and model name in specific mode', () => {
@@ -84,6 +87,10 @@ describe('ModelSelector', () => {
     // Trigger button shows the current selection; click it to open the list.
     await fireEvent.click(screen.getByText('GPT-4o'));
 
+    expect(screen.getByRole('button', { name: /openai.*gpt-4o/i })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
     expect(screen.getByText('GPT-4o Mini')).toBeInTheDocument();
     expect(screen.getByText('Llama 3')).toBeInTheDocument();
     expect(screen.getByText('Flagship multimodal')).toBeInTheDocument();

--- a/packages/ui/src/lib/flows/chat/components/Sidebar.svelte
+++ b/packages/ui/src/lib/flows/chat/components/Sidebar.svelte
@@ -1,118 +1,210 @@
 <script lang="ts">
+  import { AsyncState, Button, IconButton } from '@lib/components';
   import { chatStore } from '../stores.svelte';
 
   let { isMobileMenuOpen = $bindable(false) }: { isMobileMenuOpen?: boolean } = $props();
 
-  function selectConversation(id: string) {
+  function selectConversation(id: string): void {
     chatStore.loadConversation(id);
     isMobileMenuOpen = false;
   }
 
-  function newChat() {
+  function newChat(): void {
     chatStore.startNewConversation();
     isMobileMenuOpen = false;
   }
 
-  function handleDelete(e: Event, id: string) {
-    e.stopPropagation();
+  function handleDelete(event: Event, id: string): void {
+    event.stopPropagation();
     chatStore.deleteConversation(id);
   }
 
   function formatRelativeTime(timestamp: number): string {
-    const diff = Date.now() - timestamp;
-    const seconds = Math.floor(diff / 1000);
-
+    const seconds = Math.floor((Date.now() - timestamp) / 1000);
     if (seconds < 60) return 'just now';
+
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) return `${minutes}m ago`;
+
     const hours = Math.floor(minutes / 60);
     if (hours < 24) return `${hours}h ago`;
+
     const days = Math.floor(hours / 24);
     if (days < 7) return `${days}d ago`;
     return new Date(timestamp).toLocaleDateString();
   }
 </script>
 
-<div
-  class={`flex flex-col h-full bg-slate-900 border-r border-cosmic-800 transition-all duration-300 ${isMobileMenuOpen ? 'w-64 absolute z-20 h-full' : 'hidden md:flex w-64'}`}
->
-  <div class="p-4 border-b border-cosmic-800">
-    <button
-      onclick={newChat}
-      class="w-full flex items-center justify-center gap-2 bg-cosmic-600 hover:bg-cosmic-500 text-white py-2 px-4 rounded-lg transition-colors shadow-glow"
-    >
-      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+<aside class="chat-sidebar" class:chat-sidebar--open={isMobileMenuOpen} aria-label="Conversations">
+  <div class="chat-sidebar__header">
+    <Button onclick={newChat} class="chat-sidebar__new">
+      <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path d="M9 3a1 1 0 0 1 2 0v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H3a1 1 0 1 1 0-2h6V3Z" />
       </svg>
-      New Chat
-    </button>
+      New chat
+    </Button>
   </div>
 
-  <div class="flex-1 overflow-y-auto p-2 scrollbar-thin">
+  <div class="chat-sidebar__content">
     {#if chatStore.conversations.length === 0}
-      <div class="text-slate-500 text-center py-8 text-sm px-2">
-        No history yet. Start a conversation!
-      </div>
-    {/if}
-
-    <ul class="space-y-0.5">
-      {#each chatStore.conversations as conv (conv.id)}
-        <li class="group">
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div
-            onclick={() => selectConversation(conv.id)}
-            class={`w-full text-left px-3 py-2.5 rounded-lg text-sm flex items-center gap-2 transition-all cursor-pointer ${
-              chatStore.activeConversationId === conv.id
-                ? 'bg-cosmic-800/70 text-white border border-cosmic-600/30'
-                : 'text-slate-300 hover:bg-slate-800/70'
-            }`}
-            title={conv.title}
-          >
-            <svg
-              class="w-3.5 h-3.5 shrink-0 text-slate-500"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="1.5"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.068.157 2.148.279 3.238.364.466.037.893.281 1.153.671L12 21l2.652-3.978c.26-.39.687-.634 1.153-.671 1.09-.085 2.17-.207 3.238-.364 1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"
-              />
-            </svg>
-
-            <div class="min-w-0 flex-1">
-              <div class="truncate">{conv.title}</div>
-              <div class="text-[10px] text-slate-500 mt-0.5">
-                {formatRelativeTime(conv.updatedAt)}
-              </div>
-            </div>
-
-            <!-- Delete button (visible on hover) -->
+      <AsyncState state="empty" title="No history yet" message="Start a conversation." />
+    {:else}
+      <ul>
+        {#each chatStore.conversations as conversation (conversation.id)}
+          {@const isActive = chatStore.activeConversationId === conversation.id}
+          <li>
             <button
-              class="shrink-0 opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-slate-500 transition-all"
-              onclick={(e) => handleDelete(e, conv.id)}
-              title="Delete conversation"
+              class="chat-sidebar__item"
+              class:chat-sidebar__item--active={isActive}
+              aria-current={isActive ? 'page' : undefined}
+              title={conversation.title}
+              onclick={() => selectConversation(conversation.id)}
             >
-              <svg
-                class="w-3.5 h-3.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
+              <strong>{conversation.title}</strong>
+              <span>{formatRelativeTime(conversation.updatedAt)}</span>
+            </button>
+
+            <IconButton
+              label={`Delete conversation ${conversation.title}`}
+              variant="danger"
+              size="sm"
+              class="chat-sidebar__delete"
+              onclick={(event) => handleDelete(event, conversation.id)}
+            >
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                  d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3a1 1 0 1 1 0 2h-1v10a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6H4a1 1 0 0 1 0-2h3V3Zm2 4a1 1 0 0 0-2 0v7a1 1 0 1 0 2 0V7Zm4 0a1 1 0 1 0-2 0v7a1 1 0 1 0 2 0V7Z"
                 />
               </svg>
-            </button>
-          </div>
-        </li>
-      {/each}
-    </ul>
+            </IconButton>
+          </li>
+        {/each}
+      </ul>
+    {/if}
   </div>
-</div>
+</aside>
+
+<style>
+  .chat-sidebar {
+    z-index: 20;
+    display: flex;
+    width: 16rem;
+    min-width: 16rem;
+    height: 100%;
+    flex-direction: column;
+    border-right: 1px solid var(--ui-border);
+    background: var(--ui-surface);
+  }
+
+  .chat-sidebar__header {
+    flex: 0 0 auto;
+    padding: 1rem;
+    border-bottom: 1px solid var(--ui-border);
+  }
+
+  .chat-sidebar__header :global(.chat-sidebar__new) {
+    width: 100%;
+  }
+
+  .chat-sidebar svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .chat-sidebar__content {
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0.5rem;
+  }
+
+  ul {
+    display: grid;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .chat-sidebar__item {
+    display: grid;
+    min-width: 0;
+    min-height: 2.75rem;
+    flex: 1 1 auto;
+    gap: 0.125rem;
+    cursor: pointer;
+    border: 1px solid transparent;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: var(--ui-text-muted);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  .chat-sidebar__item:hover,
+  .chat-sidebar__item--active {
+    border-color: var(--ui-border);
+    background: var(--ui-surface-raised);
+    color: var(--ui-text);
+  }
+
+  .chat-sidebar__item--active {
+    border-left-color: var(--ui-accent);
+  }
+
+  .chat-sidebar__item:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+
+  .chat-sidebar__item strong,
+  .chat-sidebar__item span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chat-sidebar__item strong {
+    font-size: 0.875rem;
+  }
+
+  .chat-sidebar__item span {
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+  }
+
+  .chat-sidebar__content :global(.chat-sidebar__delete) {
+    opacity: 0;
+  }
+
+  li:hover :global(.chat-sidebar__delete),
+  :global(.chat-sidebar__delete:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (max-width: 48rem) {
+    .chat-sidebar {
+      position: absolute;
+      inset: 0 auto 0 0;
+      transform: translateX(-100%);
+      transition: transform 150ms ease;
+    }
+
+    .chat-sidebar--open {
+      transform: translateX(0);
+    }
+  }
+
+  @media (hover: none) {
+    .chat-sidebar__content :global(.chat-sidebar__delete) {
+      opacity: 1;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/chat/components/Sidebar.svelte.test.ts
+++ b/packages/ui/src/lib/flows/chat/components/Sidebar.svelte.test.ts
@@ -58,12 +58,13 @@ describe('Sidebar', () => {
 
   it('always renders the New Chat button', () => {
     renderWith([]);
-    expect(screen.getByText('New Chat')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /new chat/i })).toBeInTheDocument();
   });
 
   it('shows the empty-history placeholder when there are no conversations', () => {
     renderWith([]);
-    expect(screen.getByText('No history yet. Start a conversation!')).toBeInTheDocument();
+    expect(screen.getByText('No history yet')).toBeInTheDocument();
+    expect(screen.getByText('Start a conversation.')).toBeInTheDocument();
   });
 
   it('lists conversation titles once loaded', () => {
@@ -75,7 +76,7 @@ describe('Sidebar', () => {
     expect(screen.getByText('Trip planning')).toBeInTheDocument();
     expect(screen.getByText('Recipe ideas')).toBeInTheDocument();
     // Negative space: placeholder gone.
-    expect(screen.queryByText('No history yet. Start a conversation!')).not.toBeInTheDocument();
+    expect(screen.queryByText('No history yet')).not.toBeInTheDocument();
   });
 
   it('renders a deterministic relative timestamp', () => {
@@ -87,7 +88,7 @@ describe('Sidebar', () => {
 
   it('clicking New Chat starts a fresh conversation in the store', async () => {
     renderWith([]);
-    await fireEvent.click(screen.getByText('New Chat'));
+    await fireEvent.click(screen.getByRole('button', { name: /new chat/i }));
 
     expect(chatStore.activeConversationId).toBeTruthy();
   });
@@ -106,7 +107,7 @@ describe('Sidebar', () => {
     renderWith([makeConversation({ id: 'conv-9', title: 'Delete me' })]);
     deleteConversation.mockResolvedValueOnce(undefined);
 
-    await fireEvent.click(screen.getByTitle('Delete conversation'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete conversation Delete me' }));
 
     expect(deleteConversation).toHaveBeenCalledWith('conv-9');
   });
@@ -116,9 +117,17 @@ describe('Sidebar', () => {
     deleteConversation.mockResolvedValueOnce(undefined);
     fetchMessages.mockClear();
 
-    await fireEvent.click(screen.getByTitle('Delete conversation'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete conversation Delete me' }));
 
     // handleDelete stops propagation, so selectConversation must not run.
     expect(fetchMessages).not.toHaveBeenCalled();
+  });
+
+  it('marks the active conversation for assistive technology', async () => {
+    renderWith([makeConversation({ id: 'conv-7', title: 'Current chat' })]);
+    fetchMessages.mockResolvedValueOnce([]);
+    await fireEvent.click(screen.getByTitle('Current chat'));
+
+    expect(screen.getByTitle('Current chat')).toHaveAttribute('aria-current', 'page');
   });
 });

--- a/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte
+++ b/packages/ui/src/lib/flows/lyrics/LyricsCanvas.svelte
@@ -137,7 +137,7 @@
   }
 </script>
 
-<div class="canvas-container" data-theme="organic">
+<div class="canvas-container">
   {#if loading}
     <div class="center-state">
       <AsyncState state="loading" title="Loading canvas" />
@@ -215,7 +215,7 @@
               {@html renderMarkdown(interpretation)}
               {#if isInterpreting}
                 <span
-                  class="inline-block w-0.5 h-4 bg-aurora animate-pulse ml-0.5 align-text-bottom"
+                  class="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-accent align-text-bottom"
                 ></span>
               {/if}
             </div>
@@ -252,7 +252,8 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    background: var(--surface-900);
+    background: var(--ui-background);
+    color: var(--ui-text);
     overflow-y: auto;
   }
 
@@ -268,30 +269,28 @@
   }
 
   .album-art {
-    width: 120px;
-    height: 120px;
+    width: 7.5rem;
+    height: 7.5rem;
     border-radius: 0.5rem;
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
+    box-shadow: var(--ui-shadow);
   }
 
   h2 {
     font-size: 2rem;
     margin: 0;
-    background: linear-gradient(to right, var(--primary-400), var(--secondary-400));
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
+    color: var(--ui-accent);
+    letter-spacing: 0;
   }
 
   .author {
     font-size: 1.25rem;
-    color: var(--surface-300);
+    color: var(--ui-text);
     margin: 0;
   }
 
   .description {
-    color: var(--surface-400);
-    max-width: 400px;
+    color: var(--ui-text-muted);
+    max-width: 25rem;
     line-height: 1.5;
   }
 
@@ -307,14 +306,13 @@
     position: sticky;
     top: 0;
     z-index: 10;
-    background: rgba(15, 23, 42, 0.8);
-    backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--surface-800);
+    background: var(--ui-nav);
+    border-bottom: 1px solid var(--ui-border);
     padding: 1.5rem 2rem;
   }
 
   .header-content {
-    max-width: 1000px;
+    max-width: 62.5rem;
     margin: 0 auto;
     display: flex;
     justify-content: space-between;
@@ -346,7 +344,7 @@
     display: grid;
     grid-template-columns: 2fr 1fr;
     gap: 2rem;
-    max-width: 1400px;
+    max-width: 87.5rem;
     margin: 0 auto;
     padding: 2rem;
     width: 100%;
@@ -359,17 +357,17 @@
   }
 
   .canvas-sidebar {
-    background: rgba(15, 23, 42, 0.4);
-    border: 1px solid var(--surface-800);
-    border-radius: 1rem;
+    background: var(--ui-surface);
+    border: 1px solid var(--ui-border);
+    border-radius: 0.5rem;
     overflow: hidden;
     position: sticky;
-    top: 120px; /* offset from header */
+    top: 7.5rem;
   }
 
   .sidebar-header {
-    background: rgba(15, 23, 42, 0.8);
-    border-bottom: 1px solid var(--surface-800);
+    background: var(--ui-surface-raised);
+    border-bottom: 1px solid var(--ui-border);
     padding: 1rem 1.5rem;
   }
 
@@ -377,19 +375,19 @@
     margin: 0;
     font-size: 1rem;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--aurora);
+    letter-spacing: 0;
+    color: var(--ui-accent);
   }
 
   .sidebar-content {
     padding: 1.5rem;
-    max-height: calc(100vh - 200px);
+    max-height: calc(100vh - 12.5rem);
     overflow-y: auto;
   }
 
   .empty-meaning {
     text-align: center;
-    color: var(--surface-400);
+    color: var(--ui-text-muted);
     padding: 2rem 0;
   }
 
@@ -397,7 +395,7 @@
     margin-top: 1rem;
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 56.25rem) {
     .canvas-header {
       padding: 1rem;
     }

--- a/packages/ui/src/lib/flows/lyrics/LyricsFlow.svelte
+++ b/packages/ui/src/lib/flows/lyrics/LyricsFlow.svelte
@@ -4,7 +4,7 @@
   import type { LyricsPageData, LyricsTrackRow } from '../../../routes/lyrics/+page';
   import { getLyricsStats, getLyricsLibrary, fetchAllLyrics, getLyrics } from './api';
   import { toast } from '@lib/toast';
-  import { AsyncState, Badge, Button, FlowLayout, IconButton } from '@lib/components';
+  import { AsyncState, Badge, Button, FlowLayout, IconButton, Panel } from '@lib/components';
   import LyricsModal from './components/LyricsModal.svelte';
   import LyricsCanvas from './LyricsCanvas.svelte';
 
@@ -173,24 +173,22 @@
 </script>
 
 <FlowLayout>
-  <div class="h-full w-full overflow-hidden flex flex-col pb-8" data-theme="organic">
+  <div class="lyrics-flow">
     <!-- Header -->
-    <header
-      class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8"
-    >
+    <header class="lyrics-header">
       <div>
-        <h1 class="flex min-w-0 items-center gap-3 text-2xl font-bold sm:text-3xl md:text-4xl">
+        <h1 class="lyrics-title">
           <span aria-hidden="true">🎤</span>
-          <span class="min-w-0 text-cosmic">Lyrics Dashboard</span>
+          <span>Lyrics Dashboard</span>
         </h1>
-        <p class="text-pulsar mt-2 max-w-xl">
+        <p class="lyrics-subtitle">
           Manage lyrics availability. To read lyrics, visit the
-          <a href="/spotify" class="text-aurora hover:underline">Spotify Flow</a>.
+          <a href="/spotify">Spotify Flow</a>.
         </p>
       </div>
 
       <!-- Actions -->
-      <div class="flex items-center gap-3">
+      <div class="lyrics-actions">
         <!-- Retry Failed Button -->
         <Button
           onclick={() => handleFetchAllLyrics(true)}
@@ -247,7 +245,7 @@
       <AsyncState state="error" title="Error Loading Data" message={error} action={retryAction} />
     {:else if canvasTrackId}
       <div class="flex flex-col h-full">
-        <div class="p-4 border-b border-white/5">
+        <div class="border-b border-border p-4">
           <Button variant="ghost" onclick={() => (canvasTrackId = null)}>Back to Dashboard</Button>
         </div>
         <div class="flex-grow overflow-hidden relative">
@@ -256,45 +254,51 @@
       </div>
     {:else if stats}
       <!-- Stats Grid -->
-      <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-12">
+      <div class="lyrics-stats">
         <!-- Total Tracks -->
-        <div class="glass p-5 rounded-2xl border-l-4 border-nebula">
-          <h3 class="text-pulsar text-xs font-bold uppercase tracking-wider mb-1">Total Tracks</h3>
-          <p class="text-3xl font-bold text-cosmic">{stats.total}</p>
-        </div>
+        <Panel padding="md">
+          <div class="lyrics-stat">
+            <h3>Total Tracks</h3>
+            <p>{stats.total}</p>
+          </div>
+        </Panel>
 
         <!-- Found -->
-        <div class="glass p-5 rounded-2xl border-l-4 border-aurora">
-          <h3 class="text-pulsar text-xs font-bold uppercase tracking-wider mb-1">Found</h3>
-          <div class="flex justify-between items-end">
-            <p class="text-3xl font-bold text-cosmic">{stats.found}</p>
-            <p class="text-sm text-aurora font-medium">{getPercentage(stats.found, stats.total)}</p>
+        <Panel padding="md">
+          <div class="lyrics-stat lyrics-stat--success">
+            <h3>Found</h3>
+            <div>
+              <p>{stats.found}</p>
+              <Badge tone="success">{getPercentage(stats.found, stats.total)}</Badge>
+            </div>
           </div>
-        </div>
+        </Panel>
 
         <!-- Not Found -->
-        <div class="glass p-5 rounded-2xl border-l-4 border-red-400">
-          <h3 class="text-pulsar text-xs font-bold uppercase tracking-wider mb-1">Not Found</h3>
-          <div class="flex justify-between items-end">
-            <p class="text-3xl font-bold text-cosmic">{stats.notFound}</p>
-            <p class="text-sm text-red-400 font-medium">
-              {getPercentage(stats.notFound, stats.total)}
-            </p>
+        <Panel padding="md">
+          <div class="lyrics-stat lyrics-stat--danger">
+            <h3>Not Found</h3>
+            <div>
+              <p>{stats.notFound}</p>
+              <Badge tone="danger">{getPercentage(stats.notFound, stats.total)}</Badge>
+            </div>
           </div>
-        </div>
+        </Panel>
 
         <!-- Pending -->
-        <div class="glass p-5 rounded-2xl border-l-4 border-pulsar">
-          <h3 class="text-pulsar text-xs font-bold uppercase tracking-wider mb-1">Pending</h3>
-          <p class="text-3xl font-bold text-cosmic">{stats.pending}</p>
-        </div>
+        <Panel padding="md">
+          <div class="lyrics-stat lyrics-stat--info">
+            <h3>Pending</h3>
+            <p>{stats.pending}</p>
+          </div>
+        </Panel>
       </div>
 
       <!-- Tracks Table -->
-      <div class="glass rounded-2xl overflow-hidden border border-white/5">
-        <div class="p-6 border-b border-white/5 flex justify-between items-center bg-white/5">
+      <Panel padding="none">
+        <div class="flex items-center justify-between border-b border-border bg-surface-subtle p-4">
           <div class="flex items-center gap-4">
-            <h2 class="text-lg font-bold text-cosmic">Recent Tracks</h2>
+            <h2 class="text-lg font-bold">Recent Tracks</h2>
 
             <!-- Filter Control -->
             <div class="relative">
@@ -326,7 +330,7 @@
           <div class="overflow-x-auto">
             <table class="w-full text-left border-collapse">
               <thead>
-                <tr class="border-b border-white/5 text-xs text-pulsar uppercase tracking-wider">
+                <tr class="border-b border-border text-xs uppercase text-muted">
                   <th class="p-4 font-medium w-16">Cover</th>
                   <th class="p-4 font-medium">Title</th>
                   <th class="p-4 font-medium">Artist</th>
@@ -334,10 +338,10 @@
                   <th class="p-4 font-medium w-24 text-right">Actions</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-white/5">
+              <tbody class="divide-y divide-border">
                 {#each tracks as track (track.id)}
                   <tr
-                    class="hover:bg-white/5 transition-colors group {track.status === 'found'
+                    class="group transition-colors hover:bg-surface-raised {track.status === 'found'
                       ? 'cursor-pointer'
                       : ''}"
                     onclick={() => {
@@ -367,16 +371,16 @@
                         />
                       {:else}
                         <div
-                          class="w-10 h-10 rounded bg-white/10 flex items-center justify-center text-xl"
+                          class="flex h-10 w-10 items-center justify-center rounded bg-surface-raised text-xl"
                         >
                           🎵
                         </div>
                       {/if}
                     </td>
-                    <td class="p-4 text-white font-medium group-hover:text-aurora transition-colors"
+                    <td class="p-4 font-medium transition-colors group-hover:text-accent"
                       >{track.title}</td
                     >
-                    <td class="p-4 text-pulsar">{track.artist}</td>
+                    <td class="p-4 text-muted">{track.artist}</td>
                     <td class="p-4 text-right">
                       <Badge tone={getStatusTone(track.status)}>
                         {track.status.replace('_', ' ')}
@@ -473,13 +477,13 @@
 
         <!-- Load More Action -->
         {#if hasMore && tracks.length > 0}
-          <div class="p-4 border-t border-white/5 flex justify-center">
+          <div class="flex justify-center border-t border-border p-4">
             <Button onclick={handleLoadMore} disabled={loading} {loading} variant="secondary">
               {loading ? 'Loading more...' : 'Load More'}
             </Button>
           </div>
         {/if}
-      </div>
+      </Panel>
     {/if}
   </div>
 </FlowLayout>
@@ -487,3 +491,126 @@
 {#if selectedTrack}
   <LyricsModal track={selectedTrack} onclose={() => (selectedTrack = null)} />
 {/if}
+
+<style>
+  .lyrics-flow {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    flex-direction: column;
+    overflow: hidden;
+    padding-bottom: 2rem;
+  }
+
+  .lyrics-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .lyrics-title {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+    font-size: 2.25rem;
+    letter-spacing: 0;
+  }
+
+  .lyrics-subtitle {
+    max-width: 36rem;
+    margin: 0.5rem 0 0;
+    color: var(--ui-text-muted);
+  }
+
+  .lyrics-subtitle a {
+    color: var(--ui-accent);
+  }
+
+  .lyrics-subtitle a:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+
+  .lyrics-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .lyrics-stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .lyrics-stat {
+    display: grid;
+    gap: 0.5rem;
+    border-left: 3px solid var(--ui-border);
+    padding-left: 0.75rem;
+  }
+
+  .lyrics-stat--success {
+    border-left-color: var(--ui-success);
+  }
+
+  .lyrics-stat--danger {
+    border-left-color: var(--ui-danger);
+  }
+
+  .lyrics-stat--info {
+    border-left-color: var(--ui-accent);
+  }
+
+  .lyrics-stat h3 {
+    margin: 0;
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+  }
+
+  .lyrics-stat > div {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .lyrics-stat p {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+  }
+
+  @media (max-width: 48rem) {
+    .lyrics-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .lyrics-title {
+      font-size: 1.75rem;
+    }
+
+    .lyrics-stats {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 30rem) {
+    .lyrics-actions :global(.ui-button) {
+      flex: 1 1 10rem;
+    }
+
+    .lyrics-stats {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
+++ b/packages/ui/src/lib/flows/lyrics/components/LyricsModal.svelte
@@ -274,7 +274,7 @@
     }
   }
 
-  @media (max-width: 640px) {
+  @media (max-width: 40rem) {
     .album-art {
       width: 2.5rem;
       height: 2.5rem;

--- a/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte
+++ b/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { toast } from 'svelte-5-french-toast';
   import type { GenreCount, SearchOptions, Track, YearCount } from '@flows/shared';
-  import { AsyncState, Button, FlowLayout } from '@lib/components';
+  import { AsyncState, Button, FlowLayout, Panel } from '@lib/components';
   import InfiniteScroll from '@lib/components/common/InfiniteScroll.svelte';
   import type { TopStats } from '@lib/types';
   import { loadTracks } from './api';
@@ -47,7 +47,6 @@
     if (url.searchParams.get('connected') === 'true') {
       toast.success('Successfully connected to Spotify!', {
         position: 'bottom-right',
-        className: 'glass text-cosmic font-medium',
       });
       url.searchParams.delete('connected');
       window.history.replaceState({}, '', url.toString());
@@ -76,17 +75,19 @@
 </svelte:head>
 
 <FlowLayout>
-  <div class="flex flex-col gap-6" data-theme="organic">
+  <div class="spotify-flow">
     <SpotifyHeader stats={spotifyStore.topStats} />
     <InsightsPanel stats={spotifyStore.topStats} />
 
     <div class="flex items-center"><Controls /></div>
 
-    <div
-      class="glass sticky top-4 z-10 flex flex-col items-center justify-between gap-4 p-4 md:flex-row"
-    >
-      <div class="w-full flex-grow md:w-auto"><SearchBar /></div>
-      <div class="flex w-full gap-2 md:w-auto"><FilterPanel {genres} {years} /></div>
+    <div class="spotify-toolbar">
+      <Panel padding="sm">
+        <div class="spotify-toolbar__content">
+          <div class="spotify-toolbar__search"><SearchBar /></div>
+          <div><FilterPanel {genres} {years} /></div>
+        </div>
+      </Panel>
     </div>
 
     <section class="min-h-[50vh]" aria-label="Spotify tracks">
@@ -119,6 +120,48 @@
       />
     {/if}
 
-    <footer class="mt-12 pb-8 text-center text-sm text-white/20">Flow Sample - Spotify</footer>
+    <footer>Flow Sample - Spotify</footer>
   </div>
 </FlowLayout>
+
+<style>
+  .spotify-flow {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .spotify-toolbar {
+    position: sticky;
+    top: calc(var(--app-nav-height) + 0.5rem);
+    z-index: 10;
+  }
+
+  .spotify-toolbar__content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .spotify-toolbar__search {
+    width: 100%;
+    flex: 1 1 auto;
+  }
+
+  footer {
+    margin-top: 2rem;
+    padding-bottom: 2rem;
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+    text-align: center;
+  }
+
+  @media (max-width: 48rem) {
+    .spotify-toolbar__content {
+      align-items: stretch;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/AlbumArt.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/AlbumArt.svelte
@@ -7,32 +7,25 @@
   }
 
   let { imageUrl, albumName, durationMs, spotifyUrl }: Props = $props();
-
   let formattedDuration = $derived(
     `${Math.floor(durationMs / 60000)}:${((durationMs % 60000) / 1000).toFixed(0).padStart(2, '0')}`
   );
 </script>
 
-<div class="relative w-full aspect-square bg-void/50">
-  <img src={imageUrl} alt="{albumName} cover" class="w-full h-full object-cover" loading="lazy" />
+<div class="album-art">
+  <img src={imageUrl} alt="{albumName} cover" loading="lazy" />
+  <span class="album-art__duration">{formattedDuration}</span>
 
-  <!-- Duration overlay -->
-  <span
-    class="absolute bottom-2 right-2 px-2 py-1 bg-void/80 rounded text-xs text-pulsar font-mono backdrop-blur-sm"
-  >
-    {formattedDuration}
-  </span>
-
-  <!-- Spotify Link (on hover) -->
   {#if spotifyUrl}
     <a
       href={spotifyUrl}
       target="_blank"
       rel="noopener noreferrer"
-      class="absolute top-2 right-2 p-2 bg-aurora rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow-lg hover:bg-aurora-hover"
+      class="album-art__link"
+      aria-label="Open in Spotify"
       title="Open in Spotify"
     >
-      <svg class="w-4 h-4 text-void" viewBox="0 0 24 24" fill="currentColor">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path
           d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"
         />
@@ -40,3 +33,67 @@
     </a>
   {/if}
 </div>
+
+<style>
+  .album-art {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    aspect-ratio: 1;
+    background: var(--ui-surface-raised);
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .album-art__duration {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    background: var(--ui-overlay);
+    color: var(--ui-text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+  }
+
+  .album-art__link {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: grid;
+    width: 2.5rem;
+    height: 2.5rem;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--ui-accent-strong);
+    color: var(--ui-accent-contrast);
+    opacity: 0;
+    transition: opacity 150ms ease;
+  }
+
+  .album-art:hover .album-art__link,
+  .album-art__link:focus-visible {
+    opacity: 1;
+  }
+
+  .album-art__link:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  @media (hover: none) {
+    .album-art__link {
+      opacity: 1;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/DecadeChart.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/DecadeChart.svelte
@@ -1,95 +1,86 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import {
+    BarController,
+    BarElement,
+    CategoryScale,
     Chart,
+    Legend,
+    LinearScale,
     Title,
     Tooltip,
-    Legend,
-    BarElement,
-    BarController,
-    CategoryScale,
-    LinearScale,
     type ChartConfiguration,
   } from 'chart.js';
+  import { THEME_CHANGE_EVENT } from '@lib/theme';
+  import { readChartTheme } from '@lib/chart-theme';
 
   Chart.register(Title, Tooltip, Legend, BarElement, BarController, CategoryScale, LinearScale);
 
-  let { data } = $props<{
-    data: Record<string, number>;
-  }>();
-
+  let { data }: { data: Record<string, number> } = $props();
   let canvas: HTMLCanvasElement;
-  let chart: Chart | null = null;
+  let chart: Chart<'bar'> | null = null;
 
-  function updateChart() {
-    if (!chart) return;
-
+  function getChartData(): { labels: string[]; values: number[] } {
     const labels = Object.keys(data).sort();
-    const values = labels.map((k) => data[k]);
-
-    chart.data.labels = labels;
-    chart.data.datasets[0].data = values;
-    chart.update();
+    return { labels, values: labels.map((label) => data[label]) };
   }
 
-  onMount(() => {
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+  function createChart(): void {
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    chart?.destroy();
 
-    const labels = Object.keys(data).sort();
-    const values = labels.map((k) => data[k]);
-
-    const config: ChartConfiguration = {
+    const { labels, values } = getChartData();
+    const theme = readChartTheme(getComputedStyle(document.documentElement));
+    const config: ChartConfiguration<'bar'> = {
       type: 'bar',
       data: {
         labels,
         datasets: [
           {
-            label: 'Tracks by Decade',
+            label: 'Tracks by decade',
             data: values,
-            backgroundColor: 'rgba(168, 85, 247, 0.6)', // Purple-500
-            borderColor: 'rgba(168, 85, 247, 1)',
+            backgroundColor: theme.colors[1],
+            borderColor: theme.colors[0],
             borderWidth: 1,
           },
         ],
       },
       options: {
         responsive: true,
-        plugins: {
-          legend: {
-            display: false,
-          },
-        },
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
         scales: {
           y: {
             beginAtZero: true,
-            grid: {
-              color: 'rgba(255, 255, 255, 0.1)',
-            },
-            ticks: {
-              color: 'rgba(255, 255, 255, 0.7)',
-            },
+            grid: { color: theme.border },
+            ticks: { color: theme.muted },
           },
-          x: {
-            grid: {
-              display: false,
-            },
-            ticks: {
-              color: 'rgba(255, 255, 255, 0.7)',
-            },
-          },
+          x: { grid: { display: false }, ticks: { color: theme.muted } },
         },
       },
     };
 
-    chart = new Chart(ctx, config);
+    chart = new Chart(context, config);
+  }
+
+  function updateChart(): void {
+    if (!chart) return;
+    const { labels, values } = getChartData();
+    chart.data.labels = labels;
+    chart.data.datasets[0].data = values;
+    chart.update();
+  }
+
+  onMount(() => {
+    createChart();
+    window.addEventListener(THEME_CHANGE_EVENT, createChart);
   });
 
   onDestroy(() => {
-    if (chart) {
-      chart.destroy();
-      chart = null;
-    }
+    window.removeEventListener(THEME_CHANGE_EVENT, createChart);
+    chart?.destroy();
+    chart = null;
   });
 
   $effect(() => {
@@ -97,6 +88,14 @@
   });
 </script>
 
-<div class="h-64 w-full flex justify-center items-center">
-  <canvas bind:this={canvas} class="w-full h-full"></canvas>
+<div class="chart-container">
+  <canvas bind:this={canvas}></canvas>
 </div>
+
+<style>
+  .chart-container {
+    width: 100%;
+    height: 16rem;
+    min-width: 0;
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/FilterPanel.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/FilterPanel.svelte
@@ -93,7 +93,7 @@
           options={orderOptions}
         />
       </div>
-      <div class="mt-4 flex flex-wrap justify-end gap-2 border-t border-white/10 pt-4">
+      <div class="mt-4 flex flex-wrap justify-end gap-2 border-t border-border pt-4">
         <Button variant="ghost" onclick={clearFilters}>Clear all</Button>
         <Button onclick={applyFilters}>Apply filters</Button>
       </div>
@@ -112,10 +112,10 @@
     border: 1px solid var(--ui-border);
     border-radius: 0.5rem;
     background: var(--ui-surface);
-    box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+    box-shadow: var(--ui-shadow);
   }
 
-  @media (max-width: 640px) {
+  @media (max-width: 40rem) {
     .spotify-filter-panel {
       position: fixed;
       top: 4.5rem;

--- a/packages/ui/src/lib/flows/spotify/components/GenreBadges.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/GenreBadges.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
-  interface Props {
-    genres: string[];
-    maxDisplay?: number;
-  }
+  import { Badge } from '@lib/components';
 
-  let { genres, maxDisplay = 2 }: Props = $props();
+  let { genres, maxDisplay = 2 }: { genres: string[]; maxDisplay?: number } = $props();
 </script>
 
-{#if genres && genres.length > 0}
-  <div class="flex flex-wrap gap-1 mt-3">
+{#if genres.length > 0}
+  <div class="genre-list" aria-label="Genres">
     {#each genres.slice(0, maxDisplay) as genre (genre)}
-      <span
-        class="px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wider font-semibold
-               bg-aurora/20 text-aurora border border-aurora/30"
-      >
-        {genre}
-      </span>
+      <Badge tone="info">{genre}</Badge>
     {/each}
   </div>
 {/if}
+
+<style>
+  .genre-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.75rem;
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/GenreChart.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/GenreChart.svelte
@@ -1,81 +1,57 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import {
+    ArcElement,
+    CategoryScale,
     Chart,
+    DoughnutController,
+    Legend,
     Title,
     Tooltip,
-    Legend,
-    ArcElement,
-    DoughnutController,
-    CategoryScale,
     type ChartConfiguration,
   } from 'chart.js';
   import type { GenreCount } from '@flows/shared';
+  import { THEME_CHANGE_EVENT } from '@lib/theme';
+  import { readChartTheme } from '@lib/chart-theme';
 
   Chart.register(Title, Tooltip, Legend, ArcElement, DoughnutController, CategoryScale);
 
-  let { data } = $props<{
-    data: GenreCount[];
-  }>();
-
+  let { data }: { data: GenreCount[] } = $props();
   let canvas: HTMLCanvasElement;
-  let chart: Chart | null = null;
+  let chart: Chart<'doughnut'> | null = null;
 
-  // Cosmic Flow color palette for charts
-  const cosmicColors = [
-    'rgba(52, 211, 153, 0.85)', // Aurora (emerald)
-    'rgba(59, 130, 246, 0.85)', // Nebula (blue)
-    'rgba(139, 92, 246, 0.85)', // Cosmic purple
-    'rgba(236, 72, 153, 0.85)', // Pink accent
-    'rgba(6, 182, 212, 0.85)', // Cyan
-    'rgba(16, 185, 129, 0.85)', // Teal
-    'rgba(99, 102, 241, 0.85)', // Indigo
-    'rgba(168, 85, 247, 0.85)', // Purple
-  ];
+  function createChart(): void {
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    chart?.destroy();
 
-  function updateChart() {
-    if (!chart) return;
-
-    chart.data.labels = data.map((d: GenreCount) => d.genre);
-    chart.data.datasets[0].data = data.map((d: GenreCount) => d.count);
-    chart.update();
-  }
-
-  onMount(() => {
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
+    const theme = readChartTheme(getComputedStyle(document.documentElement));
     const config: ChartConfiguration<'doughnut'> = {
       type: 'doughnut',
       data: {
-        labels: data.map((d: GenreCount) => d.genre),
+        labels: data.map((item) => item.genre),
         datasets: [
           {
-            data: data.map((d: GenreCount) => d.count),
-            backgroundColor: cosmicColors,
-            borderColor: 'rgba(15, 23, 42, 0.8)',
+            data: data.map((item) => item.count),
+            backgroundColor: theme.colors,
+            borderColor: theme.surface,
             borderWidth: 2,
           },
         ],
       },
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         plugins: {
           legend: {
             position: 'right',
-            labels: {
-              color: 'rgba(148, 163, 184, 0.9)',
-              padding: 12,
-              font: {
-                size: 11,
-              },
-            },
+            labels: { color: theme.muted, padding: 12, font: { size: 11 } },
           },
           tooltip: {
-            backgroundColor: 'rgba(15, 23, 42, 0.95)',
-            titleColor: 'rgba(226, 232, 240, 1)',
-            bodyColor: 'rgba(148, 163, 184, 1)',
-            borderColor: 'rgba(52, 211, 153, 0.3)',
+            backgroundColor: theme.surface,
+            titleColor: theme.text,
+            bodyColor: theme.muted,
+            borderColor: theme.border,
             borderWidth: 1,
             padding: 12,
             cornerRadius: 8,
@@ -84,22 +60,40 @@
       },
     };
 
-    chart = new Chart(ctx, config);
+    chart = new Chart(context, config);
+  }
+
+  function updateChart(): void {
+    if (!chart) return;
+    chart.data.labels = data.map((item) => item.genre);
+    chart.data.datasets[0].data = data.map((item) => item.count);
+    chart.update();
+  }
+
+  onMount(() => {
+    createChart();
+    window.addEventListener(THEME_CHANGE_EVENT, createChart);
   });
 
   onDestroy(() => {
-    if (chart) {
-      chart.destroy();
-      chart = null;
-    }
+    window.removeEventListener(THEME_CHANGE_EVENT, createChart);
+    chart?.destroy();
+    chart = null;
   });
 
   $effect(() => {
-    // React to data changes
     if (data) updateChart();
   });
 </script>
 
-<div class="h-64 flex justify-center items-center w-full">
-  <canvas bind:this={canvas} class="max-h-full"></canvas>
+<div class="chart-container">
+  <canvas bind:this={canvas}></canvas>
 </div>
+
+<style>
+  .chart-container {
+    width: 100%;
+    height: 16rem;
+    min-width: 0;
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/InsightsPanel.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/InsightsPanel.svelte
@@ -2,6 +2,7 @@
   import GenreChart from './GenreChart.svelte';
   import DecadeChart from './DecadeChart.svelte';
   import type { TopStats } from '@lib/types';
+  import { Panel } from '@lib/components';
 
   interface Props {
     stats: TopStats;
@@ -11,17 +12,17 @@
 </script>
 
 {#if stats.genres.length > 0}
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
     <!-- Genre Chart -->
-    <div class="glass glass-hover p-6">
-      <h3 class="text-lg font-semibold text-white/90 mb-4">Top Genres</h3>
+    <Panel element="section" ariaLabel="Top genres">
+      <h3 class="mb-4 text-lg font-semibold">Top Genres</h3>
       <GenreChart data={stats.genres.slice(0, 6)} />
-    </div>
+    </Panel>
 
     <!-- Decade/Timeline Chart -->
-    <div class="glass glass-hover p-6">
-      <h3 class="text-lg font-semibold text-white/90 mb-4">Eras</h3>
+    <Panel element="section" ariaLabel="Track eras">
+      <h3 class="mb-4 text-lg font-semibold">Eras</h3>
       <DecadeChart data={stats.decadeDistribution} />
-    </div>
+    </Panel>
   </div>
 {/if}

--- a/packages/ui/src/lib/flows/spotify/components/Pagination.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/Pagination.svelte
@@ -22,11 +22,11 @@
       disabled={currentPage === 1}
       variant="secondary"
     >
-      ← Previous
+      Previous
     </Button>
 
-    <div class="flex items-center gap-1 px-4 text-white/50">
-      <span class="font-semibold text-white">{currentPage}</span>
+    <div class="flex items-center gap-1 px-4 text-muted">
+      <span class="font-semibold text-foreground">{currentPage}</span>
       <span>/</span>
       <span>{totalPages}</span>
     </div>
@@ -36,7 +36,7 @@
       disabled={currentPage === totalPages}
       variant="secondary"
     >
-      Next →
+      Next
     </Button>
   </div>
 {/if}

--- a/packages/ui/src/lib/flows/spotify/components/PopularitySlider.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/PopularitySlider.svelte
@@ -11,7 +11,30 @@
   let { id, label, value = $bindable(), min = 0, max = 100, step = 10 }: Props = $props();
 </script>
 
-<div class="flex flex-col gap-1">
-  <label for={id} class="text-xs text-pulsar uppercase tracking-wide">{label}: {value}</label>
-  <input {id} type="range" {min} {max} {step} bind:value class="w-full accent-aurora" />
+<div class="popularity-slider">
+  <label for={id}>{label}: {value}</label>
+  <input {id} type="range" {min} {max} {step} bind:value />
 </div>
+
+<style>
+  .popularity-slider {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  label {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+  }
+
+  input {
+    width: 100%;
+    accent-color: var(--ui-accent);
+  }
+
+  input:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 2px;
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/SpotifyHeader.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/SpotifyHeader.svelte
@@ -1,36 +1,113 @@
 <script lang="ts">
   import type { TopStats } from '@lib/types';
 
-  interface Props {
-    stats: TopStats;
-  }
-
-  let { stats }: Props = $props();
+  let { stats }: { stats: TopStats } = $props();
 </script>
 
-<header class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-2">
-  <div>
-    <a
-      href="/"
-      class="text-white/50 hover:text-white text-sm flex items-center gap-1 mb-2 transition-colors group"
-    >
-      <span class="group-hover:-translate-x-1 transition-transform">←</span> Back to Flows
-    </a>
-    <h1 class="text-4xl md:text-5xl font-bold text-aurora">Spotify Flow</h1>
-    <p class="text-white/40 text-sm mt-1">Your music library, visualized</p>
+<header class="spotify-header">
+  <div class="spotify-header__title">
+    <a href="/">Back to flows</a>
+    <h1>Spotify Flow</h1>
+    <p>Your music library, visualized</p>
   </div>
 
-  <!-- Stats Panel (Compact) -->
-  <div class="flex gap-6 md:gap-10">
-    <div class="text-right">
-      <div class="text-3xl font-bold text-aurora">{stats.total}</div>
-      <div class="text-xs text-white/40 uppercase tracking-widest">Tracks</div>
+  <dl class="spotify-header__stats" aria-label="Spotify library summary">
+    <div>
+      <dt>Tracks</dt>
+      <dd class="spotify-header__accent">{stats.total}</dd>
     </div>
-    <div class="text-right">
-      <div class="text-xl font-semibold text-white truncate max-w-[150px]">
-        {stats.topGenre}
-      </div>
-      <div class="text-xs text-white/40 uppercase tracking-widest">Top Genre</div>
+    <div>
+      <dt>Top genre</dt>
+      <dd title={stats.topGenre}>{stats.topGenre}</dd>
     </div>
-  </div>
+  </dl>
 </header>
+
+<style>
+  .spotify-header {
+    display: flex;
+    min-width: 0;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .spotify-header__title a {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+    text-decoration: none;
+  }
+
+  .spotify-header__title a:hover {
+    color: var(--ui-text);
+  }
+
+  .spotify-header__title a:focus-visible {
+    outline: 2px solid var(--ui-focus);
+    outline-offset: 3px;
+  }
+
+  h1 {
+    margin: 0.5rem 0 0;
+    color: var(--ui-text);
+    font-size: 2.25rem;
+    line-height: 1.1;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 0.375rem 0 0;
+    color: var(--ui-text-muted);
+    font-size: 0.875rem;
+  }
+
+  .spotify-header__stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(7rem, 1fr));
+    gap: 1.5rem;
+    margin: 0;
+  }
+
+  .spotify-header__stats div {
+    display: grid;
+    min-width: 0;
+    gap: 0.25rem;
+    text-align: right;
+  }
+
+  dt {
+    color: var(--ui-text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 0;
+    overflow: hidden;
+    font-size: 1.125rem;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .spotify-header__accent {
+    color: var(--ui-accent);
+    font-size: 1.75rem;
+  }
+
+  @media (max-width: 40rem) {
+    .spotify-header {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    h1 {
+      font-size: 1.75rem;
+    }
+
+    .spotify-header__stats div {
+      text-align: left;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/flows/spotify/components/SpotifyHeader.svelte.test.ts
+++ b/packages/ui/src/lib/flows/spotify/components/SpotifyHeader.svelte.test.ts
@@ -29,7 +29,7 @@ describe('SpotifyHeader', () => {
     expect(screen.getByText('142')).toBeInTheDocument();
     expect(screen.getByText('indie rock')).toBeInTheDocument();
     expect(screen.getByText('Tracks')).toBeInTheDocument();
-    expect(screen.getByText('Top Genre')).toBeInTheDocument();
+    expect(screen.getByText(/top genre/i)).toBeInTheDocument();
   });
 
   it('renders the placeholder top genre when none is set', () => {

--- a/packages/ui/src/lib/flows/spotify/components/TrackCard.svelte
+++ b/packages/ui/src/lib/flows/spotify/components/TrackCard.svelte
@@ -1,101 +1,157 @@
 <script lang="ts">
   import type { Track } from '@flows/shared';
+  import { Button, Panel } from '@lib/components';
+  import LyricsModal from '@lib/flows/lyrics/components/LyricsModal.svelte';
   import AlbumArt from './AlbumArt.svelte';
   import GenreBadges from './GenreBadges.svelte';
-  import LyricsModal from '@lib/flows/lyrics/components/LyricsModal.svelte';
-  import { Button } from '@lib/components';
 
-  interface Props {
-    track: Track;
-  }
-
-  let { track }: Props = $props();
-
-  // Get the first artist for the avatar
+  let { track }: { track: Track } = $props();
   let mainArtist = $derived(track.artists[0]);
-
-  // Lyrics modal state
   let showLyrics = $state(false);
 </script>
 
-<article
-  class="glass rounded-xl overflow-hidden transition-all duration-300 hover:bg-white/10 hover:scale-[1.02] flex flex-col group h-full hover:shadow-lg hover:shadow-aurora/10"
->
-  <!-- Album Art -->
-  {#if track.album.imageUrl}
-    <AlbumArt
-      imageUrl={track.album.imageUrl}
-      albumName={track.album.name}
-      durationMs={track.durationMs}
-      spotifyUrl={track.spotifyUrl}
-    />
-  {/if}
+<div class="track-card">
+  <Panel element="article" padding="none" class="spotify-track-card">
+    {#if track.album.imageUrl}
+      <AlbumArt
+        imageUrl={track.album.imageUrl}
+        albumName={track.album.name}
+        durationMs={track.durationMs}
+        spotifyUrl={track.spotifyUrl}
+      />
+    {/if}
 
-  <div class="p-4 flex flex-col flex-grow">
-    <!-- Artist with Avatar -->
-    <div class="flex items-center gap-2 mb-2">
-      {#if mainArtist?.imageUrl}
-        <img
-          src={mainArtist.imageUrl}
-          alt={mainArtist.name}
-          class="w-6 h-6 rounded-full object-cover ring-1 ring-aurora/30"
-          loading="lazy"
-        />
-      {:else}
-        <div
-          class="w-6 h-6 rounded-full bg-gradient-to-br from-aurora to-nebula flex items-center justify-center text-[10px] font-bold text-void"
-        >
-          {mainArtist?.name?.[0] || '?'}
-        </div>
-      {/if}
-      <p class="text-pulsar text-sm line-clamp-1 flex-grow">
-        {track.artists.map((a) => a.name).join(', ')}
+    <div class="track-card__body">
+      <div class="track-card__artist">
+        {#if mainArtist?.imageUrl}
+          <img src={mainArtist.imageUrl} alt={mainArtist.name} loading="lazy" />
+        {:else}
+          <span class="track-card__avatar" aria-hidden="true">{mainArtist?.name?.[0] || '?'}</span>
+        {/if}
+        <p>{track.artists.map((artist) => artist.name).join(', ')}</p>
+      </div>
+
+      <h3 title={track.title}>{track.title}</h3>
+      <p class="track-card__album">
+        {track.album.name}
+        {#if track.album.releaseYear}<span> / {track.album.releaseYear}</span>{/if}
       </p>
+
+      <GenreBadges genres={mainArtist?.genres || []} />
+
+      <div class="track-card__footer">
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={(event) => {
+            event.stopPropagation();
+            showLyrics = true;
+          }}
+        >
+          Lyrics
+        </Button>
+        {#if track.addedAt}<time datetime={track.addedAt}
+            >{new Date(track.addedAt).toLocaleDateString()}</time
+          >{/if}
+      </div>
     </div>
+  </Panel>
+</div>
 
-    <!-- Title -->
-    <h3
-      class="font-bold text-base text-cosmic group-hover:text-aurora transition-colors line-clamp-1"
-      title={track.title}
-    >
-      {track.title}
-    </h3>
-
-    <!-- Album + Year -->
-    <p class="text-white/50 text-xs mt-1 line-clamp-1">
-      {track.album.name}
-      {#if track.album.releaseYear}
-        <span>• {track.album.releaseYear}</span>
-      {/if}
-    </p>
-
-    <!-- Genres Badges -->
-    <GenreBadges genres={mainArtist?.genres || []} />
-
-    <!-- Footer Stats -->
-    <div class="flex justify-between items-center mt-auto pt-3">
-      <!-- Lyrics Button -->
-      <Button
-        variant="ghost"
-        size="sm"
-        onclick={(e) => {
-          e.stopPropagation();
-          showLyrics = true;
-        }}
-        title="View lyrics"
-      >
-        Lyrics
-      </Button>
-
-      <!-- Added date -->
-      <span class="text-[10px] text-pulsar/80 ml-2">
-        {track.addedAt ? new Date(track.addedAt).toLocaleDateString() : ''}
-      </span>
-    </div>
-  </div>
-</article>
-
-<!-- Lyrics Modal -->
 {#if showLyrics}
   <LyricsModal {track} onclose={() => (showLyrics = false)} />
 {/if}
+
+<style>
+  .track-card {
+    height: 100%;
+    min-width: 0;
+  }
+
+  .track-card :global(.spotify-track-card) {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    overflow: hidden;
+    transition:
+      border-color 150ms ease,
+      background-color 150ms ease;
+  }
+
+  .track-card :global(.spotify-track-card:hover) {
+    border-color: var(--ui-accent);
+    background: var(--ui-surface-subtle);
+  }
+
+  .track-card__body {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    padding: 1rem;
+  }
+
+  .track-card__artist {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .track-card__artist img,
+  .track-card__avatar {
+    width: 1.5rem;
+    height: 1.5rem;
+    flex: 0 0 auto;
+    border: 1px solid var(--ui-border);
+    border-radius: 50%;
+  }
+
+  .track-card__artist img {
+    object-fit: cover;
+  }
+
+  .track-card__avatar {
+    display: grid;
+    place-items: center;
+    background: var(--ui-accent-strong);
+    color: var(--ui-accent-contrast);
+    font-size: 0.625rem;
+    font-weight: 700;
+  }
+
+  .track-card__artist p,
+  .track-card__album {
+    margin: 0;
+    overflow: hidden;
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  h3 {
+    margin: 0;
+    overflow: hidden;
+    color: var(--ui-text);
+    font-size: 1rem;
+    letter-spacing: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .track-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: auto;
+    padding-top: 0.75rem;
+  }
+
+  time {
+    color: var(--ui-text-muted);
+    font-size: 0.625rem;
+  }
+</style>

--- a/packages/ui/src/lib/flows/trading/TradingFlow.svelte
+++ b/packages/ui/src/lib/flows/trading/TradingFlow.svelte
@@ -437,7 +437,7 @@
   }
 
   .positive {
-    color: #4ade80;
+    color: var(--ui-success);
   }
 
   .negative {
@@ -474,7 +474,7 @@
   }
 
   .positive-block {
-    border-left-color: #4ade80;
+    border-left-color: var(--ui-success);
   }
 
   .negative-block {
@@ -482,7 +482,7 @@
   }
 
   .warning-block {
-    border-left-color: #facc15;
+    border-left-color: var(--ui-warning);
   }
 
   .info-block {
@@ -521,8 +521,8 @@
     overflow: auto;
     border: 1px solid var(--ui-border);
     border-radius: 0.5rem;
-    background: #020617;
-    color: #86efac;
+    background: var(--ui-background);
+    color: var(--ui-success);
     font-size: 0.7rem;
   }
 

--- a/packages/ui/src/lib/flows/trading/components/CandleChart.svelte
+++ b/packages/ui/src/lib/flows/trading/components/CandleChart.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import type { IChartApi, ISeriesApi, Time, CandlestickData, LineData } from 'lightweight-charts';
+  import { readChartTheme } from '@lib/chart-theme';
+  import { THEME_CHANGE_EVENT } from '@lib/theme';
   import type { Candle } from '../trading';
 
   interface Props {
@@ -18,6 +20,33 @@
   let supportLine: ISeriesApi<'Line'> | null = null;
   let resistanceLine: ISeriesApi<'Line'> | null = null;
   let lineSeriesDefinition: typeof import('lightweight-charts').LineSeries | null = null;
+
+  function getTheme() {
+    return readChartTheme(getComputedStyle(document.documentElement));
+  }
+
+  function applyChartTheme(): void {
+    const theme = getTheme();
+    chart?.applyOptions({
+      layout: { background: { color: 'transparent' }, textColor: theme.muted },
+      grid: {
+        vertLines: { color: theme.border },
+        horzLines: { color: theme.border },
+      },
+      rightPriceScale: { borderColor: theme.border },
+      timeScale: { borderColor: theme.border },
+    });
+    candlestickSeries?.applyOptions({
+      upColor: theme.success,
+      downColor: theme.danger,
+      borderUpColor: theme.success,
+      borderDownColor: theme.danger,
+      wickUpColor: theme.success,
+      wickDownColor: theme.danger,
+    });
+    supportLine?.applyOptions({ color: theme.success });
+    resistanceLine?.applyOptions({ color: theme.danger });
+  }
 
   // Transform candles to lightweight-charts format (time in seconds)
   function transformCandles(data: Candle[]): CandlestickData<Time>[] {
@@ -45,7 +74,7 @@
     if (supportLevel && candles.length > 0) {
       if (!supportLine) {
         supportLine = chart.addSeries(lineSeriesDefinition, {
-          color: '#22c55e',
+          color: getTheme().success,
           lineWidth: 2,
           lineStyle: 2, // Dashed
         });
@@ -63,7 +92,7 @@
     if (resistanceLevel && candles.length > 0) {
       if (!resistanceLine) {
         resistanceLine = chart.addSeries(lineSeriesDefinition, {
-          color: '#ef4444',
+          color: getTheme().danger,
           lineWidth: 2,
           lineStyle: 2, // Dashed
         });
@@ -80,12 +109,15 @@
 
     let disposed = false;
     let resizeObserver: ResizeObserver | null = null;
+    const handleThemeChange = () => applyChartTheme();
+    window.addEventListener(THEME_CHANGE_EVENT, handleThemeChange);
 
     async function initChart() {
       const { createChart, CandlestickSeries, LineSeries } = await import('lightweight-charts');
       if (disposed || !chartContainer) return;
 
       lineSeriesDefinition = LineSeries;
+      const theme = getTheme();
 
       // Create chart with v5 API
       chart = createChart(chartContainer, {
@@ -93,17 +125,17 @@
         height: height,
         layout: {
           background: { color: 'transparent' },
-          textColor: 'rgba(255, 255, 255, 0.7)',
+          textColor: theme.muted,
         },
         grid: {
-          vertLines: { color: 'rgba(255, 255, 255, 0.05)' },
-          horzLines: { color: 'rgba(255, 255, 255, 0.05)' },
+          vertLines: { color: theme.border },
+          horzLines: { color: theme.border },
         },
         rightPriceScale: {
-          borderColor: 'rgba(255, 255, 255, 0.1)',
+          borderColor: theme.border,
         },
         timeScale: {
-          borderColor: 'rgba(255, 255, 255, 0.1)',
+          borderColor: theme.border,
           timeVisible: true,
           secondsVisible: false,
         },
@@ -122,12 +154,12 @@
 
       // Add candlestick series using v5 API
       candlestickSeries = chart.addSeries(CandlestickSeries, {
-        upColor: '#22c55e',
-        downColor: '#ef4444',
-        borderUpColor: '#22c55e',
-        borderDownColor: '#ef4444',
-        wickUpColor: '#22c55e',
-        wickDownColor: '#ef4444',
+        upColor: theme.success,
+        downColor: theme.danger,
+        borderUpColor: theme.success,
+        borderDownColor: theme.danger,
+        wickUpColor: theme.success,
+        wickDownColor: theme.danger,
       });
 
       // Set initial data
@@ -152,6 +184,7 @@
 
     return () => {
       disposed = true;
+      window.removeEventListener(THEME_CHANGE_EVENT, handleThemeChange);
       if (resizeObserver) {
         resizeObserver.disconnect();
       }
@@ -188,11 +221,11 @@
   });
 </script>
 
-<div class="w-full rounded-xl overflow-hidden bg-black/20 border border-white/10">
+<div class="w-full overflow-hidden rounded-lg border border-border bg-surface-subtle">
   {#if candles.length > 0}
     <div bind:this={chartContainer} style="height: {height}px;"></div>
   {:else}
-    <div class="flex items-center justify-center text-white/30" style="height: {height}px;">
+    <div class="flex items-center justify-center text-muted" style="height: {height}px;">
       No candle data available
     </div>
   {/if}

--- a/packages/ui/src/lib/flows/trading/components/StepWizard.svelte
+++ b/packages/ui/src/lib/flows/trading/components/StepWizard.svelte
@@ -169,14 +169,14 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <!-- Metrics -->
     <Panel padding="md">
-      <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider mb-3">
+      <h4 class="mb-3 text-sm font-semibold uppercase text-muted">
         📊 Metrics ({activeStep.label})
       </h4>
       {#if metrics}
         <div class="grid grid-cols-2 gap-3 text-sm">
           <!-- Fetched data -->
           <div
-            class="col-span-2 flex items-center gap-2 text-xs text-white/30 border-b border-white/10 pb-2 mb-1"
+            class="col-span-2 mb-1 flex items-center gap-2 border-b border-border pb-2 text-xs text-muted"
           >
             <span class="px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 font-semibold"
               >📡 Fetched</span
@@ -184,46 +184,47 @@
             <span>{metrics.dateFrom} → {metrics.dateTo}</span>
           </div>
           <div>
-            <span class="text-white/50">Velas:</span>
-            <span class="font-bold text-white">{metrics.candleCount}</span>
+            <span class="text-muted">Velas:</span>
+            <span class="font-bold text-foreground">{metrics.candleCount}</span>
           </div>
           <div>
-            <span class="text-white/50">Intervalo:</span>
+            <span class="text-muted">Intervalo:</span>
             <span class="font-bold text-cyan-400">{activeStep.interval}</span>
           </div>
           <div>
-            <span class="text-white/50">Último:</span>
+            <span class="text-muted">Último:</span>
             <span class="font-bold text-amber-400">
               ${metrics.last.toLocaleString()}
             </span>
           </div>
           <div>
-            <span class="text-white/50">Volumen Total:</span>
-            <span class="font-bold text-white">{formatCompactVolume(metrics.totalVolume)}</span>
+            <span class="text-muted">Volumen Total:</span>
+            <span class="font-bold text-foreground">{formatCompactVolume(metrics.totalVolume)}</span
+            >
           </div>
 
           <!-- Calculated data -->
           <div
-            class="col-span-2 flex items-center gap-2 text-xs text-white/30 border-b border-white/10 pb-2 mb-1 mt-2"
+            class="col-span-2 mb-1 mt-2 flex items-center gap-2 border-b border-border pb-2 text-xs text-muted"
           >
             <span class="px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 font-semibold"
               >🔢 Calculated</span
             >
           </div>
           <div>
-            <span class="text-white/50">High:</span>
+            <span class="text-muted">High:</span>
             <span class="font-bold text-green-400">
               ${metrics.high.toLocaleString()}
             </span>
           </div>
           <div>
-            <span class="text-white/50">Low:</span>
+            <span class="text-muted">Low:</span>
             <span class="font-bold text-red-400">
               ${metrics.low.toLocaleString()}
             </span>
           </div>
           <div>
-            <span class="text-white/50">Variación:</span>
+            <span class="text-muted">Variación:</span>
             <span
               class="font-bold {metrics.priceChangePercent >= 0
                 ? 'text-green-400'
@@ -233,7 +234,7 @@
             </span>
           </div>
           <div>
-            <span class="text-white/50">Volatilidad:</span>
+            <span class="text-muted">Volatilidad:</span>
             <span class="font-bold text-orange-400">{metrics.volatilityPercent.toFixed(2)}%</span>
           </div>
         </div>
@@ -247,7 +248,7 @@
       {@const analysis = stepAnalysis[activeStep.label]}
       <Panel padding="md">
         <div class="flex items-center gap-2 mb-3">
-          <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider">
+          <h4 class="text-sm font-semibold uppercase text-muted">
             🖥️ Análisis Técnico ({activeStep.label})
           </h4>
           <Badge tone="success">Backend</Badge>
@@ -255,52 +256,56 @@
         <div class="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
           {#if analysis.regime_analysis}
             <div>
-              <span class="text-white/50">Régimen:</span>
+              <span class="text-muted">Régimen:</span>
               <span
                 class="font-bold {analysis.regime_analysis.classification === 'TRENDING'
                   ? 'text-cyan-400'
                   : analysis.regime_analysis.classification === 'RANGING'
                     ? 'text-yellow-400'
-                    : 'text-white/60'}"
+                    : 'text-muted'}"
               >
                 {analysis.regime_analysis.classification}
               </span>
             </div>
             <div>
-              <span class="text-white/50">Hurst:</span>
-              <span class="font-bold text-white">{analysis.regime_analysis.hurst_exponent}</span>
+              <span class="text-muted">Hurst:</span>
+              <span class="font-bold text-foreground"
+                >{analysis.regime_analysis.hurst_exponent}</span
+              >
             </div>
             <div>
-              <span class="text-white/50">Dim. Fractal:</span>
-              <span class="font-bold text-white">{analysis.regime_analysis.fractal_dimension}</span>
+              <span class="text-muted">Dim. Fractal:</span>
+              <span class="font-bold text-foreground"
+                >{analysis.regime_analysis.fractal_dimension}</span
+              >
             </div>
           {/if}
           {#if analysis.fractal_structure}
             <div>
-              <span class="text-white/50">Resistencia:</span>
+              <span class="text-muted">Resistencia:</span>
               <span class="font-bold text-red-400">
                 {typeof analysis.fractal_structure.nearest_resistance === 'number'
                   ? '$' + analysis.fractal_structure.nearest_resistance.toLocaleString()
                   : analysis.fractal_structure.nearest_resistance}
               </span>
-              <span class="text-[10px] text-white/30"
+              <span class="text-[10px] text-muted"
                 >({analysis.fractal_structure.distance_to_resistance})</span
               >
             </div>
             <div>
-              <span class="text-white/50">Soporte:</span>
+              <span class="text-muted">Soporte:</span>
               <span class="font-bold text-green-400">
                 {typeof analysis.fractal_structure.nearest_support === 'number'
                   ? '$' + analysis.fractal_structure.nearest_support.toLocaleString()
                   : analysis.fractal_structure.nearest_support}
               </span>
-              <span class="text-[10px] text-white/30"
+              <span class="text-[10px] text-muted"
                 >({analysis.fractal_structure.distance_to_support})</span
               >
             </div>
             <div>
-              <span class="text-white/50">Toques S/R:</span>
-              <span class="font-bold text-white">
+              <span class="text-muted">Toques S/R:</span>
+              <span class="font-bold text-foreground">
                 S:{analysis.fractal_structure.support_touch_count} / R:{analysis.fractal_structure
                   .resistance_touch_count}
               </span>
@@ -309,13 +314,13 @@
           {#if analysis.indicators}
             {#if analysis.indicators.rsi && analysis.indicators.rsi !== 'N/A'}
               <div>
-                <span class="text-white/50">RSI:</span>
+                <span class="text-muted">RSI:</span>
                 <span
                   class="font-bold {parseFloat(analysis.indicators.rsi) > 70
                     ? 'text-red-400'
                     : parseFloat(analysis.indicators.rsi) < 30
                       ? 'text-green-400'
-                      : 'text-white'}"
+                      : 'text-foreground'}"
                 >
                   {analysis.indicators.rsi}
                 </span>
@@ -323,7 +328,7 @@
             {/if}
             {#if analysis.indicators.macd}
               <div>
-                <span class="text-white/50">MACD:</span>
+                <span class="text-muted">MACD:</span>
                 <span
                   class="font-bold {parseFloat(analysis.indicators.macd.histogram) > 0
                     ? 'text-green-400'
@@ -333,7 +338,7 @@
                 </span>
               </div>
               <div>
-                <span class="text-white/50">MACD Bias:</span>
+                <span class="text-muted">MACD Bias:</span>
                 <span
                   class="font-bold {analysis.indicators.macd.bias === 'Bullish'
                     ? 'text-green-400'
@@ -346,7 +351,7 @@
           {/if}
           {#if analysis.candle_patterns}
             <div class="col-span-2 md:col-span-3">
-              <span class="text-white/50">Patrones:</span>
+              <span class="text-muted">Patrones:</span>
               <span class="font-bold text-amber-400">
                 {Array.isArray(analysis.candle_patterns)
                   ? analysis.candle_patterns.join(', ')
@@ -361,7 +366,7 @@
     <!-- Insight for this step -->
     <Panel padding="md">
       <div class="flex items-center justify-between mb-3">
-        <h4 class="text-sm font-semibold text-white/40 uppercase tracking-wider">
+        <h4 class="text-sm font-semibold uppercase text-muted">
           🧠 {activeStep.label} Insight
         </h4>
         <Button
@@ -378,7 +383,7 @@
       {#if currentInsight}
         <div class="space-y-2">
           <p class="text-sm font-semibold text-amber-400">{currentInsight.title}</p>
-          <p class="text-sm text-white/80">{currentInsight.mentor_tip}</p>
+          <p class="text-sm text-foreground">{currentInsight.mentor_tip}</p>
           {#if currentInsight.sentiment_bias}
             <Badge tone={getSentimentTone(currentInsight.sentiment_bias)}>
               {getSentimentLabel(currentInsight.sentiment_bias)}
@@ -386,7 +391,7 @@
           {/if}
         </div>
       {:else}
-        <p class="text-white/30 text-sm">
+        <p class="text-sm text-muted">
           Click "Generate" to get AI insight for {activeStep.label} timeframe
         </p>
       {/if}
@@ -397,7 +402,7 @@
   <div class="step-actions">
     <Button variant="secondary" onclick={goPrev} disabled={!canGoPrev}>Previous</Button>
 
-    <span class="text-white/40 text-sm">
+    <span class="text-sm text-muted">
       Step {currentStep + 1} of {TRADING_WIZARD_STEPS.length}
     </span>
 
@@ -428,7 +433,7 @@
     width: 0.5rem;
     height: 0.5rem;
     border-radius: 50%;
-    background: #4ade80;
+    background: var(--ui-success);
   }
 
   .step-heading {

--- a/packages/ui/src/lib/pages/Landing.svelte
+++ b/packages/ui/src/lib/pages/Landing.svelte
@@ -91,7 +91,7 @@
 
   .flow-index__header h1 {
     margin: 0;
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-size: 2rem;
   }
 
   .flow-index__summary {
@@ -112,19 +112,23 @@
     gap: 1rem;
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 56.25rem) {
     .flow-index__grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
-  @media (max-width: 640px) {
+  @media (max-width: 40rem) {
     .flow-index {
       gap: 1rem;
     }
 
     .flow-index__header {
       align-items: flex-start;
+    }
+
+    .flow-index__header h1 {
+      font-size: 1.75rem;
     }
 
     .flow-index__grid {

--- a/packages/ui/src/lib/theme.test.ts
+++ b/packages/ui/src/lib/theme.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppTheme, applyTheme, isAppTheme, readStoredTheme, THEME_STORAGE_KEY } from './theme';
+
+describe('theme contract', () => {
+  it('recognizes only supported themes', () => {
+    expect(isAppTheme(AppTheme.GALAXY)).toBe(true);
+    expect(isAppTheme(AppTheme.FIRE)).toBe(true);
+    expect(isAppTheme(AppTheme.ORGANIC)).toBe(true);
+    expect(isAppTheme('cosmic')).toBe(false);
+    expect(isAppTheme(null)).toBe(false);
+  });
+
+  it('falls back to galaxy when persisted data is missing or invalid', () => {
+    const getItem = vi.fn().mockReturnValueOnce(null).mockReturnValueOnce('legacy');
+    expect(readStoredTheme({ getItem })).toBe(AppTheme.GALAXY);
+    expect(readStoredTheme({ getItem })).toBe(AppTheme.GALAXY);
+    expect(getItem).toHaveBeenCalledWith(THEME_STORAGE_KEY);
+  });
+
+  it('reads and applies a supported persisted theme', () => {
+    const target = document.createElement('div');
+    const theme = readStoredTheme({ getItem: () => AppTheme.ORGANIC });
+    applyTheme(target, theme);
+    expect(target).toHaveAttribute('data-theme', AppTheme.ORGANIC);
+  });
+});

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -1,0 +1,29 @@
+export const AppTheme = {
+  GALAXY: 'galaxy',
+  FIRE: 'fire',
+  ORGANIC: 'organic',
+} as const;
+
+export type AppTheme = (typeof AppTheme)[keyof typeof AppTheme];
+
+export const THEME_STORAGE_KEY = 'flow-sample:theme';
+export const THEME_CHANGE_EVENT = 'flow-sample:theme-change';
+
+export const themeOptions = [
+  { value: AppTheme.GALAXY, label: 'Galaxy', color: '#22d3ee' },
+  { value: AppTheme.FIRE, label: 'Fire', color: '#fb7185' },
+  { value: AppTheme.ORGANIC, label: 'Organic', color: '#a3e635' },
+] as const;
+
+export function isAppTheme(value: string | null): value is AppTheme {
+  return Object.values(AppTheme).some((theme) => theme === value);
+}
+
+export function readStoredTheme(storage: Pick<Storage, 'getItem'>): AppTheme {
+  const storedTheme = storage.getItem(THEME_STORAGE_KEY);
+  return isAppTheme(storedTheme) ? storedTheme : AppTheme.GALAXY;
+}
+
+export function applyTheme(target: HTMLElement, theme: AppTheme): void {
+  target.dataset.theme = theme;
+}

--- a/scripts/check-architecture-contracts.mjs
+++ b/scripts/check-architecture-contracts.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGES = path.join(ROOT, 'packages');
-const SOURCE_EXTENSIONS = new Set(['.ts', '.svelte']);
+const SOURCE_EXTENSIONS = new Set(['.css', '.ts', '.svelte']);
 const IGNORED_PARTS = new Set([
   '.svelte-kit',
   'dist',
@@ -48,6 +48,10 @@ export function checkSource(file, source) {
   const sqlCall = /\.(?:prepare|exec)\s*\(/g;
   const flowImport = /from\s+['"]@flows\/(spotify|lyrics|trading|chat|canvas)(?:\/[^'"]*)?['"]/g;
   const processEnv = /process\.env/g;
+  const legacyUiUtility = /\b(?:glass|(?:text|bg|border|shadow)-(?:cosmic|aurora|pulsar|nebula|stardust|void)(?:-[\w/]+)?)\b/g;
+  const legacyUiVariable = /var\(--(?:surface|primary|secondary)-\d+\)/g;
+  const uiGradient = /(?:linear|radial|conic)-gradient\s*\(/g;
+  const accessibilitySuppression = /svelte-ignore\s+a11y_/g;
 
   for (const match of source.matchAll(explicitAny)) {
     violations.push(violation(file, source, match, 'no-explicit-any', 'Replace `any` with a concrete type or safe narrowing.'));
@@ -80,6 +84,21 @@ export function checkSource(file, source) {
   if (!isEnvOwner) {
     for (const match of source.matchAll(processEnv)) {
       violations.push(violation(file, source, match, 'env-in-config-only', 'Read environment variables in an explicitly named config/env factory and inject the result.'));
+    }
+  }
+
+  if (file.startsWith('packages/ui/src/')) {
+    for (const match of source.matchAll(legacyUiUtility)) {
+      violations.push(violation(file, source, match, 'no-legacy-ui-styles', 'Use shared primitives and semantic `--ui-*` tokens.'));
+    }
+    for (const match of source.matchAll(legacyUiVariable)) {
+      violations.push(violation(file, source, match, 'no-legacy-ui-styles', 'Replace retired palette variables with semantic `--ui-*` tokens.'));
+    }
+    for (const match of source.matchAll(uiGradient)) {
+      violations.push(violation(file, source, match, 'no-ui-gradients', 'Use a solid semantic surface or accent token.'));
+    }
+    for (const match of source.matchAll(accessibilitySuppression)) {
+      violations.push(violation(file, source, match, 'no-a11y-suppression', 'Fix the control semantics instead of suppressing the Svelte accessibility warning.'));
     }
   }
 

--- a/scripts/check-architecture-contracts.test.mjs
+++ b/scripts/check-architecture-contracts.test.mjs
@@ -51,3 +51,31 @@ test('allows environment reads in explicitly named config modules', () => {
   );
   assert.deepEqual(violations, []);
 });
+
+test('rejects legacy UI utilities and retired palette variables', () => {
+  const violations = checkSource(
+    'packages/ui/src/lib/example.svelte',
+    '<div class="glass text-cosmic-400" style="color: var(--surface-100)"></div>',
+  );
+  assert.deepEqual(violations.map(({ rule }) => rule), [
+    'no-legacy-ui-styles',
+    'no-legacy-ui-styles',
+    'no-legacy-ui-styles',
+  ]);
+});
+
+test('rejects gradients in production UI styles', () => {
+  const violations = checkSource(
+    'packages/ui/src/app.css',
+    '.hero { background: linear-gradient(red, blue); }',
+  );
+  assert.equal(violations[0]?.rule, 'no-ui-gradients');
+});
+
+test('rejects Svelte accessibility suppressions', () => {
+  const violations = checkSource(
+    'packages/ui/src/lib/example.svelte',
+    '<!-- svelte-ignore a11y_no_static_element_interactions -->',
+  );
+  assert.equal(violations[0]?.rule, 'no-a11y-suppression');
+});


### PR DESCRIPTION
## Why

Complete the remaining scope of #24 with one application-level design system instead of flow-local visual themes.

## What changed

- adds persisted galaxy, fire, and organic palettes through semantic Tailwind v4 tokens and a global navbar selector
- migrates the landing page and Spotify, Lyrics, Trading, Chat, and Canvas to shared primitives, accessible controls, responsive workspaces, and semantic chart colors
- adds architecture contracts for retired styles, gradients, and accessibility suppressions plus desktop/mobile Playwright coverage for every route
- updates the roadmap, architecture, testing, workflow, and design-system documentation to match the implemented contract
- excludes generated Playwright and build artifacts from Prettier checks so formatting remains reproducible

## Validation

- `pnpm format:check`
- `pnpm verify`
- `pnpm build`
- `pnpm --filter @flows/ui test:e2e` (11 passed)
- browser audit of all routes and all three themes on desktop and mobile

Closes #24