### PR TITLE
feat(ui): add board card contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ independently testable bounded module hosted by one Elysia API and one SvelteKit
 
 The home experience is an accessible board where flows can be reordered, collapsed, and
 resized with a versioned local layout while their dedicated routes remain available.
+Every registered flow publishes a typed card contract for its live summary, optional
+expanded metrics, and loading/empty/error/stale states; the board renders that contract
+without importing flow internals.
 
 The UI shares one semantic design system across all routes, with persistent galaxy,
 fire, and organic themes and responsive desktop/mobile workspaces.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,9 @@ follow-up polish.
   flow, including browser-rendered charts and responsive workspaces.
 - Board v1 renders the flow registry as reorderable, collapsible, resizable items with
   versioned local persistence, keyboard controls, drag-and-drop, and a reset command.
+- Registered flows publish typed board summaries and optional expanded content. Spotify
+  and Lyrics provide richer live contracts; the remaining flows use the generic stats
+  adapter. Loading, empty, error, and stale data share one renderer.
 - Architecture contracts reject retired UI styles, gradients, and accessibility
   suppressions.
 - CI builds the monorepo and runs lint, type checks, Svelte checks, and coverage.
@@ -35,14 +38,11 @@ longer import each other's internals.
 
 ## Execution Queue
 
-1. **Board card contracts
-   ([#43](https://github.com/jorgesalica/flow-sample/issues/43))**: typed summaries,
-   expansion, and async states without flow-specific renderer branches.
-2. **Named boards ([#44](https://github.com/jorgesalica/flow-sample/issues/44))**:
+1. **Named boards ([#44](https://github.com/jorgesalica/flow-sample/issues/44))**:
    repository-backed persistence, API, loader integration, and local migration.
 
-Relationships and graph edges get a separate issue only after the board and card
-contracts are proven. A DOM/CSS board is the default; an HTML canvas or graph library
+Relationships and graph edges get a separate issue only after named boards are proven.
+A DOM/CSS board is the default; an HTML canvas or graph library
 requires an interaction-driven spike first.
 
 ## Deferred Epics

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -125,6 +125,8 @@ flowchart TD
     flowUi --> sharedUi["Shared UI primitives\nlib/components/ui"]
     home --> registry["Flow registry\nlib/flows/registry.ts"]
     home --> board["FlowBoard + BoardItem\npages/components"]
+    registry --> cardContract["Board card contract\nflows/board-card.ts"]
+    cardContract --> board
     board --> layout["Versioned layout contract\npages/board-layout.ts"]
     layout --> localStorage[("localStorage")]
     board --> sharedUi
@@ -135,6 +137,8 @@ Target shape:
 - Route files stay thin: load data, pass props, render the flow surface.
 - Flow surfaces own page-level composition.
 - Components own visual fragments and ephemeral UI state.
+- Registered flows own summary/expansion production behind a generic board card contract;
+  `BoardCardContent` owns rendering and never imports flow-specific modules.
 - `*.svelte.ts` modules own reusable flow state only when there is a documented
   reason not to keep state local.
 - Server data comes from loaders and Eden, then mutations call Eden and
@@ -200,5 +204,6 @@ Target shape:
 
 8. **Board/Canvas vision (#18)**
    Board v1 (#42) now renders the `FlowDefinition` registry with local layout
-   persistence and accessible reorder controls. Continue with typed card contracts
-   (#43) and named server-persisted boards (#44) before cross-flow relationships.
+   persistence and accessible reorder controls. Typed card contracts (#43) now provide
+   validated summaries, expansion, and async/stale states. Continue with named
+   server-persisted boards (#44) before cross-flow relationships.

--- a/docs/architecture/ui.md
+++ b/docs/architecture/ui.md
@@ -49,19 +49,20 @@ ui/
 │       ├── toast.ts              # svelte-5-french-toast wrapper (Toaster, showError…)
 │       ├── types.ts              # local UI types (domain types come from @flows/shared)
 │       ├── pages/
-│       │   ├── Landing.svelte    # flow registry orchestration + live stats
+│       │   ├── Landing.svelte    # validated flow-manifest handoff
 │       │   ├── board-layout.ts   # versioned local layout contract + operations
-│       │   ├── types.ts          # root dashboard presentation model
 │       │   └── components/
 │       │       ├── FlowBoard.svelte # state, persistence, reset, drag/drop
-│       │       └── BoardItem.svelte # flow presentation + accessible controls
+│       │       ├── BoardItem.svelte # flow presentation + accessible controls
+│       │       └── BoardCardContent.svelte # generic async/summary/expansion renderer
 │       ├── components/
 │       │   ├── layout/           # Navbar, FlowLayout
 │       │   ├── common/           # InfiniteScroll, …
 │       │   └── canvas/           # TokenRenderer, TokenTooltip, LayerToggle
 │       └── flows/
-│           ├── registry.ts       # FlowDefinition + registerFlow/getFlows/getFlow
-│           ├── index.ts          # the board manifest (registers every flow)
+│           ├── board-card.ts     # typed card states, content, and stats adapter
+│           ├── registry.ts       # validated FlowDefinition registry factory
+│           ├── index.ts          # immutable board manifest
 │           └── <flow>/           # SpotifyFlow.svelte + components/ + api.ts + stores.ts + index.ts
 ├── vite.config.ts                # sveltekit() + tailwindcss(); /api + /outputs dev proxy
 ├── svelte.config.js              # adapter-static (SPA), @lib/@components aliases
@@ -75,17 +76,29 @@ ui/
 
 File-based. Each flow is a route under `src/routes/<flow>/+page.svelte` that renders the
 flow's page component from `lib/flows/<flow>/`. The home route renders the flow index
-(`Landing.svelte`), which resolves registry stats and delegates registered flows to
-`FlowBoard`. Available flows retain route links inside each `BoardItem`; unavailable and
-failed flows remain non-interactive. (The old `#/`-hash router was removed in the
+(`Landing.svelte`), which delegates the validated manifest to `FlowBoard`. The board
+loads each card contract independently. Available flows retain route links inside each
+`BoardItem`; unavailable and failed flows remain non-interactive. (The old `#/`-hash router was removed in the
 SvelteKit migration.)
 
 ## Flows registry
 
-`lib/flows/registry.ts` defines `FlowDefinition` (id, name, icon, description, route,
-color, `getStats()`); `lib/flows/index.ts` registers each flow. The board reads the
-registry to render cards and pull live stats. Each flow's `index.ts` exports its
-`FlowDefinition`; its `api.ts` wraps the Eden calls; `stores.ts` holds flow state.
+`lib/flows/registry.ts` defines `FlowDefinition` (id, name, icon, description, route, and
+`boardCard`) plus `createFlowRegistry()`. Registry construction rejects duplicate IDs,
+missing metadata, invalid routes, and contracts without `boardCard.load`; lookups return
+defensive manifest copies. `lib/flows/index.ts` builds the immutable application manifest.
+
+`lib/flows/board-card.ts` owns the board-only presentation boundary. A contract resolves
+to `ready`, `empty`, or `error`; `FlowBoard` adds `loading` while a request is pending and
+converts refresh failures with prior data into `stale`. Summary status and metrics remain
+visible while collapsed; optional expanded metrics and notes render only when open.
+Spotify and Lyrics own representative rich contracts. Trading, Chat, and Canvas adapt
+their existing status/count response through `createStatsBoardCard()`. `BoardCardContent`
+renders every flow from the discriminated contract and never branches on a flow ID.
+
+Board DTOs are UI presentation types because they never cross the backend boundary.
+Provider/domain DTOs continue to live in `@flows/shared`; each flow's `api.ts` wraps its
+typed Eden calls, and `stores.ts` holds reusable flow state where needed.
 
 ## Board layout
 
@@ -134,9 +147,11 @@ cosmic/glass utility layer, or gradient-based production UI.
 
 Unit/component tests run under Vitest + `@testing-library/svelte` (jsdom), beside the code
 as `*.svelte.test.ts` / `*.test.ts`. Mock the Eden client (`@lib/client`) — never hit the
-network. Pure chart-theme and board-layout mapping are unit-tested; chart canvas
-rendering, keyboard reorder, native drag-and-drop, persistence reloads, and responsive
-behavior are verified in a real browser. E2E lives in `e2e/` (Playwright).
+network. Pure chart-theme, board-layout, registry, and card-contract mapping are
+unit-tested. The generic renderer covers every async state and negative space. Chart
+canvas rendering, live summary/expansion, stale refresh, keyboard reorder, native
+drag-and-drop, persistence reloads, and responsive behavior are verified in a real
+browser. E2E lives in `e2e/` (Playwright).
 
 ## Tooling
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -121,6 +121,9 @@ from `lib/flows/<flow>/`. See [architecture/ui.md](architecture/ui.md).
 - **Browser preferences are contracts**: version and validate persisted `localStorage`
   data, reconcile it against current identifiers, and provide a safe default/reset path.
   Do not mix presentation preferences with backend or cross-boundary DTOs.
+- **Board flows publish presentation contracts**: register immutable definitions through
+  `createFlowRegistry()`, keep card DTOs generic, and render discriminated async states.
+  The board must not import flow internals or select renderers by flow ID.
 - **Data access** goes through the typed Eden client (`@lib/client`), wrapped per flow in
   `api.ts`. Preferred target: SvelteKit `+page.ts` loaders (universal load) over `onMount`.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -80,6 +80,13 @@ button with `aria-expanded`; size uses a native select; reset is an explicit tex
 Actions update a polite live region and persist only layout preferences. Board items are
 single cards with internal controls, never cards nested inside decorative cards.
 
+Each registered flow supplies a `BoardCardContract`; the board owns loading and refresh
+orchestration while `BoardCardContent` renders the discriminated state. Collapsed cards
+retain their status and summary metrics, hiding only optional expanded content. Loading,
+empty, and error use compact `AsyncState`; stale keeps the last successful content visible
+with a warning. The renderer consumes only generic status, metric, and note fields and
+must not import or branch on flow-specific modules.
+
 ## Interaction Rules
 
 - Every control has an accessible name, native keyboard behavior, and visible focus.

--- a/docs/history/ui.md
+++ b/docs/history/ui.md
@@ -2,6 +2,24 @@
 
 Changelog for the frontend (Svelte) application.
 
+## 2026-07-13 - Board card contracts
+
+Issue #43 replaced the board's implicit stats model with an explicit presentation
+contract:
+
+- Added validated immutable flow registration and rejected duplicate or incomplete
+  definitions at construction time.
+- Added generic loading, ready, empty, error, and stale card states with summaries and
+  optional expansion; collapsed cards keep their summary visible.
+- Added rich Spotify and Lyrics producers plus a compatibility adapter for Trading, Chat,
+  and Canvas, without flow-specific renderer branches.
+- Kept prior successful content visible when refresh fails and exposed recovery through
+  the board refresh action.
+- Added producer, registry, renderer, component, and Playwright coverage for success,
+  malformed/failure paths, live expansion, stale refresh, and mobile behavior.
+
+---
+
 ## 2026-07-13 - Board v1
 
 Issue #42 replaced the fixed landing grid with the first persistent flow board:

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -14,6 +14,7 @@ journeys. Do not pursue coverage by duplicating implementation details in tests.
 | Service | Vitest with ports mocked | orchestration, calls made and deliberately not made |
 | Route/application | Vitest and `app.handle()` | validation, status/error mapping, dependency wiring |
 | Loader/API facade | Vitest with Eden mocked | DTO mapping, invalidation, empty/error behavior |
+| UI contract/registry | Vitest | manifest validation, state mapping, stale preservation |
 | Svelte component | Testing Library | accessible behavior and user-observable state |
 | Critical journey | Playwright | real navigation and desktop/mobile interaction |
 | Architecture/docs | Node check scripts | repository contracts and valid local links |
@@ -48,9 +49,13 @@ SSE, browser-only charting, drag-and-drop, keyboard reordering, persistence migr
 multi-step flows deserve Playwright or explicit manual verification because jsdom cannot
 fully model their runtime behavior.
 
-Board changes pair pure layout-contract tests with component role/callback tests.
-Playwright must prove explicit keyboard reorder, native drag-and-drop, reload persistence,
-reset behavior, and a no-overflow mobile fallback when those behaviors change.
+Board changes pair pure layout and card-contract tests with registry validation and
+component role/callback tests. Flow contract producers cover success, empty/malformed
+data, and provider failure. The generic renderer covers loading, ready, empty, error,
+stale, collapsed negative space, and expanded content without flow-specific branches.
+Playwright must prove representative live summary/expansion, stale refresh preservation,
+explicit keyboard reorder, native drag-and-drop, reload persistence, reset behavior, and
+a no-overflow mobile fallback when those behaviors change.
 
 ## Commands And CI
 

--- a/packages/ui/e2e/board.spec.ts
+++ b/packages/ui/e2e/board.spec.ts
@@ -2,6 +2,14 @@ import { expect, test, type Page } from '@playwright/test';
 
 const BOARD_LAYOUT_STORAGE_KEY = 'flow-sample:board-layout';
 const defaultOrder = ['spotify', 'trading', 'lyrics-flow', 'chat-flow', 'canvas-flow'];
+const spotifyStats = {
+  totalTracks: 42,
+  totalGenres: 8,
+  topGenres: [{ genre: 'rock', count: 12 }],
+  decadeDistribution: { '2020s': 20 },
+  yearRange: { oldest: 1998, newest: 2025 },
+};
+const lyricsStats = { total: 20, found: 12, notFound: 3, pending: 5 };
 
 async function openCleanBoard(page: Page): Promise<void> {
   await page.goto('/');
@@ -17,6 +25,46 @@ async function boardOrder(page: Page): Promise<string[]> {
 }
 
 test.describe('Board v1', () => {
+  test('renders representative live summary and expansion contracts', async ({ page }) => {
+    await page.route('**/api/spotify/stats', (route) => route.fulfill({ json: spotifyStats }));
+    await page.route('**/api/lyrics/stats', (route) => route.fulfill({ json: lyricsStats }));
+    await openCleanBoard(page);
+
+    const spotifyCard = page.locator('[data-board-id="spotify"]');
+    const lyricsCard = page.locator('[data-board-id="lyrics-flow"]');
+    await expect(spotifyCard.getByRole('region', { name: 'Library snapshot' })).toBeVisible();
+    await expect(spotifyCard.getByText('Top genre')).toBeVisible();
+    await expect(spotifyCard.getByText('rock')).toBeVisible();
+    await expect(lyricsCard.getByRole('region', { name: 'Lyrics coverage' })).toBeVisible();
+    await expect(lyricsCard.getByText('Coverage', { exact: true })).toBeVisible();
+    await expect(lyricsCard.getByText('60%')).toBeVisible();
+  });
+
+  test('keeps the previous summary as stale when refresh fails', async ({ page }) => {
+    let failSpotifyRefresh = false;
+    await page.route('**/api/spotify/stats', (route) =>
+      failSpotifyRefresh
+        ? route.fulfill({ status: 503, json: { error: 'unavailable' } })
+        : route.fulfill({ json: spotifyStats })
+    );
+    await page.goto('/');
+
+    const spotifyCard = page.locator('[data-board-id="spotify"]');
+    await expect(spotifyCard.getByRole('region', { name: 'Library snapshot' })).toBeVisible();
+    await expect(spotifyCard.getByText('42', { exact: true })).toBeVisible();
+    const refresh = page.getByRole('button', { name: 'Refresh summaries' });
+    await expect(refresh).toBeEnabled();
+
+    failSpotifyRefresh = true;
+    await refresh.click();
+
+    await expect(spotifyCard.getByText('Stale')).toBeVisible();
+    await expect(spotifyCard.getByText('42', { exact: true })).toBeVisible();
+    await expect(spotifyCard.getByRole('status')).toContainText(
+      'Refresh failed. Showing the previous summary.'
+    );
+  });
+
   test('keyboard controls persist order, collapsed state, size, and reset', async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await openCleanBoard(page);

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -296,6 +296,13 @@ body {
   margin: 0;
 }
 
+.ui-async-state--compact {
+  justify-items: start;
+  gap: 0.375rem;
+  padding: 0.5rem 0;
+  text-align: left;
+}
+
 .ui-modal-backdrop {
   position: fixed;
   inset: 0;

--- a/packages/ui/src/lib/components/ui/AsyncState.svelte
+++ b/packages/ui/src/lib/components/ui/AsyncState.svelte
@@ -5,15 +5,21 @@
     title,
     message,
     action,
+    compact = false,
   }: {
     state: 'loading' | 'empty' | 'error';
     title: string;
     message?: string;
     action?: Snippet;
+    compact?: boolean;
   } = $props();
 </script>
 
-<div class="ui-async-state" role={state === 'error' ? 'alert' : 'status'}>
+<div
+  class="ui-async-state"
+  class:ui-async-state--compact={compact}
+  role={state === 'error' ? 'alert' : 'status'}
+>
   {#if state === 'loading'}<span class="ui-async-state__spinner" aria-hidden="true"></span>{/if}
   <strong>{title}</strong>
   {#if message}<p>{message}</p>{/if}

--- a/packages/ui/src/lib/components/ui/ui.test.ts
+++ b/packages/ui/src/lib/components/ui/ui.test.ts
@@ -56,6 +56,13 @@ describe('UI primitives', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Request failed');
   });
 
+  it('AsyncState offers a compact layout for constrained surfaces', () => {
+    render(AsyncState, {
+      props: { state: 'empty', title: 'No card data', compact: true },
+    });
+    expect(screen.getByRole('status')).toHaveClass('ui-async-state--compact');
+  });
+
   it('Panel exposes its semantic element, label, and surface variant', () => {
     render(Panel, {
       props: {

--- a/packages/ui/src/lib/flows/board-card.test.ts
+++ b/packages/ui/src/lib/flows/board-card.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BoardCardState,
+  BoardCardTone,
+  FlowStatus,
+  createStaleBoardCard,
+  createStatsBoardCard,
+  type BoardCardReady,
+} from './board-card';
+
+describe('board card contract', () => {
+  it('maps a successful stats result to a typed collapsed summary', async () => {
+    const contract = createStatsBoardCard(
+      async () => ({ count: 12, status: FlowStatus.ACTIVE, statusMessage: 'Streaming' }),
+      { metricLabel: 'Candles', emptyTitle: 'No candles', emptyMessage: 'Start the stream.' }
+    );
+
+    await expect(contract.load()).resolves.toEqual({
+      state: BoardCardState.READY,
+      canOpen: true,
+      summary: {
+        status: { label: 'Streaming', tone: BoardCardTone.SUCCESS },
+        primary: { label: 'Candles', value: '12' },
+      },
+    });
+  });
+
+  it('maps configured zero-count results to an openable empty state', async () => {
+    const contract = createStatsBoardCard(
+      async () => ({ count: 0, status: FlowStatus.CONFIGURED }),
+      { metricLabel: 'Chats', emptyTitle: 'No chats', emptyMessage: 'Start a conversation.' }
+    );
+
+    await expect(contract.load()).resolves.toEqual({
+      state: BoardCardState.EMPTY,
+      canOpen: true,
+      status: { label: 'Configured', tone: BoardCardTone.INFO },
+      title: 'No chats',
+      message: 'Start a conversation.',
+    });
+  });
+
+  it('keeps disabled definitions non-interactive', async () => {
+    const contract = createStatsBoardCard(
+      async () => ({
+        count: 0,
+        status: FlowStatus.DISABLED,
+        statusMessage: 'Coming soon',
+      }),
+      { metricLabel: 'Items', emptyTitle: 'Unavailable', emptyMessage: 'Not configured.' }
+    );
+
+    await expect(contract.load()).resolves.toMatchObject({
+      state: BoardCardState.EMPTY,
+      canOpen: false,
+      status: { label: 'Coming soon', tone: BoardCardTone.NEUTRAL },
+    });
+  });
+
+  it.each([
+    async () => ({ count: 0, status: FlowStatus.ERROR, statusMessage: 'Disconnected' }),
+    async () => {
+      throw new Error('network failed');
+    },
+  ])('isolates failed summary loads as an error state', async (loadStats) => {
+    const contract = createStatsBoardCard(loadStats, {
+      metricLabel: 'Items',
+      emptyTitle: 'No items',
+      emptyMessage: 'Nothing yet.',
+      errorTitle: 'Summary unavailable',
+      errorMessage: 'Try again later.',
+    });
+
+    await expect(contract.load()).resolves.toEqual({
+      state: BoardCardState.ERROR,
+      canOpen: false,
+      status: { label: 'Error', tone: BoardCardTone.DANGER },
+      title: 'Summary unavailable',
+      message: 'Try again later.',
+    });
+  });
+
+  it('rejects malformed runtime counts instead of rendering invalid metrics', async () => {
+    const contract = createStatsBoardCard(
+      async () => ({ count: Number.NaN, status: FlowStatus.ACTIVE }),
+      {
+        metricLabel: 'Items',
+        emptyTitle: 'No items',
+        emptyMessage: 'Nothing yet.',
+        errorTitle: 'Summary unavailable',
+        errorMessage: 'Try again later.',
+      }
+    );
+
+    await expect(contract.load()).resolves.toMatchObject({
+      state: BoardCardState.ERROR,
+      title: 'Summary unavailable',
+    });
+  });
+
+  it('preserves the last ready summary and expansion when a refresh becomes stale', () => {
+    const ready: BoardCardReady = {
+      state: BoardCardState.READY,
+      canOpen: true,
+      summary: {
+        status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+        primary: { label: 'Tracks', value: '42', detail: '8 genres' },
+      },
+      expanded: {
+        heading: 'Library snapshot',
+        metrics: [{ label: 'Top genre', value: 'Rock' }],
+      },
+    };
+
+    expect(createStaleBoardCard(ready, 'Refresh failed. Showing previous data.')).toEqual({
+      ...ready,
+      state: BoardCardState.STALE,
+      message: 'Refresh failed. Showing previous data.',
+    });
+  });
+});

--- a/packages/ui/src/lib/flows/board-card.ts
+++ b/packages/ui/src/lib/flows/board-card.ts
@@ -1,0 +1,209 @@
+export const FlowStatus = {
+  ACTIVE: 'active',
+  CONFIGURED: 'configured',
+  DISABLED: 'disabled',
+  ERROR: 'error',
+} as const;
+
+export type FlowStatus = (typeof FlowStatus)[keyof typeof FlowStatus];
+
+export interface FlowStats {
+  count: number;
+  status: FlowStatus;
+  statusMessage?: string;
+}
+
+export const BoardCardState = {
+  LOADING: 'loading',
+  READY: 'ready',
+  EMPTY: 'empty',
+  ERROR: 'error',
+  STALE: 'stale',
+} as const;
+
+export type BoardCardState = (typeof BoardCardState)[keyof typeof BoardCardState];
+
+export const BoardCardTone = {
+  NEUTRAL: 'neutral',
+  INFO: 'info',
+  SUCCESS: 'success',
+  WARNING: 'warning',
+  DANGER: 'danger',
+} as const;
+
+export type BoardCardTone = (typeof BoardCardTone)[keyof typeof BoardCardTone];
+
+export interface BoardCardStatus {
+  label: string;
+  tone: BoardCardTone;
+}
+
+export interface BoardCardMetric {
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+export interface BoardCardSummary {
+  status: BoardCardStatus;
+  primary: BoardCardMetric;
+}
+
+export interface BoardCardExpandedContent {
+  heading: string;
+  metrics: BoardCardMetric[];
+  note?: string;
+}
+
+export interface BoardCardLoading {
+  state: typeof BoardCardState.LOADING;
+  canOpen: false;
+}
+
+export interface BoardCardReady {
+  state: typeof BoardCardState.READY;
+  canOpen: boolean;
+  summary: BoardCardSummary;
+  expanded?: BoardCardExpandedContent;
+}
+
+export interface BoardCardEmpty {
+  state: typeof BoardCardState.EMPTY;
+  canOpen: boolean;
+  status: BoardCardStatus;
+  title: string;
+  message: string;
+}
+
+export interface BoardCardError {
+  state: typeof BoardCardState.ERROR;
+  canOpen: false;
+  status: BoardCardStatus;
+  title: string;
+  message: string;
+}
+
+export interface BoardCardStale {
+  state: typeof BoardCardState.STALE;
+  canOpen: boolean;
+  summary: BoardCardSummary;
+  expanded?: BoardCardExpandedContent;
+  message: string;
+}
+
+export type BoardCardSnapshot = BoardCardReady | BoardCardEmpty | BoardCardError | BoardCardStale;
+
+export type BoardCardViewState = BoardCardLoading | BoardCardSnapshot;
+
+export interface BoardCardContract {
+  load: () => Promise<BoardCardSnapshot>;
+}
+
+export interface StatsBoardCardOptions {
+  metricLabel: string;
+  emptyTitle: string;
+  emptyMessage: string;
+  errorTitle?: string;
+  errorMessage?: string;
+}
+
+function statusFor(stats: FlowStats): BoardCardStatus {
+  switch (stats.status) {
+    case FlowStatus.ACTIVE:
+      return {
+        label: stats.statusMessage ?? 'Active',
+        tone: BoardCardTone.SUCCESS,
+      };
+    case FlowStatus.CONFIGURED:
+      return {
+        label: stats.statusMessage ?? 'Configured',
+        tone: BoardCardTone.INFO,
+      };
+    case FlowStatus.DISABLED:
+      return {
+        label: stats.statusMessage ?? 'Unavailable',
+        tone: BoardCardTone.NEUTRAL,
+      };
+    case FlowStatus.ERROR:
+      return { label: 'Error', tone: BoardCardTone.DANGER };
+  }
+}
+
+function isFlowStatus(value: unknown): value is FlowStatus {
+  return typeof value === 'string' && Object.values(FlowStatus).includes(value as FlowStatus);
+}
+
+export function createBoardCardError(
+  title = 'Summary unavailable',
+  message = 'The latest flow summary could not be loaded.'
+): BoardCardError {
+  return {
+    state: BoardCardState.ERROR,
+    canOpen: false,
+    status: { label: 'Error', tone: BoardCardTone.DANGER },
+    title,
+    message,
+  };
+}
+
+export function createStatsBoardCard(
+  loadStats: () => Promise<FlowStats>,
+  options: StatsBoardCardOptions
+): BoardCardContract {
+  return {
+    async load(): Promise<BoardCardSnapshot> {
+      try {
+        const stats = await loadStats();
+        if (!Number.isSafeInteger(stats.count) || stats.count < 0 || !isFlowStatus(stats.status)) {
+          return createBoardCardError(options.errorTitle, options.errorMessage);
+        }
+
+        if (stats.status === FlowStatus.ERROR) {
+          return createBoardCardError(options.errorTitle, options.errorMessage);
+        }
+
+        const status = statusFor(stats);
+        if (stats.status === FlowStatus.DISABLED || stats.count <= 0) {
+          return {
+            state: BoardCardState.EMPTY,
+            canOpen: stats.status !== FlowStatus.DISABLED,
+            status,
+            title: options.emptyTitle,
+            message: options.emptyMessage,
+          };
+        }
+
+        return {
+          state: BoardCardState.READY,
+          canOpen: true,
+          summary: {
+            status,
+            primary: {
+              label: options.metricLabel,
+              value: String(stats.count),
+            },
+          },
+        };
+      } catch {
+        return createBoardCardError(options.errorTitle, options.errorMessage);
+      }
+    },
+  };
+}
+
+export function hasBoardCardData(
+  state: BoardCardViewState
+): state is BoardCardReady | BoardCardStale {
+  return state.state === BoardCardState.READY || state.state === BoardCardState.STALE;
+}
+
+export function createStaleBoardCard(
+  previous: BoardCardReady | BoardCardStale,
+  message: string
+): BoardCardStale {
+  return {
+    ...previous,
+    state: BoardCardState.STALE,
+    message,
+  };
+}

--- a/packages/ui/src/lib/flows/canvas/index.ts
+++ b/packages/ui/src/lib/flows/canvas/index.ts
@@ -1,4 +1,5 @@
-import type { FlowDefinition, FlowStats } from '../registry';
+import { createStatsBoardCard, FlowStatus, type FlowStats } from '../board-card';
+import type { FlowDefinition } from '../registry';
 import { fetchCanvasList } from './api';
 
 async function getStats(): Promise<FlowStats> {
@@ -6,13 +7,12 @@ async function getStats(): Promise<FlowStats> {
     const canvases = await fetchCanvasList();
     return {
       count: canvases.length,
-      status: 'active',
-      statusMessage: `${canvases.length} Canvases`,
+      status: canvases.length > 0 ? FlowStatus.ACTIVE : FlowStatus.CONFIGURED,
     };
   } catch {
     return {
       count: 0,
-      status: 'error',
+      status: FlowStatus.ERROR,
       statusMessage: 'Backend unavailable',
     };
   }
@@ -24,6 +24,11 @@ export const canvasFlow: FlowDefinition = {
   icon: '📝',
   description: 'Paste any text and get a deep literary AI analysis.',
   route: '/canvas',
-  color: 'from-cyan-400 to-blue-500',
-  getStats,
+  boardCard: createStatsBoardCard(getStats, {
+    metricLabel: 'Canvases',
+    emptyTitle: 'No canvases yet',
+    emptyMessage: 'Open Text Canvas to create an analysis.',
+    errorTitle: 'Canvas summary unavailable',
+    errorMessage: 'Connect the backend and refresh the board to try again.',
+  }),
 };

--- a/packages/ui/src/lib/flows/chat/index.ts
+++ b/packages/ui/src/lib/flows/chat/index.ts
@@ -1,4 +1,5 @@
-import type { FlowDefinition, FlowStats } from '../registry';
+import { createStatsBoardCard, FlowStatus, type FlowStats } from '../board-card';
+import type { FlowDefinition } from '../registry';
 import { fetchConversations } from './api';
 
 async function getStats(): Promise<FlowStats> {
@@ -6,13 +7,12 @@ async function getStats(): Promise<FlowStats> {
     const conversations = await fetchConversations();
     return {
       count: conversations.length,
-      status: conversations.length > 0 ? 'active' : 'configured',
-      statusMessage: `${conversations.length} Chats`,
+      status: conversations.length > 0 ? FlowStatus.ACTIVE : FlowStatus.CONFIGURED,
     };
   } catch {
     return {
       count: 0,
-      status: 'error',
+      status: FlowStatus.ERROR,
       statusMessage: 'Backend unavailable',
     };
   }
@@ -24,6 +24,11 @@ export const chatFlow: FlowDefinition = {
   icon: '💬',
   description: 'Converse with your favorite AI models.',
   route: '/chat',
-  color: 'from-blue-500 to-indigo-500',
-  getStats,
+  boardCard: createStatsBoardCard(getStats, {
+    metricLabel: 'Chats',
+    emptyTitle: 'No conversations yet',
+    emptyMessage: 'Open Chat Flow to start a conversation.',
+    errorTitle: 'Chat summary unavailable',
+    errorMessage: 'Connect the backend and refresh the board to try again.',
+  }),
 };

--- a/packages/ui/src/lib/flows/index.ts
+++ b/packages/ui/src/lib/flows/index.ts
@@ -1,19 +1,14 @@
-// Flow exports
-export { registerFlow, getFlows, getFlow, type FlowDefinition, type FlowStats } from './registry';
+export * from './board-card';
+export { createFlowRegistry, type FlowDefinition, type FlowRegistry } from './registry';
 
-import { registerFlow } from './registry';
+import { createFlowRegistry } from './registry';
+import { canvasFlow } from './canvas';
+import { chatFlow } from './chat';
+import { lyricsFlow } from './lyrics';
 import { spotifyFlow } from './spotify';
 import { tradingFlow } from './trading/trading';
-import { lyricsFlow } from './lyrics';
-import { chatFlow } from './chat';
-import { canvasFlow } from './canvas';
 
-// ──────────────────────────────────────────────
-// The board manifest
-//
-// Every flow hung on the canvas, in display order.
-// To add a flow: export its FlowDefinition, then list it here.
-// This is the single place that decides what's on the board.
-// ──────────────────────────────────────────────
-const flows = [spotifyFlow, tradingFlow, lyricsFlow, chatFlow, canvasFlow];
-flows.forEach(registerFlow);
+const registry = createFlowRegistry([spotifyFlow, tradingFlow, lyricsFlow, chatFlow, canvasFlow]);
+
+export const getFlows = registry.getFlows;
+export const getFlow = registry.getFlow;

--- a/packages/ui/src/lib/flows/lyrics/index.test.ts
+++ b/packages/ui/src/lib/flows/lyrics/index.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BoardCardState, BoardCardTone } from '../board-card';
+
+const { getLyricsStats } = vi.hoisted(() => ({ getLyricsStats: vi.fn() }));
+
+vi.mock('./api', () => ({ getLyricsStats }));
+
+import { lyricsFlow } from './index';
+
+beforeEach(() => {
+  getLyricsStats.mockReset();
+});
+
+describe('Lyrics board card contract', () => {
+  it('maps live coverage stats to collapsed and expanded content', async () => {
+    getLyricsStats.mockResolvedValue({ total: 20, found: 12, notFound: 3, pending: 5 });
+
+    await expect(lyricsFlow.boardCard.load()).resolves.toEqual({
+      state: BoardCardState.READY,
+      canOpen: true,
+      summary: {
+        status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+        primary: { label: 'Lyrics found', value: '12', detail: '15/20 checked' },
+      },
+      expanded: {
+        heading: 'Lyrics coverage',
+        metrics: [
+          { label: 'Coverage', value: '60%' },
+          { label: 'Pending', value: '5' },
+          { label: 'Unavailable', value: '3' },
+        ],
+        note: 'Open the flow to fetch missing lyrics or inspect individual tracks.',
+      },
+    });
+  });
+
+  it('returns an openable empty state when the music library is empty', async () => {
+    getLyricsStats.mockResolvedValue({ total: 0, found: 0, notFound: 0, pending: 0 });
+
+    await expect(lyricsFlow.boardCard.load()).resolves.toMatchObject({
+      state: BoardCardState.EMPTY,
+      canOpen: true,
+      title: 'No tracks to check',
+    });
+  });
+
+  it('returns a stable error contract when lyrics stats fail', async () => {
+    getLyricsStats.mockRejectedValue(new Error('backend unavailable'));
+
+    await expect(lyricsFlow.boardCard.load()).resolves.toMatchObject({
+      state: BoardCardState.ERROR,
+      canOpen: false,
+      title: 'Lyrics summary unavailable',
+    });
+  });
+
+  it('rejects inconsistent coverage totals', async () => {
+    getLyricsStats.mockResolvedValue({ total: 20, found: 18, notFound: 3, pending: 5 });
+
+    await expect(lyricsFlow.boardCard.load()).resolves.toMatchObject({
+      state: BoardCardState.ERROR,
+      title: 'Lyrics summary unavailable',
+    });
+  });
+});

--- a/packages/ui/src/lib/flows/lyrics/index.ts
+++ b/packages/ui/src/lib/flows/lyrics/index.ts
@@ -1,32 +1,64 @@
-import type { FlowDefinition, FlowStats } from '../registry';
+import {
+  BoardCardState,
+  BoardCardTone,
+  createBoardCardError,
+  type BoardCardSnapshot,
+} from '../board-card';
+import type { FlowDefinition } from '../registry';
 import { getLyricsStats } from './api';
 
-async function getStats(): Promise<FlowStats> {
+function isValidCount(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+async function loadBoardCard(): Promise<BoardCardSnapshot> {
   try {
     const stats = await getLyricsStats();
+    if (
+      ![stats.total, stats.found, stats.notFound, stats.pending].every(isValidCount) ||
+      stats.found + stats.notFound + stats.pending !== stats.total
+    ) {
+      throw new Error('Invalid lyrics stats response');
+    }
 
-    const total = stats.total;
-    const processed = stats.found + stats.notFound;
-
-    if (total === 0) {
+    if (stats.total === 0) {
       return {
-        count: 0,
-        status: 'configured',
-        statusMessage: 'Ready to sync',
+        state: BoardCardState.EMPTY,
+        canOpen: true,
+        status: { label: 'Configured', tone: BoardCardTone.INFO },
+        title: 'No tracks to check',
+        message: 'Sync the music library to begin lyrics coverage.',
       };
     }
 
+    const processed = stats.found + stats.notFound;
+    const coverage = Math.round((stats.found / stats.total) * 100);
     return {
-      count: stats.found,
-      status: 'active',
-      statusMessage: `${processed}/${total} checked`,
+      state: BoardCardState.READY,
+      canOpen: true,
+      summary: {
+        status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+        primary: {
+          label: 'Lyrics found',
+          value: String(stats.found),
+          detail: `${processed}/${stats.total} checked`,
+        },
+      },
+      expanded: {
+        heading: 'Lyrics coverage',
+        metrics: [
+          { label: 'Coverage', value: `${coverage}%` },
+          { label: 'Pending', value: String(stats.pending) },
+          { label: 'Unavailable', value: String(stats.notFound) },
+        ],
+        note: 'Open the flow to fetch missing lyrics or inspect individual tracks.',
+      },
     };
   } catch {
-    return {
-      count: 0,
-      status: 'error',
-      statusMessage: 'Backend unavailable',
-    };
+    return createBoardCardError(
+      'Lyrics summary unavailable',
+      'Connect the backend and refresh the board to try again.'
+    );
   }
 }
 
@@ -36,6 +68,5 @@ export const lyricsFlow: FlowDefinition = {
   icon: '🎤',
   description: 'Manage and view lyrics status for your library.',
   route: '/lyrics',
-  color: 'from-pink-500 to-rose-500',
-  getStats,
+  boardCard: { load: loadBoardCard },
 };

--- a/packages/ui/src/lib/flows/registry.test.ts
+++ b/packages/ui/src/lib/flows/registry.test.ts
@@ -1,85 +1,87 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { FlowDefinition, FlowStats } from './registry';
+import { describe, expect, it } from 'vitest';
+import { BoardCardState, type BoardCardContract } from './board-card';
+import { createFlowRegistry, type FlowDefinition } from './registry';
 
-// The registry is a module-level singleton. Each test gets a fresh module
-// instance (and therefore an empty registry) via dynamic import after a reset,
-// so registrations from one test never leak into another.
-async function freshRegistry() {
-  vi.resetModules();
-  return import('./registry');
-}
+const boardCard: BoardCardContract = {
+  load: async () => ({
+    state: BoardCardState.EMPTY,
+    canOpen: true,
+    status: { label: 'Configured', tone: 'info' },
+    title: 'No items',
+    message: 'Nothing has been created yet.',
+  }),
+};
 
 function makeFlow(overrides: Partial<FlowDefinition> = {}): FlowDefinition {
-  const stats: FlowStats = { count: 0, status: 'active' };
   return {
     id: 'spotify',
     name: 'Spotify Flow',
-    icon: '🎵',
+    icon: 'M',
     description: 'Explore your music.',
     route: '/spotify',
-    color: 'from-green-400 to-emerald-500',
-    getStats: async () => stats,
+    boardCard,
     ...overrides,
   };
 }
 
 describe('flow registry', () => {
-  let registerFlow: typeof import('./registry').registerFlow;
-  let getFlows: typeof import('./registry').getFlows;
-  let getFlow: typeof import('./registry').getFlow;
+  it('keeps validated definitions in manifest order', () => {
+    const spotify = makeFlow();
+    const lyrics = makeFlow({ id: 'lyrics', name: 'Lyrics Flow', route: '/lyrics' });
+    const registry = createFlowRegistry([spotify, lyrics]);
 
-  beforeEach(async () => {
-    ({ registerFlow, getFlows, getFlow } = await freshRegistry());
+    expect(registry.getFlows()).toEqual([spotify, lyrics]);
+    expect(registry.getFlow('lyrics')).toEqual(lyrics);
+    expect(registry.getFlow('lyrics')).not.toBe(lyrics);
+    expect(registry.getFlow('missing')).toBeUndefined();
   });
 
-  it('starts empty', () => {
-    expect(getFlows()).toEqual([]);
-    expect(getFlow('spotify')).toBeUndefined();
+  it('rejects duplicate ids instead of silently discarding a definition', () => {
+    expect(() => createFlowRegistry([makeFlow(), makeFlow({ name: 'Duplicate Spotify' })])).toThrow(
+      'Duplicate flow id "spotify"'
+    );
   });
 
-  it('registers a flow and retrieves it by id', () => {
-    const flow = makeFlow();
-    registerFlow(flow);
-
-    expect(getFlows()).toHaveLength(1);
-    expect(getFlow('spotify')).toBe(flow);
+  it.each([
+    {},
+    { id: '', name: 'Missing id', icon: 'M', description: 'Description', route: '/missing' },
+    { id: 'missing-name', name: '', icon: 'M', description: 'Description', route: '/missing' },
+    { id: 'missing-route', name: 'Missing route', icon: 'M', description: 'Description' },
+    {
+      id: 'missing-board-card',
+      name: 'Missing card',
+      icon: 'M',
+      description: 'Description',
+      route: '/missing',
+    },
+    {
+      id: 'invalid-route',
+      name: 'Invalid route',
+      icon: 'M',
+      description: 'Description',
+      route: 'missing-leading-slash',
+      boardCard,
+    },
+    {
+      id: 'invalid-card',
+      name: 'Invalid card',
+      icon: 'M',
+      description: 'Description',
+      route: '/invalid-card',
+      boardCard: { load: 'not-a-function' },
+    },
+  ])('rejects incomplete runtime definitions', (definition) => {
+    expect(() => createFlowRegistry([definition])).toThrow(/Invalid flow definition/);
   });
 
-  it('registers multiple distinct flows in insertion order', () => {
-    const spotify = makeFlow({ id: 'spotify' });
-    const lyrics = makeFlow({ id: 'lyrics', name: 'Lyrics Flow' });
+  it('returns a defensive manifest copy', () => {
+    const registry = createFlowRegistry([makeFlow()]);
+    const snapshot = registry.getFlows();
+    expect(Object.isFrozen(snapshot[0])).toBe(true);
+    expect(Object.isFrozen(snapshot[0]?.boardCard)).toBe(true);
+    snapshot.push(makeFlow({ id: 'injected', route: '/injected' }));
 
-    registerFlow(spotify);
-    registerFlow(lyrics);
-
-    expect(getFlows().map((f) => f.id)).toEqual(['spotify', 'lyrics']);
-  });
-
-  it('ignores duplicate ids (first registration wins)', () => {
-    const first = makeFlow({ id: 'spotify', name: 'Original' });
-    const duplicate = makeFlow({ id: 'spotify', name: 'Replacement' });
-
-    registerFlow(first);
-    registerFlow(duplicate);
-
-    expect(getFlows()).toHaveLength(1);
-    expect(getFlow('spotify')?.name).toBe('Original');
-  });
-
-  it('returns undefined for an unknown id', () => {
-    registerFlow(makeFlow({ id: 'spotify' }));
-
-    expect(getFlow('does-not-exist')).toBeUndefined();
-  });
-
-  it('getFlows returns a defensive copy, not the internal array', () => {
-    registerFlow(makeFlow({ id: 'spotify' }));
-
-    const snapshot = getFlows();
-    snapshot.push(makeFlow({ id: 'injected' }));
-
-    // Mutating the returned array must not affect the registry.
-    expect(getFlows()).toHaveLength(1);
-    expect(getFlow('injected')).toBeUndefined();
+    expect(registry.getFlows()).toHaveLength(1);
+    expect(registry.getFlow('injected')).toBeUndefined();
   });
 });

--- a/packages/ui/src/lib/flows/registry.ts
+++ b/packages/ui/src/lib/flows/registry.ts
@@ -1,35 +1,71 @@
-// Flow Registry - Dynamic flow registration system
-
-export interface FlowStats {
-  count: number;
-  status: 'active' | 'configured' | 'disabled' | 'error';
-  statusMessage?: string;
-}
+import type { BoardCardContract } from './board-card';
 
 export interface FlowDefinition {
-  id: string;
-  name: string;
-  icon: string;
-  description: string;
-  route: string;
-  color: string;
-  getStats: () => Promise<FlowStats>;
+  readonly id: string;
+  readonly name: string;
+  readonly icon: string;
+  readonly description: string;
+  readonly route: string;
+  readonly boardCard: BoardCardContract;
 }
 
-// Registry of all available flows
-const flowRegistry: FlowDefinition[] = [];
+export interface FlowRegistry {
+  readonly getFlows: () => FlowDefinition[];
+  readonly getFlow: (id: string) => FlowDefinition | undefined;
+}
 
-export function registerFlow(flow: FlowDefinition): void {
-  // Avoid duplicates
-  if (!flowRegistry.find((f) => f.id === flow.id)) {
-    flowRegistry.push(flow);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasNonEmptyString(value: Record<string, unknown>, field: string): boolean {
+  return typeof value[field] === 'string' && value[field].trim().length > 0;
+}
+
+function parseFlowDefinition(value: unknown, index: number): FlowDefinition {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid flow definition at index ${index}: expected an object.`);
   }
+
+  for (const field of ['id', 'name', 'icon', 'description', 'route']) {
+    if (!hasNonEmptyString(value, field)) {
+      throw new Error(`Invalid flow definition at index ${index}: ${field} is required.`);
+    }
+  }
+
+  if (!(value.route as string).startsWith('/')) {
+    throw new Error(`Invalid flow definition at index ${index}: route must start with "/".`);
+  }
+
+  if (!isRecord(value.boardCard) || typeof value.boardCard.load !== 'function') {
+    throw new Error(`Invalid flow definition at index ${index}: boardCard.load is required.`);
+  }
+
+  const boardCard = Object.freeze({
+    load: value.boardCard.load as BoardCardContract['load'],
+  });
+
+  return Object.freeze({
+    id: value.id as string,
+    name: value.name as string,
+    icon: value.icon as string,
+    description: value.description as string,
+    route: value.route as string,
+    boardCard,
+  });
 }
 
-export function getFlows(): FlowDefinition[] {
-  return [...flowRegistry];
-}
+export function createFlowRegistry(definitions: readonly unknown[]): FlowRegistry {
+  const flows = definitions.map(parseFlowDefinition);
+  const flowById = new Map<string, FlowDefinition>();
 
-export function getFlow(id: string): FlowDefinition | undefined {
-  return flowRegistry.find((f) => f.id === id);
+  for (const flow of flows) {
+    if (flowById.has(flow.id)) throw new Error(`Duplicate flow id "${flow.id}".`);
+    flowById.set(flow.id, flow);
+  }
+
+  return {
+    getFlows: () => [...flows],
+    getFlow: (id) => flowById.get(id),
+  };
 }

--- a/packages/ui/src/lib/flows/spotify/index.test.ts
+++ b/packages/ui/src/lib/flows/spotify/index.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BoardCardState, BoardCardTone } from '../board-card';
+
+const { statsGet } = vi.hoisted(() => ({ statsGet: vi.fn() }));
+
+vi.mock('@lib/client', () => ({
+  api: {
+    api: {
+      spotify: {
+        stats: { get: statsGet },
+      },
+    },
+  },
+}));
+
+import { spotifyFlow } from './index';
+
+beforeEach(() => {
+  statsGet.mockReset();
+});
+
+describe('Spotify board card contract', () => {
+  it('maps live library stats to collapsed and expanded content', async () => {
+    statsGet.mockResolvedValue({
+      data: {
+        totalTracks: 42,
+        totalGenres: 8,
+        topGenres: [{ genre: 'rock', count: 12 }],
+        decadeDistribution: { '2020s': 20 },
+        yearRange: { oldest: 1998, newest: 2025 },
+      },
+      error: null,
+    });
+
+    await expect(spotifyFlow.boardCard.load()).resolves.toEqual({
+      state: BoardCardState.READY,
+      canOpen: true,
+      summary: {
+        status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+        primary: { label: 'Tracks', value: '42', detail: '8 genres' },
+      },
+      expanded: {
+        heading: 'Library snapshot',
+        metrics: [
+          { label: 'Genres', value: '8' },
+          { label: 'Top genre', value: 'rock' },
+          { label: 'Year range', value: '1998-2025' },
+        ],
+        note: 'Open the flow for filters, charts, and track details.',
+      },
+    });
+  });
+
+  it('returns an openable empty state for a library with no tracks', async () => {
+    statsGet.mockResolvedValue({
+      data: {
+        totalTracks: 0,
+        totalGenres: 0,
+        topGenres: [],
+        decadeDistribution: {},
+        yearRange: null,
+      },
+      error: null,
+    });
+
+    await expect(spotifyFlow.boardCard.load()).resolves.toMatchObject({
+      state: BoardCardState.EMPTY,
+      canOpen: true,
+      title: 'No tracks synced',
+    });
+  });
+
+  it('returns a stable error contract for failed or malformed responses', async () => {
+    statsGet.mockResolvedValue({ data: { totalTracks: 'unknown' }, error: null });
+
+    await expect(spotifyFlow.boardCard.load()).resolves.toMatchObject({
+      state: BoardCardState.ERROR,
+      canOpen: false,
+      title: 'Spotify summary unavailable',
+    });
+  });
+
+  it('omits an invalid provider year range without losing valid summary data', async () => {
+    statsGet.mockResolvedValue({
+      data: {
+        totalTracks: 42,
+        totalGenres: 8,
+        topGenres: [],
+        decadeDistribution: {},
+        yearRange: { oldest: 0, newest: 2026 },
+      },
+      error: null,
+    });
+
+    const card = await spotifyFlow.boardCard.load();
+    expect(card).toMatchObject({ state: BoardCardState.READY });
+    if (card.state !== BoardCardState.READY) throw new Error('Expected a ready card');
+    expect(card.expanded?.metrics).toContainEqual({
+      label: 'Year range',
+      value: 'Not available',
+    });
+  });
+});

--- a/packages/ui/src/lib/flows/spotify/index.ts
+++ b/packages/ui/src/lib/flows/spotify/index.ts
@@ -1,35 +1,116 @@
-// Spotify Flow Registration
-import { type FlowStats, type FlowDefinition } from '../registry';
 import { api } from '@lib/client';
+import {
+  BoardCardState,
+  BoardCardTone,
+  createBoardCardError,
+  type BoardCardSnapshot,
+} from '../board-card';
+import type { FlowDefinition } from '../registry';
 
-async function getSpotifyStats(): Promise<FlowStats> {
+interface SpotifyBoardStats {
+  totalTracks: number;
+  totalGenres: number;
+  topGenre: string | null;
+  yearRange: { oldest: number; newest: number } | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function readYear(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1000 && value <= 9999
+    ? value
+    : null;
+}
+
+function parseSpotifyStats(value: unknown): SpotifyBoardStats | null {
+  if (!isRecord(value)) return null;
+  const totalTracks = readCount(value.totalTracks);
+  const totalGenres = readCount(value.totalGenres);
+  if (totalTracks === null || totalGenres === null || !Array.isArray(value.topGenres)) return null;
+
+  const firstGenre = value.topGenres[0];
+  const topGenre =
+    isRecord(firstGenre) &&
+    typeof firstGenre.genre === 'string' &&
+    firstGenre.genre.trim().length > 0
+      ? firstGenre.genre
+      : null;
+
+  let yearRange: SpotifyBoardStats['yearRange'] = null;
+  if (value.yearRange !== null) {
+    if (!isRecord(value.yearRange)) return null;
+    const oldest = readYear(value.yearRange.oldest);
+    const newest = readYear(value.yearRange.newest);
+    if (oldest !== null && newest !== null && oldest <= newest) {
+      yearRange = { oldest, newest };
+    }
+  }
+
+  return { totalTracks, totalGenres, topGenre, yearRange };
+}
+
+async function loadBoardCard(): Promise<BoardCardSnapshot> {
   try {
     const { data, error } = await api.api.spotify.stats.get();
-    if (error) throw new Error('Failed to fetch stats');
-    const stats = data as unknown as Record<string, unknown>;
+    if (error) throw new Error('Failed to fetch Spotify stats');
+    const stats = parseSpotifyStats(data);
+    if (!stats) throw new Error('Invalid Spotify stats response');
+
+    if (stats.totalTracks === 0) {
+      return {
+        state: BoardCardState.EMPTY,
+        canOpen: true,
+        status: { label: 'Configured', tone: BoardCardTone.INFO },
+        title: 'No tracks synced',
+        message: 'Sync Spotify to populate this board summary.',
+      };
+    }
+
     return {
-      count: (stats.totalTracks as number) || 0,
-      status: 'active',
-      statusMessage: `${(stats.totalGenres as number) || 0} genres`,
+      state: BoardCardState.READY,
+      canOpen: true,
+      summary: {
+        status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+        primary: {
+          label: 'Tracks',
+          value: String(stats.totalTracks),
+          detail: `${stats.totalGenres} genres`,
+        },
+      },
+      expanded: {
+        heading: 'Library snapshot',
+        metrics: [
+          { label: 'Genres', value: String(stats.totalGenres) },
+          { label: 'Top genre', value: stats.topGenre ?? 'Not available' },
+          {
+            label: 'Year range',
+            value: stats.yearRange
+              ? `${stats.yearRange.oldest}-${stats.yearRange.newest}`
+              : 'Not available',
+          },
+        ],
+        note: 'Open the flow for filters, charts, and track details.',
+      },
     };
   } catch {
-    return {
-      count: 0,
-      status: 'error',
-      statusMessage: 'Failed to connect',
-    };
+    return createBoardCardError(
+      'Spotify summary unavailable',
+      'Connect the backend and refresh the board to try again.'
+    );
   }
 }
 
-// Flow definition — hung on the board centrally in flows/index.ts
 export const spotifyFlow: FlowDefinition = {
   id: 'spotify',
   name: 'Spotify Flow',
   icon: '🎵',
   description: 'Explore your liked songs, discover genres, and analyze your music taste.',
   route: '/spotify',
-  color: 'from-green-400 to-emerald-500',
-  getStats: getSpotifyStats,
+  boardCard: { load: loadBoardCard },
 };
-
-export { getSpotifyStats };

--- a/packages/ui/src/lib/flows/trading/trading.test.ts
+++ b/packages/ui/src/lib/flows/trading/trading.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BoardCardState } from '../board-card';
 import type { StatusResponse } from './types';
 
 // --- Mock the network edge (Eden client). Never hit a real backend. ---
@@ -143,23 +144,24 @@ describe('tradingFlow definition contract', () => {
     expect(tradingFlow.name).toBe('Trading Bot');
     expect(tradingFlow.route).toBe('/trading');
     expect(tradingFlow.icon).toBe('📈');
-    expect(tradingFlow.color).toContain('amber');
     expect(tradingFlow.description).toMatch(/Hurst/);
   });
 
-  it('exposes a getStats function (routing is file-based, no component field)', () => {
-    expect(typeof tradingFlow.getStats).toBe('function');
+  it('exposes a board card loader (routing remains file-based)', () => {
+    expect(typeof tradingFlow.boardCard.load).toBe('function');
   });
 
-  it('getStats on the definition delegates to getTradingStats', async () => {
+  it('maps trading stats through the generic board card contract', async () => {
     statusGet.mockResolvedValue({
       data: statusFixture({ isRunning: true, candleCount: 9 }),
       error: null,
     });
 
-    const stats = await tradingFlow.getStats();
+    const card = await tradingFlow.boardCard.load();
 
-    expect(stats.count).toBe(9);
-    expect(stats.status).toBe('active');
+    expect(card.state).toBe(BoardCardState.READY);
+    if (card.state !== BoardCardState.READY) throw new Error('Expected a ready card');
+    expect(card.summary.primary).toEqual({ label: 'Candles', value: '9' });
+    expect(card.summary.status.label).toBe('Streaming');
   });
 });

--- a/packages/ui/src/lib/flows/trading/trading.ts
+++ b/packages/ui/src/lib/flows/trading/trading.ts
@@ -5,7 +5,8 @@
 //   - stores.svelte.ts  → Runes-based state (tradingStore)
 //   - api.ts            → API functions + SSE streaming
 
-import { type FlowStats, type FlowDefinition } from '../registry';
+import { createStatsBoardCard, FlowStatus, type FlowStats } from '../board-card';
+import type { FlowDefinition } from '../registry';
 import { api } from '@lib/client';
 import type { StatusResponse } from './types';
 
@@ -40,13 +41,13 @@ async function getTradingStats(): Promise<FlowStats> {
     const result = data as unknown as StatusResponse;
     return {
       count: result.trading?.candleCount || 0,
-      status: result.trading?.isRunning ? 'active' : 'configured',
+      status: result.trading?.isRunning ? FlowStatus.ACTIVE : FlowStatus.CONFIGURED,
       statusMessage: result.trading?.isRunning ? 'Streaming' : 'Stopped',
     };
   } catch {
     return {
       count: 0,
-      status: 'error',
+      status: FlowStatus.ERROR,
       statusMessage: 'Disconnected',
     };
   }
@@ -59,8 +60,13 @@ export const tradingFlow: FlowDefinition = {
   icon: '📈',
   description: 'Real-time BTC analysis with Hurst exponent, fractals, and AI-powered insights.',
   route: '/trading',
-  color: 'from-amber-400 to-orange-500',
-  getStats: getTradingStats,
+  boardCard: createStatsBoardCard(getTradingStats, {
+    metricLabel: 'Candles',
+    emptyTitle: 'No market data yet',
+    emptyMessage: 'Open Trading Bot to start the stream.',
+    errorTitle: 'Trading summary unavailable',
+    errorMessage: 'Connect the backend and refresh the board to try again.',
+  }),
 };
 
 export { getTradingStats };

--- a/packages/ui/src/lib/pages/Landing.svelte
+++ b/packages/ui/src/lib/pages/Landing.svelte
@@ -1,32 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { AsyncState, FlowLayout } from '@lib/components';
-  import { getFlows, type FlowDefinition, type FlowStats } from '@lib/flows';
+  import { FlowLayout } from '@lib/components';
+  import { getFlows } from '@lib/flows';
   import FlowBoard from './components/FlowBoard.svelte';
-  import type { FlowCardModel } from './types';
 
   const pageTitle = 'Cosmic Flow - Data Exploration Hub';
-
-  let flows = $state<FlowCardModel[]>([]);
-  let isLoading = $state(true);
-  const readyFlowCount = $derived(
-    flows.filter((flow) => ['active', 'configured'].includes(flow.stats.status)).length
-  );
-
-  async function resolveFlow(flow: FlowDefinition): Promise<FlowCardModel> {
-    try {
-      return { ...flow, stats: await flow.getStats() };
-    } catch {
-      const stats: FlowStats = { count: 0, status: 'error' };
-      return { ...flow, stats };
-    }
-  }
-
-  onMount(async () => {
-    const flowsWithStats = await Promise.all(getFlows().map(resolveFlow));
-    flows = flowsWithStats;
-    isLoading = false;
-  });
+  const flows = getFlows();
 </script>
 
 <svelte:head>
@@ -40,11 +18,7 @@
     </header>
 
     <div class="flow-index__content">
-      {#if isLoading}
-        <AsyncState state="loading" title="Loading flow status" />
-      {:else}
-        <FlowBoard {flows} {readyFlowCount} />
-      {/if}
+      <FlowBoard {flows} />
     </div>
   </section>
 </FlowLayout>

--- a/packages/ui/src/lib/pages/Landing.svelte.test.ts
+++ b/packages/ui/src/lib/pages/Landing.svelte.test.ts
@@ -1,29 +1,43 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/svelte';
-import type { FlowDefinition, FlowStats } from '@lib/flows';
+import { render, screen } from '@testing-library/svelte';
+import {
+  BoardCardState,
+  BoardCardTone,
+  type BoardCardSnapshot,
+  type FlowDefinition,
+} from '@lib/flows';
 
 const getFlows = vi.fn<() => FlowDefinition[]>();
-vi.mock('@lib/flows', () => ({
+vi.mock('@lib/flows', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@lib/flows')>()),
   getFlows: () => getFlows(),
 }));
 
 function makeFlow(
   id: string,
-  stats: FlowStats | (() => Promise<FlowStats>),
+  snapshot: BoardCardSnapshot | (() => Promise<BoardCardSnapshot>),
   overrides: Partial<FlowDefinition> = {}
 ): FlowDefinition {
-  const getStats = typeof stats === 'function' ? stats : async () => stats;
+  const load = typeof snapshot === 'function' ? snapshot : async () => snapshot;
   return {
     id,
     name: `${id} Flow`,
-    icon: '🎵',
+    icon: 'M',
     description: `${id} description`,
     route: `/${id}`,
-    color: 'from-green-400 to-emerald-500',
-    getStats,
+    boardCard: { load },
     ...overrides,
   };
 }
+
+const readyCard: BoardCardSnapshot = {
+  state: BoardCardState.READY,
+  canOpen: true,
+  summary: {
+    status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+    primary: { label: 'Tracks', value: '12' },
+  },
+};
 
 const { default: Landing } = await import('./Landing.svelte');
 
@@ -34,36 +48,26 @@ describe('Landing board', () => {
 
   it('sets the branded page title', () => {
     getFlows.mockReturnValue([]);
-
     render(Landing);
-
     expect(document.title).toBe('Cosmic Flow - Data Exploration Hub');
   });
 
-  it('uses the shared loading state while flow stats resolve', () => {
-    getFlows.mockReturnValue([makeFlow('spotify', () => new Promise<FlowStats>(() => {}))]);
-
-    render(Landing);
-
-    expect(screen.getByRole('status')).toHaveTextContent('Loading flow status');
-  });
-
-  it('renders registered flows without inventing unregistered board items', async () => {
+  it('renders registered items immediately while their summaries load independently', async () => {
     getFlows.mockReturnValue([
-      makeFlow('spotify', { count: 12, status: 'active' }, { name: 'Spotify Flow' }),
+      makeFlow('spotify', () => new Promise<BoardCardSnapshot>(() => {}), {
+        name: 'Spotify Flow',
+      }),
     ]);
 
     render(Landing);
 
-    expect(await screen.findByRole('link', { name: 'Open Spotify Flow' })).toBeInTheDocument();
+    expect(await screen.findByText('Spotify Flow')).toBeInTheDocument();
+    expect(screen.getByText('Loading summary')).toBeInTheDocument();
     expect(screen.queryByText('YouTube Flow')).not.toBeInTheDocument();
   });
 
-  it('renders active and configured flows as route links', async () => {
-    getFlows.mockReturnValue([
-      makeFlow('spotify', { count: 5, status: 'active' }, { name: 'Spotify Flow' }),
-      makeFlow('lyrics', { count: 0, status: 'configured' }, { name: 'Lyrics Flow' }),
-    ]);
+  it('preserves route navigation supplied by a successful card contract', async () => {
+    getFlows.mockReturnValue([makeFlow('spotify', readyCard, { name: 'Spotify Flow' })]);
 
     render(Landing);
 
@@ -71,76 +75,25 @@ describe('Landing board', () => {
       'href',
       '/spotify'
     );
-    expect(screen.getByRole('link', { name: 'Open Lyrics Flow' })).toHaveAttribute(
-      'href',
-      '/lyrics'
-    );
+    expect(screen.getByText('12')).toBeInTheDocument();
   });
 
-  it('renders disabled flows as non-interactive articles', async () => {
+  it('isolates a failed summary contract to its board item', async () => {
     getFlows.mockReturnValue([
-      makeFlow(
-        'trading',
-        { count: 0, status: 'disabled', statusMessage: 'Coming Soon' },
-        { name: 'Trading Flow' }
-      ),
+      makeFlow('broken', {
+        state: BoardCardState.ERROR,
+        canOpen: false,
+        status: { label: 'Error', tone: BoardCardTone.DANGER },
+        title: 'Summary unavailable',
+        message: 'Try refreshing the board.',
+      }),
+      makeFlow('spotify', readyCard, { name: 'Spotify Flow' }),
     ]);
 
     render(Landing);
 
-    const heading = await screen.findByText('Trading Flow');
-    expect(heading.closest('article')).toHaveAttribute('data-state', 'unavailable');
-    expect(screen.queryByRole('link', { name: 'Open Trading Flow' })).not.toBeInTheDocument();
-  });
-
-  it('shows item counts only when they are positive', async () => {
-    getFlows.mockReturnValue([
-      makeFlow('spotify', { count: 42, status: 'active' }, { name: 'Spotify Flow' }),
-      makeFlow('empty', { count: 0, status: 'active' }, { name: 'Empty Flow' }),
-    ]);
-
-    render(Landing);
-
-    await screen.findByRole('link', { name: 'Open Spotify Flow' });
-    expect(screen.getByText('42')).toBeInTheDocument();
-    expect(screen.getAllByText('Items')).toHaveLength(1);
-  });
-
-  it('isolates a stats failure to the affected flow card', async () => {
-    getFlows.mockReturnValue([
-      makeFlow('broken', () => Promise.reject(new Error('boom')), { name: 'Broken Flow' }),
-    ]);
-
-    render(Landing);
-
-    const heading = await screen.findByText('Broken Flow');
-    expect(heading.closest('article')).toHaveAttribute('data-state', 'unavailable');
-    expect(screen.getByText('Error')).toHaveClass('ui-badge--danger');
-  });
-
-  it('preserves custom status messages from the registry', async () => {
-    getFlows.mockReturnValue([
-      makeFlow(
-        'spotify',
-        { count: 3, status: 'active', statusMessage: '8 genres' },
-        { name: 'Spotify Flow' }
-      ),
-    ]);
-
-    render(Landing);
-
-    expect(await screen.findByText('8 genres')).toHaveClass('ui-badge--success');
-  });
-
-  it('summarizes ready and total flows in the compact header', async () => {
-    getFlows.mockReturnValue([]);
-
-    render(Landing);
-
-    expect(screen.getByRole('heading', { name: 'Board' })).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByText('0 ready')).toBeInTheDocument();
-      expect(screen.getByText('0 total')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('link', { name: 'Open Spotify Flow' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Open broken Flow' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Summary unavailable');
   });
 });

--- a/packages/ui/src/lib/pages/components/BoardCardContent.svelte
+++ b/packages/ui/src/lib/pages/components/BoardCardContent.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  import { AsyncState, Badge } from '@lib/components';
+  import { BoardCardState, BoardCardTone, type BoardCardViewState } from '@lib/flows';
+
+  interface Props {
+    card: BoardCardViewState;
+    description: string;
+    showExpanded: boolean;
+  }
+
+  let { card, description, showExpanded }: Props = $props();
+</script>
+
+<div class="board-card-content" data-summary-state={card.state}>
+  {#if card.state === BoardCardState.LOADING}
+    <AsyncState state="loading" title="Loading summary" compact />
+  {:else if card.state === BoardCardState.EMPTY}
+    <div class="board-card-content__state">
+      <Badge tone={card.status.tone}>{card.status.label}</Badge>
+      <AsyncState state="empty" title={card.title} message={card.message} compact />
+    </div>
+  {:else if card.state === BoardCardState.ERROR}
+    <div class="board-card-content__state">
+      <Badge tone={card.status.tone}>{card.status.label}</Badge>
+      <AsyncState state="error" title={card.title} message={card.message} compact />
+    </div>
+  {:else}
+    <div class="board-card-content__summary">
+      <div class="board-card-content__badges">
+        <Badge tone={card.summary.status.tone}>{card.summary.status.label}</Badge>
+        {#if card.state === BoardCardState.STALE}
+          <Badge tone={BoardCardTone.WARNING}>Stale</Badge>
+        {/if}
+      </div>
+      <div class="board-card-content__primary">
+        <strong>{card.summary.primary.value}</strong>
+        <span>{card.summary.primary.label}</span>
+        {#if card.summary.primary.detail}
+          <small>{card.summary.primary.detail}</small>
+        {/if}
+      </div>
+    </div>
+
+    {#if card.state === BoardCardState.STALE}
+      <p class="board-card-content__stale" role="status">{card.message}</p>
+    {/if}
+
+    {#if showExpanded}
+      <div class="board-card-content__expanded">
+        <p>{description}</p>
+
+        {#if card.expanded}
+          <section class="board-card-content__details" aria-label={card.expanded.heading}>
+            <h3>{card.expanded.heading}</h3>
+            <dl>
+              {#each card.expanded.metrics as metric (metric.label)}
+                <div>
+                  <dt>{metric.label}</dt>
+                  <dd>{metric.value}</dd>
+                  {#if metric.detail}<small>{metric.detail}</small>{/if}
+                </div>
+              {/each}
+            </dl>
+            {#if card.expanded.note}<p class="board-card-content__note">
+                {card.expanded.note}
+              </p>{/if}
+          </section>
+        {/if}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .board-card-content {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 0.875rem;
+  }
+
+  .board-card-content__state {
+    display: grid;
+    justify-items: start;
+    gap: 0.25rem;
+  }
+
+  .board-card-content__summary {
+    display: flex;
+    min-width: 0;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .board-card-content__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .board-card-content__primary {
+    display: grid;
+    min-width: 0;
+    grid-template-columns: auto auto;
+    align-items: baseline;
+    justify-content: end;
+    gap: 0.25rem 0.375rem;
+    text-align: right;
+  }
+
+  .board-card-content__primary strong {
+    color: var(--ui-text);
+    font-size: 1.375rem;
+    line-height: 1;
+  }
+
+  .board-card-content__primary span,
+  .board-card-content__primary small {
+    color: var(--ui-text-muted);
+    font-size: 0.75rem;
+  }
+
+  .board-card-content__primary small {
+    grid-column: 1 / -1;
+  }
+
+  .board-card-content__stale {
+    margin: 0;
+    color: var(--ui-warning);
+    font-size: 0.75rem;
+  }
+
+  .board-card-content__expanded {
+    display: grid;
+    gap: 0.875rem;
+    padding-top: 0.875rem;
+    border-top: 1px solid var(--ui-border);
+  }
+
+  .board-card-content__expanded > p,
+  .board-card-content__note {
+    margin: 0;
+    color: var(--ui-text-muted);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+  }
+
+  .board-card-content__details {
+    display: grid;
+    gap: 0.625rem;
+  }
+
+  .board-card-content__details h3 {
+    margin: 0;
+    color: var(--ui-text);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+  }
+
+  .board-card-content__details dl {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+    gap: 0.5rem;
+    margin: 0;
+  }
+
+  .board-card-content__details dl > div {
+    display: grid;
+    min-width: 0;
+    gap: 0.125rem;
+    padding: 0.625rem;
+    border-left: 2px solid var(--ui-border-strong);
+    background: var(--ui-surface-subtle);
+  }
+
+  .board-card-content__details dt,
+  .board-card-content__details small {
+    color: var(--ui-text-muted);
+    font-size: 0.6875rem;
+  }
+
+  .board-card-content__details dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--ui-text);
+    font-size: 0.875rem;
+    font-weight: 700;
+  }
+
+  @media (max-width: 40rem) {
+    .board-card-content__summary {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .board-card-content__primary {
+      justify-content: start;
+      text-align: left;
+    }
+  }
+</style>

--- a/packages/ui/src/lib/pages/components/BoardCardContent.svelte.test.ts
+++ b/packages/ui/src/lib/pages/components/BoardCardContent.svelte.test.ts
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import {
+  BoardCardState,
+  BoardCardTone,
+  type BoardCardReady,
+  type BoardCardViewState,
+} from '@lib/flows';
+import BoardCardContent from './BoardCardContent.svelte';
+
+const readyCard: BoardCardReady = {
+  state: BoardCardState.READY,
+  canOpen: true,
+  summary: {
+    status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+    primary: { label: 'Tracks', value: '42', detail: '8 genres' },
+  },
+  expanded: {
+    heading: 'Library snapshot',
+    metrics: [
+      { label: 'Top genre', value: 'rock' },
+      { label: 'Year range', value: '1998-2025' },
+    ],
+    note: 'Open the flow for track details.',
+  },
+};
+
+function renderContent(card: BoardCardViewState, showExpanded = true) {
+  return render(BoardCardContent, {
+    props: {
+      card,
+      description: 'Explore your music library.',
+      showExpanded,
+    },
+  });
+}
+
+describe('BoardCardContent', () => {
+  it('uses the shared compact primitive for loading, empty, and error states', () => {
+    const loading = renderContent({ state: BoardCardState.LOADING, canOpen: false });
+    expect(screen.getByRole('status')).toHaveTextContent('Loading summary');
+    expect(screen.getByRole('status')).toHaveClass('ui-async-state--compact');
+    loading.unmount();
+
+    const empty = renderContent({
+      state: BoardCardState.EMPTY,
+      canOpen: true,
+      status: { label: 'Configured', tone: BoardCardTone.INFO },
+      title: 'No tracks synced',
+      message: 'Sync Spotify to populate this summary.',
+    });
+    expect(screen.getByText('Configured')).toHaveClass('ui-badge--info');
+    expect(screen.getByRole('status')).toHaveTextContent('No tracks synced');
+    empty.unmount();
+
+    renderContent({
+      state: BoardCardState.ERROR,
+      canOpen: false,
+      status: { label: 'Error', tone: BoardCardTone.DANGER },
+      title: 'Summary unavailable',
+      message: 'Try refreshing the board.',
+    });
+    expect(screen.getByText('Error')).toHaveClass('ui-badge--danger');
+    expect(screen.getByRole('alert')).toHaveTextContent('Try refreshing the board.');
+  });
+
+  it('keeps the typed summary visible when expanded content is collapsed', () => {
+    renderContent(readyCard, false);
+
+    expect(screen.getByText('Active')).toHaveClass('ui-badge--success');
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Tracks')).toBeInTheDocument();
+    expect(screen.getByText('8 genres')).toBeInTheDocument();
+    expect(screen.queryByText('Explore your music library.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Library snapshot' })).not.toBeInTheDocument();
+  });
+
+  it('renders expanded metrics without knowing which flow produced them', () => {
+    renderContent(readyCard);
+
+    expect(screen.getByText('Explore your music library.')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Library snapshot' })).toBeInTheDocument();
+    expect(screen.getByText('Top genre')).toBeInTheDocument();
+    expect(screen.getByText('rock')).toBeInTheDocument();
+    expect(screen.getByText('Open the flow for track details.')).toBeInTheDocument();
+  });
+
+  it('renders stale data with an explicit warning and the last summary', () => {
+    renderContent({
+      ...readyCard,
+      state: BoardCardState.STALE,
+      message: 'Refresh failed. Showing the previous summary.',
+    });
+
+    expect(screen.getByText('Stale')).toHaveClass('ui-badge--warning');
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Refresh failed. Showing the previous summary.'
+    );
+  });
+});

--- a/packages/ui/src/lib/pages/components/BoardItem.svelte
+++ b/packages/ui/src/lib/pages/components/BoardItem.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { Badge, IconButton } from '@lib/components';
-  import type { FlowStats } from '@lib/flows';
+  import { IconButton } from '@lib/components';
+  import { BoardCardState, type BoardCardViewState, type FlowDefinition } from '@lib/flows';
   import { BoardItemSize, isBoardItemSize, type BoardItemLayout } from '../board-layout';
-  import type { FlowCardModel } from '../types';
+  import BoardCardContent from './BoardCardContent.svelte';
 
   interface Props {
-    flow: FlowCardModel;
+    flow: FlowDefinition;
+    card: BoardCardViewState;
     layout: BoardItemLayout;
     position: number;
     itemCount: number;
@@ -23,6 +24,7 @@
 
   let {
     flow,
+    card,
     layout,
     position,
     itemCount,
@@ -38,39 +40,9 @@
     onDrop,
   }: Props = $props();
 
-  const isClickable = $derived(
-    flow.stats.status === 'active' || flow.stats.status === 'configured'
-  );
+  const isClickable = $derived(card.canOpen);
   const titleId = $derived(`board-item-title-${flow.id}`);
   const contentId = $derived(`board-item-content-${flow.id}`);
-
-  function getStatusTone(status: FlowStats['status']): 'success' | 'info' | 'danger' | 'neutral' {
-    switch (status) {
-      case 'active':
-        return 'success';
-      case 'configured':
-        return 'info';
-      case 'error':
-        return 'danger';
-      default:
-        return 'neutral';
-    }
-  }
-
-  function getStatusLabel(stats: FlowStats): string {
-    if (stats.statusMessage) return stats.statusMessage;
-
-    switch (stats.status) {
-      case 'active':
-        return 'Active';
-      case 'configured':
-        return 'Configured';
-      case 'error':
-        return 'Error';
-      default:
-        return 'Unavailable';
-    }
-  }
 
   function handleSizeChange(event: Event): void {
     const value = (event.currentTarget as HTMLSelectElement).value;
@@ -84,10 +56,12 @@
   class:board-item--dragging={isDragging}
   class:board-item--drop-target={isDropTarget}
   aria-labelledby={titleId}
+  aria-busy={card.state === BoardCardState.LOADING}
   data-board-id={flow.id}
   data-size={layout.size}
   data-collapsed={layout.collapsed}
-  data-state={isClickable ? undefined : 'unavailable'}
+  data-state={card.state}
+  data-openable={isClickable}
   draggable="true"
   ondragstart={onDragStart}
   ondragend={onDragEnd}
@@ -109,10 +83,7 @@
             {flow.name}
           {/if}
         </h2>
-        <div class="board-item__meta">
-          <Badge tone={getStatusTone(flow.stats.status)}>{getStatusLabel(flow.stats)}</Badge>
-          <span>{position + 1} of {itemCount}</span>
-        </div>
+        <span class="board-item__position">{position + 1} of {itemCount}</span>
       </div>
     </div>
 
@@ -151,28 +122,21 @@
         aria-controls={contentId}
         onclick={onToggleCollapsed}
       >
-        <span aria-hidden="true">{layout.collapsed ? '+' : '−'}</span>
+        <span aria-hidden="true"
+          >{#if layout.collapsed}+{:else}&minus;{/if}</span
+        >
       </IconButton>
     </div>
   </header>
 
-  <div id={contentId} class="board-item__content" hidden={layout.collapsed}>
-    <p>{flow.description}</p>
+  <div id={contentId} class="board-item__body">
+    <BoardCardContent {card} description={flow.description} showExpanded={!layout.collapsed} />
 
-    <footer class="board-item__footer">
-      {#if flow.stats.count > 0}
-        <span class="board-item__count">
-          <strong>{flow.stats.count}</strong>
-          <span>Items</span>
-        </span>
-      {:else}
-        <span></span>
-      {/if}
-
-      {#if isClickable}
-        <span class="board-item__action">Open flow <span aria-hidden="true">&rarr;</span></span>
-      {/if}
-    </footer>
+    {#if !layout.collapsed && isClickable}
+      <footer class="board-item__footer">
+        <span>Open flow <span aria-hidden="true">&rarr;</span></span>
+      </footer>
+    {/if}
   </div>
 </article>
 
@@ -209,7 +173,7 @@
   }
 
   .board-item--collapsed {
-    min-height: 0;
+    min-height: 9rem;
   }
 
   .board-item--dragging {
@@ -225,9 +189,7 @@
   .board-item__header,
   .board-item__identity,
   .board-item__controls,
-  .board-item__meta,
-  .board-item__footer,
-  .board-item__count {
+  .board-item__footer {
     display: flex;
     align-items: center;
   }
@@ -267,7 +229,9 @@
   }
 
   .board-item__heading {
+    display: grid;
     min-width: 0;
+    gap: 0.25rem;
   }
 
   .board-item__heading h2 {
@@ -290,11 +254,7 @@
     outline-offset: 2px;
   }
 
-  .board-item__meta {
-    min-height: 1.5rem;
-    flex-wrap: wrap;
-    gap: 0.375rem;
-    margin-top: 0.25rem;
+  .board-item__position {
     color: var(--ui-text-muted);
     font-size: 0.6875rem;
   }
@@ -314,51 +274,26 @@
     font-size: 0.75rem;
   }
 
-  .board-item__content {
+  .board-item__body {
     display: flex;
     min-width: 0;
     flex: 1 1 auto;
     flex-direction: column;
-  }
-
-  .board-item__content[hidden] {
-    display: none;
-  }
-
-  .board-item__content > p {
-    margin: 0;
-    color: var(--ui-text-muted);
-    font-size: 0.875rem;
-    line-height: 1.5;
+    gap: 0.875rem;
   }
 
   .board-item__footer {
     min-height: 2rem;
     margin-top: auto;
-    justify-content: space-between;
-    gap: 1rem;
+    justify-content: flex-end;
     padding-top: 0.875rem;
     border-top: 1px solid var(--ui-border);
   }
 
-  .board-item__count {
-    align-items: baseline;
-    gap: 0.375rem;
-  }
-
-  .board-item__count strong {
-    font-size: 1.125rem;
-  }
-
-  .board-item__count span,
-  .board-item__action {
-    color: var(--ui-text-muted);
+  .board-item__footer span {
+    color: var(--ui-accent);
     font-size: 0.75rem;
     font-weight: 600;
-  }
-
-  .board-item__action {
-    color: var(--ui-accent);
   }
 
   @media (max-width: 56.25rem) {

--- a/packages/ui/src/lib/pages/components/BoardItem.svelte.test.ts
+++ b/packages/ui/src/lib/pages/components/BoardItem.svelte.test.ts
@@ -1,22 +1,38 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import type { ComponentProps } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
+import {
+  BoardCardState,
+  BoardCardTone,
+  type BoardCardReady,
+  type FlowDefinition,
+} from '@lib/flows';
 import { BoardItemSize } from '../board-layout';
-import type { FlowCardModel } from '../types';
 import BoardItem from './BoardItem.svelte';
 
 type BoardItemProps = ComponentProps<typeof BoardItem>;
 
-function makeFlow(overrides: Partial<FlowCardModel> = {}): FlowCardModel {
+const readyCard: BoardCardReady = {
+  state: BoardCardState.READY,
+  canOpen: true,
+  summary: {
+    status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+    primary: { label: 'Tracks', value: '12', detail: '4 genres' },
+  },
+  expanded: {
+    heading: 'Library snapshot',
+    metrics: [{ label: 'Top genre', value: 'rock' }],
+  },
+};
+
+function makeFlow(overrides: Partial<FlowDefinition> = {}): FlowDefinition {
   return {
     id: 'spotify',
     name: 'Spotify Flow',
     icon: 'M',
     description: 'Explore your music library.',
     route: '/spotify',
-    color: 'unused',
-    getStats: async () => ({ count: 12, status: 'active' }),
-    stats: { count: 12, status: 'active' },
+    boardCard: { load: async () => readyCard },
     ...overrides,
   };
 }
@@ -24,6 +40,7 @@ function makeFlow(overrides: Partial<FlowCardModel> = {}): FlowCardModel {
 function makeProps(overrides: Partial<BoardItemProps> = {}): BoardItemProps {
   return {
     flow: makeFlow(),
+    card: readyCard,
     layout: { id: 'spotify', collapsed: false, size: BoardItemSize.COMPACT },
     position: 0,
     itemCount: 2,
@@ -42,7 +59,7 @@ function makeProps(overrides: Partial<BoardItemProps> = {}): BoardItemProps {
 }
 
 describe('BoardItem', () => {
-  it('renders an available flow with navigation, status, count, and layout controls', () => {
+  it('renders an available contract with navigation, summary, expansion, and layout controls', () => {
     render(BoardItem, { props: makeProps() });
 
     expect(screen.getByRole('link', { name: 'Open Spotify Flow' })).toHaveAttribute(
@@ -51,32 +68,40 @@ describe('BoardItem', () => {
     );
     expect(screen.getByText('Active')).toHaveClass('ui-badge--success');
     expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Library snapshot' })).toBeInTheDocument();
     expect(
       screen.getByRole('group', { name: 'Layout controls for Spotify Flow' })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Move Spotify Flow earlier' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Move Spotify Flow later' })).toBeEnabled();
-    expect(screen.getByRole('combobox', { name: 'Size for Spotify Flow' })).toHaveValue(
-      BoardItemSize.COMPACT
-    );
   });
 
-  it('keeps unavailable flows non-interactive', () => {
+  it('keeps failed contracts non-interactive', () => {
     render(BoardItem, {
       props: makeProps({
-        flow: makeFlow({ stats: { count: 0, status: 'disabled' } }),
+        card: {
+          state: BoardCardState.ERROR,
+          canOpen: false,
+          status: { label: 'Error', tone: BoardCardTone.DANGER },
+          title: 'Summary unavailable',
+          message: 'Try refreshing the board.',
+        },
       }),
     });
 
     expect(screen.queryByRole('link', { name: 'Open Spotify Flow' })).not.toBeInTheDocument();
     expect(document.querySelector('[data-board-id="spotify"]')).toHaveAttribute(
       'data-state',
-      'unavailable'
+      BoardCardState.ERROR
     );
-    expect(screen.getByText('Unavailable')).toHaveClass('ui-badge--neutral');
+    expect(document.querySelector('[data-board-id="spotify"]')).toHaveAttribute(
+      'data-openable',
+      'false'
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Summary unavailable');
   });
 
-  it('exposes collapsed state through the native disclosure contract', () => {
+  it('collapses expanded content while retaining the summary contract', () => {
     render(BoardItem, {
       props: makeProps({
         layout: { id: 'spotify', collapsed: true, size: BoardItemSize.STANDARD },
@@ -87,7 +112,9 @@ describe('BoardItem', () => {
       'aria-expanded',
       'false'
     );
-    expect(screen.getByText('Explore your music library.')).not.toBeVisible();
+    expect(screen.getByText('12')).toBeVisible();
+    expect(screen.queryByText('Explore your music library.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Library snapshot' })).not.toBeInTheDocument();
     expect(document.querySelector('[data-board-id="spotify"]')).toHaveAttribute(
       'data-size',
       BoardItemSize.STANDARD

--- a/packages/ui/src/lib/pages/components/FlowBoard.svelte
+++ b/packages/ui/src/lib/pages/components/FlowBoard.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { AsyncState, Badge, Button } from '@lib/components';
+  import { AsyncState, Badge, Button, IconButton } from '@lib/components';
+  import {
+    BoardCardState,
+    createBoardCardError,
+    createStaleBoardCard,
+    hasBoardCardData,
+    type BoardCardSnapshot,
+    type BoardCardViewState,
+    type FlowDefinition,
+  } from '@lib/flows';
   import {
     createDefaultBoardLayout,
     isDefaultBoardLayout,
@@ -12,23 +21,23 @@
     type BoardItemSize,
     type BoardLayout,
   } from '../board-layout';
-  import type { FlowCardModel } from '../types';
   import BoardItem from './BoardItem.svelte';
 
   interface Props {
-    flows: FlowCardModel[];
-    readyFlowCount: number;
+    flows: FlowDefinition[];
   }
 
   interface OrderedBoardItem {
-    flow: FlowCardModel;
+    flow: FlowDefinition;
     layout: BoardLayout['items'][number];
   }
 
-  let { flows, readyFlowCount }: Props = $props();
+  let { flows }: Props = $props();
   const flowIds = $derived(flows.map((flow) => flow.id));
   let layout = $state<BoardLayout>(createDefaultBoardLayout([]));
   let isLayoutReady = $state(false);
+  let cardStates = $state<Record<string, BoardCardViewState>>({});
+  let isRefreshing = $state(false);
   let draggingId = $state<string | null>(null);
   let dropTargetId = $state<string | null>(null);
   let announcement = $state('');
@@ -41,11 +50,60 @@
     });
   });
   const isDefaultLayout = $derived(!isLayoutReady || isDefaultBoardLayout(layout, flowIds));
+  const loadingCount = $derived(
+    flows.filter((flow) => cardStates[flow.id]?.state === BoardCardState.LOADING).length
+  );
+  const readyFlowCount = $derived(flows.filter((flow) => cardStates[flow.id]?.canOpen).length);
 
   onMount(() => {
     layout = loadBoardLayout(window.localStorage, flowIds);
     isLayoutReady = true;
+    void refreshSummaries(false);
   });
+
+  function cardFor(flowId: string): BoardCardViewState {
+    return cardStates[flowId] ?? { state: BoardCardState.LOADING, canOpen: false };
+  }
+
+  async function loadCard(
+    flow: FlowDefinition,
+    previous: BoardCardViewState | undefined
+  ): Promise<void> {
+    let next: BoardCardSnapshot;
+    try {
+      next = await flow.boardCard.load();
+    } catch {
+      next = createBoardCardError();
+    }
+
+    if (next.state === BoardCardState.ERROR && previous && hasBoardCardData(previous)) {
+      next = createStaleBoardCard(previous, 'Refresh failed. Showing the previous summary.');
+    }
+
+    cardStates = { ...cardStates, [flow.id]: next };
+  }
+
+  async function refreshSummaries(announce = true): Promise<void> {
+    if (isRefreshing) return;
+    isRefreshing = true;
+    const previousStates = cardStates;
+    cardStates = Object.fromEntries(
+      flows.map((flow) => [flow.id, { state: BoardCardState.LOADING, canOpen: false }])
+    );
+
+    await Promise.all(flows.map((flow) => loadCard(flow, previousStates[flow.id])));
+    isRefreshing = false;
+
+    if (announce) {
+      const degradedCount = Object.values(cardStates).filter(
+        (card) => card.state === BoardCardState.ERROR || card.state === BoardCardState.STALE
+      ).length;
+      announcement =
+        degradedCount > 0
+          ? `Flow summaries refreshed with ${degradedCount} degraded.`
+          : 'Flow summaries refreshed.';
+    }
+  }
 
   function flowName(itemId: string): string {
     return flows.find((flow) => flow.id === itemId)?.name ?? itemId;
@@ -113,13 +171,25 @@
 <div class="flow-board">
   <div class="flow-board__toolbar">
     <div class="flow-board__summary" aria-label="Flow availability">
+      {#if loadingCount > 0}<Badge tone="info">{loadingCount} loading</Badge>{/if}
       <Badge tone="success">{readyFlowCount} ready</Badge>
       <Badge tone="neutral">{flows.length} total</Badge>
     </div>
-    <Button variant="secondary" size="sm" disabled={isDefaultLayout} onclick={resetLayout}>
-      <span aria-hidden="true">&#8634;</span>
-      Reset layout
-    </Button>
+    <div class="flow-board__actions">
+      <IconButton
+        label="Refresh summaries"
+        size="sm"
+        disabled={isRefreshing}
+        aria-busy={isRefreshing}
+        onclick={() => void refreshSummaries()}
+      >
+        <span aria-hidden="true">&#8635;</span>
+      </IconButton>
+      <Button variant="secondary" size="sm" disabled={isDefaultLayout} onclick={resetLayout}>
+        <span aria-hidden="true">&#8634;</span>
+        Reset layout
+      </Button>
+    </div>
   </div>
 
   {#if !isLayoutReady}
@@ -131,6 +201,7 @@
       {#each orderedItems as item, index (item.flow.id)}
         <BoardItem
           flow={item.flow}
+          card={cardFor(item.flow.id)}
           layout={item.layout}
           position={index}
           itemCount={orderedItems.length}
@@ -166,7 +237,8 @@
   }
 
   .flow-board__toolbar,
-  .flow-board__summary {
+  .flow-board__summary,
+  .flow-board__actions {
     display: flex;
     align-items: center;
   }
@@ -177,9 +249,14 @@
     gap: 1rem;
   }
 
-  .flow-board__summary {
+  .flow-board__summary,
+  .flow-board__actions {
     flex-wrap: wrap;
     gap: 0.5rem;
+  }
+
+  .flow-board__actions {
+    justify-content: flex-end;
   }
 
   .flow-board__grid {
@@ -204,6 +281,11 @@
     .flow-board__toolbar {
       align-items: flex-start;
       flex-direction: column;
+    }
+
+    .flow-board__actions {
+      width: 100%;
+      justify-content: space-between;
     }
   }
 </style>

--- a/packages/ui/src/lib/pages/components/FlowBoard.svelte.test.ts
+++ b/packages/ui/src/lib/pages/components/FlowBoard.svelte.test.ts
@@ -1,28 +1,53 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BoardCardState,
+  BoardCardTone,
+  type BoardCardSnapshot,
+  type FlowDefinition,
+} from '@lib/flows';
 import {
   BOARD_LAYOUT_STORAGE_KEY,
   BOARD_LAYOUT_VERSION,
   BoardItemSize,
   type BoardLayout,
 } from '../board-layout';
-import type { FlowCardModel } from '../types';
 import FlowBoard from './FlowBoard.svelte';
 
-function makeFlow(id: string): FlowCardModel {
+function readyCard(value = '1'): BoardCardSnapshot {
+  return {
+    state: BoardCardState.READY,
+    canOpen: true,
+    summary: {
+      status: { label: 'Active', tone: BoardCardTone.SUCCESS },
+      primary: { label: 'Items', value },
+    },
+  };
+}
+
+function errorCard(): BoardCardSnapshot {
+  return {
+    state: BoardCardState.ERROR,
+    canOpen: false,
+    status: { label: 'Error', tone: BoardCardTone.DANGER },
+    title: 'Summary unavailable',
+    message: 'Try refreshing the board.',
+  };
+}
+
+function makeFlow(
+  id: string,
+  load: () => Promise<BoardCardSnapshot> = async () => readyCard()
+): FlowDefinition {
   return {
     id,
     name: `${id[0]?.toUpperCase()}${id.slice(1)} Flow`,
     icon: id[0]?.toUpperCase() ?? 'F',
     description: `${id} description`,
     route: `/${id}`,
-    color: 'unused',
-    getStats: async () => ({ count: 1, status: 'active' }),
-    stats: { count: 1, status: 'active' },
+    boardCard: { load },
   };
 }
-
-const flows = [makeFlow('spotify'), makeFlow('lyrics'), makeFlow('trading')];
 
 function boardOrder(): string[] {
   return [...document.querySelectorAll<HTMLElement>('[data-board-id]')].map(
@@ -36,12 +61,39 @@ function savedLayout(): BoardLayout {
   return JSON.parse(serialized) as BoardLayout;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   window.localStorage.clear();
 });
 
 describe('FlowBoard', () => {
+  it('loads cards independently instead of blocking the whole board', async () => {
+    const spotify = deferred<BoardCardSnapshot>();
+    const flows = [makeFlow('spotify', () => spotify.promise), makeFlow('lyrics')];
+
+    render(FlowBoard, { props: { flows } });
+
+    expect(await screen.findByRole('link', { name: 'Open Lyrics Flow' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Open Spotify Flow' })).not.toBeInTheDocument();
+    expect(document.querySelector('[data-board-id="spotify"]')).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+
+    spotify.resolve(readyCard('42'));
+    expect(await screen.findByRole('link', { name: 'Open Spotify Flow' })).toBeInTheDocument();
+    expect(screen.getByText('2 ready')).toBeInTheDocument();
+  });
+
   it('restores saved order, collapsed state, and size', async () => {
+    const flows = [makeFlow('spotify'), makeFlow('lyrics'), makeFlow('trading')];
     window.localStorage.setItem(
       BOARD_LAYOUT_STORAGE_KEY,
       JSON.stringify({
@@ -54,7 +106,7 @@ describe('FlowBoard', () => {
       })
     );
 
-    render(FlowBoard, { props: { flows, readyFlowCount: 3 } });
+    render(FlowBoard, { props: { flows } });
 
     await screen.findByRole('link', { name: 'Open Lyrics Flow' });
     expect(boardOrder()).toEqual(['lyrics', 'spotify', 'trading']);
@@ -65,7 +117,8 @@ describe('FlowBoard', () => {
   });
 
   it('reorders with explicit controls, persists, announces, and resets', async () => {
-    render(FlowBoard, { props: { flows, readyFlowCount: 3 } });
+    const flows = [makeFlow('spotify'), makeFlow('lyrics'), makeFlow('trading')];
+    render(FlowBoard, { props: { flows } });
     await screen.findByRole('link', { name: 'Open Spotify Flow' });
 
     const resetButton = screen.getByRole('button', { name: 'Reset layout' });
@@ -83,7 +136,8 @@ describe('FlowBoard', () => {
   });
 
   it('persists collapse and size preferences', async () => {
-    render(FlowBoard, { props: { flows, readyFlowCount: 3 } });
+    const flows = [makeFlow('spotify'), makeFlow('lyrics'), makeFlow('trading')];
+    render(FlowBoard, { props: { flows } });
     await screen.findByRole('link', { name: 'Open Lyrics Flow' });
 
     await fireEvent.click(screen.getByRole('button', { name: 'Collapse Lyrics Flow' }));
@@ -93,18 +147,34 @@ describe('FlowBoard', () => {
 
     const lyrics = savedLayout().items.find((item) => item.id === 'lyrics');
     expect(lyrics).toMatchObject({ collapsed: true, size: BoardItemSize.WIDE });
-    expect(screen.getByRole('button', { name: 'Expand Lyrics Flow' })).toBeInTheDocument();
   });
 
-  it('falls back safely from persisted data with an old version', async () => {
+  it('falls back safely from persisted layout data with an old version', async () => {
+    const flows = [makeFlow('spotify'), makeFlow('lyrics')];
     window.localStorage.setItem(
       BOARD_LAYOUT_STORAGE_KEY,
       JSON.stringify({ version: 0, items: [] })
     );
 
-    render(FlowBoard, { props: { flows, readyFlowCount: 3 } });
+    render(FlowBoard, { props: { flows } });
 
-    await waitFor(() => expect(boardOrder()).toEqual(['spotify', 'lyrics', 'trading']));
+    await waitFor(() => expect(boardOrder()).toEqual(['spotify', 'lyrics']));
     expect(screen.getByRole('button', { name: 'Reset layout' })).toBeDisabled();
+  });
+
+  it('retains the last ready summary as stale when a refresh fails', async () => {
+    const load = vi.fn<() => Promise<BoardCardSnapshot>>();
+    load.mockResolvedValueOnce(readyCard('42')).mockResolvedValueOnce(errorCard());
+    render(FlowBoard, { props: { flows: [makeFlow('spotify', load)] } });
+
+    expect(await screen.findByText('42')).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: 'Refresh summaries' }));
+
+    expect(await screen.findByText('Stale')).toHaveClass('ui-badge--warning');
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Refresh failed. Showing the previous summary.'
+    );
+    expect(load).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/ui/src/lib/pages/types.ts
+++ b/packages/ui/src/lib/pages/types.ts
@@ -1,5 +1,0 @@
-import type { FlowDefinition, FlowStats } from '@lib/flows';
-
-export interface FlowCardModel extends FlowDefinition {
-  stats: FlowStats;
-}


### PR DESCRIPTION
## Why

The home board still coupled flow registration to an implicit count/status model, which made flow-specific summaries, independent failures, and richer expansion behavior difficult to evolve safely.

## What changed

- adds validated, immutable board-card contracts with loading, ready, empty, error, and stale states
- gives Spotify and Lyrics richer typed summaries while adapting Trading, Chat, and Canvas through the shared contract
- makes card loading and refresh independent, preserves stale data after refresh failures, and keeps the generic board renderer flow-agnostic
- expands unit and Playwright coverage and updates architecture, UI, testing, roadmap, and history documentation

## User impact

The landing board now loads each flow independently, keeps useful summaries visible when cards are collapsed, exposes richer details where available, and no longer lets one failed flow block the rest of the board.

## Validation

- `pnpm --filter @flows/ui format:check`
- `pnpm verify`
- `pnpm build`
- `pnpm --filter @flows/ui test:e2e` (16 passed)
- desktop and mobile visual audit with no overflow or console errors

Closes #43