### PR TITLE
fix(canvas): repair LLM rotation and runtime QA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ LOG_LEVEL=info
 # Get these from https://developer.spotify.com/dashboard
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
+# Register this exact URI in the Spotify developer dashboard.
+SPOTIFY_REDIRECT_URI=http://127.0.0.1:4173/api/spotify/auth/callback
 # Optional — if empty, connect via UI "Connect Spotify" button
 # SPOTIFY_REFRESH_TOKEN=
 SPOTIFY_PAGE_LIMIT=5
@@ -27,8 +29,9 @@ ADVISOR_AUTO_START=false
 # LLM (used by @flows/core for AI insights)
 # ============================================
 # Provider: gemini | groq | openrouter | cerebras | mistral | rotation
-# "rotation" cycles through all configured free providers with round-robin + 429 fallback.
+# "rotation" cycles through configured free providers and falls back on provider errors.
 LLM_PROVIDER=gemini
+# Direct mode only. Rotation ignores this value and uses each provider's valid default.
 LLM_MODEL=gemini-2.5-flash
 
 # ── Provider API Keys ─────────────

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ The backend runs on `http://localhost:4173`; the Vite UI runs on
 Copy `.env.example` to `.env`. Spotify requires `SPOTIFY_CLIENT_ID` and
 `SPOTIFY_CLIENT_SECRET`. AI features require at least one supported provider key such as
 `GEMINI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `CEREBRAS_API_KEY`, or
-`MISTRAL_API_KEY`. Runtime selection uses `LLM_PROVIDER` and optionally `LLM_MODEL`.
+`MISTRAL_API_KEY`. Runtime selection uses `LLM_PROVIDER`; `LLM_MODEL` is an optional
+direct-provider override and is deliberately ignored by rotation mode, which uses each
+provider's current default model.
 Trading defaults can be changed with `TRADING_SYMBOL` and `TRADING_INTERVAL`.
 
 Environment values are parsed only by named configuration factories and passed into

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -66,7 +66,7 @@ The `@flows/core/llm` module provides a unified interface for multiple LLM provi
 
 ```text
 @flows/core/src/llm/
-├── client.ts              # LLMClient class (Direct + Rotation modes, generateObject)
+├── client.ts              # Direct/rotation client and structured output metadata
 ├── types.ts               # Shared types (LLMMessage, ModelInfo, ModelTier, etc.)
 ├── index.ts               # Barrel: re-exports + createLLMClient() factory
 └── providers/
@@ -74,7 +74,7 @@ The `@flows/core/llm` module provides a unified interface for multiple LLM provi
     ├── openai-compatible.ts # OpenAICompatibleProvider (shared base for groq/openrouter/cerebras/mistral)
     ├── gemini/             # Google Gemini (paid, @google/genai SDK)
     ├── groq/               # GroqCloud (free, OpenAI-compatible)
-    ├── openrouter/         # OpenRouter aggregator (free :free models)
+    ├── openrouter/         # OpenRouter dynamic free-model router
     ├── cerebras/           # Cerebras (free, 1M tokens/day)
     └── mistral/            # Mistral La Plateforme (free experiment tier)
 ```
@@ -92,11 +92,13 @@ Each provider has:
 // Direct: use specific provider
 const client = new LLMClient('groq');
 
-// Rotation: round-robin across free providers (fallback on 429)
+// Rotation: provider defaults with fallback on provider errors
 const client = LLMClient.createRotation();
 ```
 
-Configure via `.env`: `LLM_PROVIDER=rotation` or `LLM_PROVIDER=groq`.
+Configure via `.env`: `LLM_PROVIDER=rotation` or `LLM_PROVIDER=groq`. `LLM_MODEL`
+overrides the model only in direct mode. Rotation uses each provider's catalog default
+because model identifiers are not portable across providers.
 
 ## Data Flow (Example: Spotify Sync)
 

--- a/docs/architecture/ui.md
+++ b/docs/architecture/ui.md
@@ -122,6 +122,9 @@ The typed Eden client lives in `lib/client.ts` (`treaty<App>(...)`, importing
 are fully typed. In dev, Vite proxies `/api` and `/outputs` to the backend on `:4173`.
 
 Persistent route data belongs in SvelteKit `+page.ts` universal loaders and uses Eden.
+Each loader creates a request-scoped client with `createApiClient(fetch)`, passing the
+`fetch` supplied by its `load` event. Using the browser-global client inside a loader
+bypasses SvelteKit request tracking and emits runtime warnings.
 Loaders register stable dependency keys from `lib/invalidation.ts`; successful mutations
 call the `lib/invalidate.ts` adapter so SvelteKit reruns only the affected loader. Flow
 components receive loader data as props and hydrate their runes state reactively.
@@ -129,7 +132,8 @@ components receive loader data as props and hydrate their runes state reactively
 `onMount` remains appropriate for browser-only behavior such as chart construction,
 `IntersectionObserver`, URL cleanup after OAuth redirects, and SSE subscriptions. Raw
 `fetch` is reserved for endpoints Eden cannot model cleanly; each exception must stay in
-the flow's `api.ts` and be covered by a contract test.
+the flow's `api.ts` and be covered by a contract test. Client-side history updates use
+`pushState`/`replaceState` from `$app/navigation`, never `window.history` directly.
 
 ## Styling
 
@@ -152,6 +156,10 @@ unit-tested. The generic renderer covers every async state and negative space. C
 canvas rendering, live summary/expansion, stale refresh, keyboard reorder, native
 drag-and-drop, persistence reloads, and responsive behavior are verified in a real
 browser. E2E lives in `e2e/` (Playwright).
+
+Vitest uses the plain Svelte plugin, so `src/test/app-navigation.ts` supplies the unit-test
+adapter for SvelteKit's virtual navigation module. Tests may mock that adapter to assert
+navigation without mutating shared browser history.
 
 ## Tooling
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -126,6 +126,8 @@ from `lib/flows/<flow>/`. See [architecture/ui.md](architecture/ui.md).
   The board must not import flow internals or select renderers by flow ID.
 - **Data access** goes through the typed Eden client (`@lib/client`), wrapped per flow in
   `api.ts`. Preferred target: SvelteKit `+page.ts` loaders (universal load) over `onMount`.
+  A loader must construct Eden with its event-scoped `fetch`; browser-global clients are
+  reserved for interactive calls after the loader completes.
 
 ---
 

--- a/docs/flows/llm/api-keys.md
+++ b/docs/flows/llm/api-keys.md
@@ -54,7 +54,9 @@ GROQ_API_KEY=gsk_...
 OPENROUTER_API_KEY=sk-or-v1-...
 ```
 
-> **Tip:** Append `:free` to model IDs for free routing (e.g. `meta-llama/llama-3.3-70b-instruct:free`). Without the suffix, requests use paid credits.
+> **Tip:** Rotation defaults to `openrouter/free`, which selects a currently available
+> free model that supports the request. Pin a current `:free` model only when deterministic
+> model selection is more important than availability.
 
 ---
 
@@ -72,7 +74,9 @@ OPENROUTER_API_KEY=sk-or-v1-...
 CEREBRAS_API_KEY=csk-...
 ```
 
-> **Note:** All models share the 1M tokens/day pool. Cerebras inference is extremely fast (up to 2K tokens/sec on Llama 70B).
+> **Note:** Shared-endpoint availability changes. The application currently defaults to
+> `gpt-oss-120b` and also catalogs `zai-glm-4.7`; consult the provider model endpoint before
+> pinning another model.
 
 ---
 
@@ -100,6 +104,7 @@ After setting any key, test it:
 
 ```env
 LLM_PROVIDER=groq
+LLM_MODEL=llama-3.3-70b-versatile
 GROQ_API_KEY=gsk_your_key_here
 ```
 
@@ -117,4 +122,7 @@ CEREBRAS_API_KEY=csk-...
 MISTRAL_API_KEY=...
 ```
 
-The client will round-robin through all configured providers, automatically skipping any that return 429 rate limit errors.
+Do not set a cross-provider `LLM_MODEL` override for rotation. The client uses each
+provider's valid default (`llama-3.3-70b-versatile`, `openrouter/free`, `gpt-oss-120b`, or
+`mistral-small-latest`) and falls back to the next provider on any request error, including
+rate limits and model availability failures.

--- a/docs/flows/lyrics-canvas/architecture.md
+++ b/docs/flows/lyrics-canvas/architecture.md
@@ -108,6 +108,18 @@ flowchart TD
 
 ---
 
+## Runtime API Contract
+
+| Endpoint | Success | Domain absence | Provider failure |
+| --- | --- | --- | --- |
+| `GET /api/lyrics/:trackId/canvas` | `200` analysis | `200 { needsAnalysis: true, source }`; missing track/lyrics remain `404` | n/a |
+| `POST /api/lyrics/:trackId/canvas/analyze` | `200` persisted analysis | `400` when track or lyrics are unavailable | sanitized `503` |
+
+The analyzer persists the actual `providerUsed` and `modelUsed` returned by the rotation
+client. Provider response bodies remain server-side and are never forwarded to the UI.
+
+---
+
 ## Database
 
 Two databases, two concerns:

--- a/docs/history/backend.md
+++ b/docs/history/backend.md
@@ -4,6 +4,23 @@ Changelog for the backend (API, persistence, domain logic).
 
 ---
 
+## 2026-07-16 - Lyrics Canvas QA and LLM rotation repair
+
+Issue #66 repaired Canvas generation and made the provider boundary auditable:
+
+- Rotation now ignores the direct-mode `LLM_MODEL` override and initializes Groq,
+  OpenRouter, Cerebras, and Mistral with their own catalog defaults.
+- OpenRouter now defaults to the dynamic `openrouter/free` router; retired Cerebras model
+  IDs were replaced by `gpt-oss-120b` and `zai-glm-4.7`.
+- Structured output can return the actual provider/model response metadata, which Lyrics
+  Canvas and generic Canvas persist instead of hard-coded Gemini values.
+- Canvas completions use a 4096-token output budget compatible with free-provider quotas.
+- Missing analysis is a successful domain state; unavailable AI providers map to a
+  sanitized `503` while detailed failures remain in backend logs.
+- Added rotation, metadata, service, analyzer, and `app.handle()` route coverage.
+
+---
+
 ## 2025-12-09 — Lyrics Flow (Backend)
 
 ### Infrastructure

--- a/docs/history/ui.md
+++ b/docs/history/ui.md
@@ -2,6 +2,20 @@
 
 Changelog for the frontend (Svelte) application.
 
+## 2026-07-16 - SvelteKit loader and Canvas QA
+
+Issue #66 removed the runtime warnings found during Lyrics Canvas QA:
+
+- Spotify, Lyrics, Trading, Chat, and Canvas loaders now build a request-scoped Eden
+  client with the `fetch` supplied by SvelteKit.
+- OAuth and Lyrics deep-link URL cleanup now use `$app/navigation.replaceState`.
+- The Lyrics Canvas client treats missing analysis as a normal state and surfaces genuine
+  `404`/`503` responses as stable user-facing errors.
+- Added loader fetch-propagation tests, Canvas status/error contract tests, and a Vitest
+  adapter for SvelteKit's virtual navigation module.
+
+---
+
 ## 2026-07-13 - Board card contracts
 
 Issue #43 replaced the board's implicit stats model with an explicit presentation

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -13,7 +13,7 @@ journeys. Do not pursue coverage by duplicating implementation details in tests.
 | Repository | Vitest with in-memory SQLite | SQL, hydration, absence, constraints, migrations |
 | Service | Vitest with ports mocked | orchestration, calls made and deliberately not made |
 | Route/application | Vitest and `app.handle()` | validation, status/error mapping, dependency wiring |
-| Loader/API facade | Vitest with Eden mocked | DTO mapping, invalidation, empty/error behavior |
+| Loader/API facade | Vitest with Eden mocked | request-scoped fetch, DTO mapping, invalidation, empty/error behavior |
 | UI contract/registry | Vitest | manifest validation, state mapping, stale preservation |
 | Svelte component | Testing Library | accessible behavior and user-observable state |
 | Critical journey | Playwright | real navigation and desktop/mobile interaction |
@@ -27,6 +27,7 @@ journeys. Do not pursue coverage by duplicating implementation details in tests.
 - Use factories for fixtures and fictional data only. Never use credentials or PII.
 - Repository tests use isolated temporary or in-memory databases.
 - Route tests import the app factory; they never start a listening process.
+- Universal loader tests prove the SvelteKit `fetch` is passed into `createApiClient`.
 - Component tests query by role/name when possible and assert behavior, not CSS internals.
 - Playwright locators use roles, labels, or stable product semantics rather than DOM shape.
 - A flaky test is a defect. Fix determinism or isolation instead of adding arbitrary waits.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,8 +21,8 @@ Unified interface for 5 LLM providers with a model catalog, tier system, and fre
 | -------- | ------- | ------- | ---------- |
 | **Gemini** | paid | `GEMINI_API_KEY` | Google AI Studio / Vertex. Frontier models. |
 | **Groq** | free | `GROQ_API_KEY` | Ultra-fast LPU inference. |
-| **OpenRouter** | free | `OPENROUTER_API_KEY` | Aggregator, 24+ free models. |
-| **Cerebras** | free | `CEREBRAS_API_KEY` | 1M tokens/day, fast inference. |
+| **OpenRouter** | free | `OPENROUTER_API_KEY` | Dynamic free-model router. |
+| **Cerebras** | free | `CEREBRAS_API_KEY` | GPT-OSS 120B default, fast inference. |
 | **Mistral** | free | `MISTRAL_API_KEY` | 4M tokens/month experiment tier. |
 
 ### Model Tiers
@@ -30,9 +30,9 @@ Unified interface for 5 LLM providers with a model catalog, tier system, and fre
 Each model in the catalog has a `tier` and `pricing`:
 
 - **`very_high`** — Frontier (Gemini 3.1 Pro, GPT-5, etc.)
-- **`high`** — Near-frontier (Llama 3.3 70B, Qwen 235B, Mistral Large)
-- **`medium`** — Solid generalist (Qwen 32B, Codestral, Llama 4 Scout)
-- **`low`** — Fast & lightweight (Llama 3.1 8B, Gemma 4B, Mistral Nemo)
+- **`high`** — Near-frontier (Llama 3.3 70B, GPT-OSS 120B, Mistral Large)
+- **`medium`** — Solid generalist (Codestral, Mistral Small)
+- **`low`** — Fast and lightweight models
 
 ### Usage
 
@@ -57,7 +57,7 @@ import { LLMClient } from '@flows/core';
 const client = new LLMClient('groq', groqApiKey, 'llama-3.3-70b-versatile');
 ```
 
-**Rotation mode** — round-robin across free providers (auto-fallback on 429):
+**Rotation mode** — round-robin across free providers with error fallback:
 
 ```typescript
 const client = createLLMClientFromEnv({
@@ -67,14 +67,22 @@ const client = createLLMClientFromEnv({
 });
 ```
 
+Rotation always uses each provider's own catalog default. `LLM_MODEL` is only a
+direct-mode override; model identifiers are not portable across providers.
+
+For structured generation that must persist audit metadata, use
+`generateObjectWithMetadata()`. It returns the validated value together with the actual
+provider response (`provider`, `model`, usage, and latency).
+
 ### File Structure
 
 ```
 src/llm/
-├── llm-client.ts           # LLMClient class
+├── client.ts               # LLMClient class
+├── env.ts                  # Runtime configuration factory
+├── types.ts                # LLMMessage, ModelInfo, ModelTier, etc.
 ├── index.ts                # Barrel + createLLMClient()
 └── providers/
-    ├── types.ts            # LLMMessage, ModelInfo, ModelTier, etc.
     ├── base-provider.ts    # Abstract BaseLLMProvider
     ├── gemini/             # @google/genai SDK
     ├── groq/               # OpenAI-compatible (fetch)

--- a/packages/core/src/llm/client.ts
+++ b/packages/core/src/llm/client.ts
@@ -64,7 +64,9 @@ export class LLMClient {
         for (const type of FREE_ROTATION_ORDER) {
             const key = config.apiKeys[type];
             if (key) {
-                providers.push(createProviderInstance(type, key, config.model));
+                // A global model override only makes sense in direct mode. Each
+                // rotation provider must use a model from its own catalog.
+                providers.push(createProviderInstance(type, key));
             }
         }
 
@@ -126,6 +128,15 @@ export class LLMClient {
      * ```
      */
     async generateObject<T>(request: LLMRequest, schema: ZodType<T>): Promise<T> {
+        const { value } = await this.generateObjectWithMetadata(request, schema);
+        return value;
+    }
+
+    /** Generate a typed object and retain the provider response metadata. */
+    async generateObjectWithMetadata<T>(
+        request: LLMRequest,
+        schema: ZodType<T>,
+    ): Promise<{ value: T; response: LLMResponse }> {
         // zod-to-json-schema@3 types target zod v3; this project is on zod v4, so the
         // ZodType shapes don't overlap. Cast through `unknown` (avoids `any`) — runtime is fine.
         const jsonSchema = zodToJsonSchema(
@@ -144,7 +155,10 @@ export class LLMClient {
         const response = await this.generate(structuredRequest);
 
         try {
-            return schema.parse(JSON.parse(stripJsonFences(response.content))) as T;
+            return {
+                value: schema.parse(JSON.parse(stripJsonFences(response.content))) as T,
+                response,
+            };
         } catch (firstError) {
             console.warn(
                 `[LLMClient] generateObject validation failed, retrying once. Error: ${
@@ -171,7 +185,10 @@ export class LLMClient {
             };
 
             const retryResponse = await this.generate(retryRequest);
-            return schema.parse(JSON.parse(stripJsonFences(retryResponse.content))) as T;
+            return {
+                value: schema.parse(JSON.parse(stripJsonFences(retryResponse.content))) as T,
+                response: retryResponse,
+            };
         }
     }
 

--- a/packages/core/src/llm/providers/cerebras/models.ts
+++ b/packages/core/src/llm/providers/cerebras/models.ts
@@ -17,24 +17,16 @@ export const CEREBRAS_MODELS: ModelInfo[] = [
         contextWindow: 128_000,
         description: 'OpenAI open-weight, fastest on Cerebras.',
     },
-    {
-        id: 'llama3.1-8b',
-        name: 'Llama 3.1 8B',
-        tier: 'low',
-        pricing: 'free',
-        contextWindow: 8_192,
-        description: 'Ultra-fast lightweight. ~2K tokens/sec.',
-    },
     // ── Preview ──
     {
-        id: 'qwen-3-235b-a22b-instruct-2507',
-        name: 'Qwen 3 235B',
+        id: 'zai-glm-4.7',
+        name: 'Z.ai GLM 4.7',
         tier: 'high',
         pricing: 'free',
-        contextWindow: 65_536,
-        description: 'Preview. Largest free model, MoE 22B active.',
+        contextWindow: 131_072,
+        description: 'Preview model for reasoning, coding, and tool use.',
     },
 ];
 
-export const CEREBRAS_DEFAULT_MODEL = 'llama3.1-8b';
+export const CEREBRAS_DEFAULT_MODEL = 'gpt-oss-120b';
 export const CEREBRAS_BASE_URL = 'https://api.cerebras.ai';

--- a/packages/core/src/llm/providers/openrouter/models.ts
+++ b/packages/core/src/llm/providers/openrouter/models.ts
@@ -3,69 +3,21 @@ import type { ModelInfo } from '../../types';
 /**
  * OpenRouter model catalog — Aggregator (free :free models)
  *
- * Free tier: 50 RPD (no credits) / 1K RPD (with $10 deposit, not consumed).
- * Use `:free` suffix on model IDs.
- * Docs: https://openrouter.ai/models/?q=free
+ * The router selects an available free model that supports the request's
+ * capabilities, avoiding hard-coded IDs that are retired frequently.
+ * Docs: https://openrouter.ai/docs/guides/routing/routers/free-router
  * Base URL: https://openrouter.ai/api
  */
 export const OPENROUTER_MODELS: ModelInfo[] = [
     {
-        id: 'meta-llama/llama-3.3-70b-instruct:free',
-        name: 'Llama 3.3 70B',
+        id: 'openrouter/free',
+        name: 'Free Models Router',
         tier: 'high',
         pricing: 'free',
-        contextWindow: 128_000,
-        description: 'MMLU 86%. Strong generalist.',
-    },
-    {
-        id: 'openai/gpt-oss-120b:free',
-        name: 'GPT-OSS 120B',
-        tier: 'high',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: 'OpenAI open-weight. MoE 5.1B active.',
-    },
-    {
-        id: 'qwen/qwq-32b:free',
-        name: 'QWQ 32B',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: 'Reasoning-focused Qwen variant.',
-    },
-    {
-        id: 'google/gemini-2.0-flash-exp:free',
-        name: 'Gemini 2.0 Flash',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 1_000_000,
-        description: 'Google experimental. 1M context.',
-    },
-    {
-        id: 'google/gemma-3-27b-it:free',
-        name: 'Gemma 3 27B',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: 'Google open-weight, solid generalist.',
-    },
-    {
-        id: 'mistralai/devstral-2512:free',
-        name: 'Devstral 2',
-        tier: 'medium',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: '123B agentic coding model.',
-    },
-    {
-        id: 'google/gemma-3-4b-it:free',
-        name: 'Gemma 3 4B',
-        tier: 'low',
-        pricing: 'free',
-        contextWindow: 128_000,
-        description: 'Tiny, ultra-fast for simple tasks.',
+        contextWindow: 200_000,
+        description: 'Routes each request to a currently available free model.',
     },
 ];
 
-export const OPENROUTER_DEFAULT_MODEL = 'meta-llama/llama-3.3-70b-instruct:free';
+export const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api';

--- a/packages/core/tests/llm/client-generate-object.test.ts
+++ b/packages/core/tests/llm/client-generate-object.test.ts
@@ -49,6 +49,17 @@ describe('LLMClient.generateObject', () => {
         expect(generate).toHaveBeenCalledOnce();
     });
 
+    it('returns the provider response alongside a validated object when requested', async () => {
+        const { client } = makeClientReturning(
+            JSON.stringify({ sentiment: 'focused', score: 0.8 }),
+        );
+
+        const result = await client.generateObjectWithMetadata(req, schema);
+
+        expect(result.value).toEqual({ sentiment: 'focused', score: 0.8 });
+        expect(result.response).toMatchObject({ provider: 'test', model: 'test-model' });
+    });
+
     it('passes the JSON schema as structured output to generate', async () => {
         const { client, generate } = makeClientReturning(
             JSON.stringify({ sentiment: 'sad', score: 0.1 }),

--- a/packages/core/tests/llm/llm-client.test.ts
+++ b/packages/core/tests/llm/llm-client.test.ts
@@ -88,6 +88,33 @@ describe('LLMClient constructor', () => {
     it('throws for createRotation when no free provider env vars are set', () => {
         expect(() => LLMClient.createRotation()).toThrow(/No free providers configured/);
     });
+
+    it('uses each provider default when rotation receives a global model override', () => {
+        const client = LLMClient.createRotation({
+            provider: 'rotation',
+            model: 'gemini-2.5-flash',
+            apiKeys: {
+                groq: 'groq-key',
+                openrouter: 'openrouter-key',
+                cerebras: 'cerebras-key',
+                mistral: 'mistral-key',
+            },
+        });
+        const providers = Reflect.get(client, 'rotationProviders') as Array<{
+            providerName: string;
+            defaultModel: string;
+        }>;
+
+        expect(Object.fromEntries(providers.map((provider) => [
+            provider.providerName,
+            provider.defaultModel,
+        ]))).toEqual({
+            groq: 'llama-3.3-70b-versatile',
+            openrouter: 'openrouter/free',
+            cerebras: 'gpt-oss-120b',
+            mistral: 'mistral-small-latest',
+        });
+    });
 });
 
 // ── Direct mode ───────────────────────────────────────────────────────

--- a/packages/flows/canvas/src/backend/routes.ts
+++ b/packages/flows/canvas/src/backend/routes.ts
@@ -62,8 +62,8 @@ export const canvasFlowRoutes = new Elysia({ prefix: '/api/canvas' })
                 author: author || 'User',
                 ...analysisResult.meta
             },
-            modelUsed: 'gemini-2.5-pro',
-            providerUsed: 'gemini',
+            modelUsed: analysisResult.modelUsed,
+            providerUsed: analysisResult.providerUsed,
             createdAt: now,
             updatedAt: now,
         };

--- a/packages/flows/canvas/src/backend/text-analyzer.ts
+++ b/packages/flows/canvas/src/backend/text-analyzer.ts
@@ -18,7 +18,12 @@ function formatAstForPrompt(ast: TokenAST): string {
     return output.trim();
 }
 
-export async function analyzeText(ast: TokenAST, title?: string, author?: string): Promise<{ annotations: Annotation[]; meta: TextAnalysisResult['meta'] }> {
+export async function analyzeText(ast: TokenAST, title?: string, author?: string): Promise<{
+    annotations: Annotation[];
+    meta: TextAnalysisResult['meta'];
+    modelUsed: string;
+    providerUsed: string;
+}> {
     const client = LLMClient.createRotation();
     const tokenizedText = formatAstForPrompt(ast);
     
@@ -52,11 +57,11 @@ IMPORTANT DENSITY RULE: Provide a dense, rich analysis identifying key moments i
     const startTime = Date.now();
     
     try {
-        const result = await client.generateObject(
+        const { value: result, response } = await client.generateObjectWithMetadata(
             {
                 messages: [{ role: 'user', content: prompt }],
                 temperature: 0.2,
-                maxTokens: 8192,
+                maxTokens: 4096,
             },
             textAnalysisSchema
         );
@@ -70,7 +75,9 @@ IMPORTANT DENSITY RULE: Provide a dense, rich analysis identifying key moments i
 
         return {
             ...result,
-            annotations: expandedAnnotations
+            annotations: expandedAnnotations,
+            modelUsed: response.model,
+            providerUsed: response.provider,
         };
     } catch (error) {
         log.error({ error, title }, 'Failed to generate text analysis');

--- a/packages/flows/canvas/tests/backend/routes.test.ts
+++ b/packages/flows/canvas/tests/backend/routes.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TokenAST } from '@flows/shared';
+
+const mocks = vi.hoisted(() => ({
+    tokenize: vi.fn(),
+    saveAnalysis: vi.fn(),
+    findAnalysisBySourceId: vi.fn(),
+    getAllAnalysesBySourceType: vi.fn(),
+    deleteAnalysis: vi.fn(),
+    analyzeText: vi.fn(),
+}));
+
+vi.mock('@flows/core', () => ({
+    tokenize: mocks.tokenize,
+    saveAnalysis: mocks.saveAnalysis,
+    findAnalysisBySourceId: mocks.findAnalysisBySourceId,
+    getAllAnalysesBySourceType: mocks.getAllAnalysesBySourceType,
+    deleteAnalysis: mocks.deleteAnalysis,
+}));
+
+vi.mock('../../src/backend/text-analyzer', () => ({
+    analyzeText: mocks.analyzeText,
+}));
+
+const { canvasFlowRoutes } = await import('../../src/backend/routes');
+
+const tokenAst: TokenAST = {
+    totalTokens: 1,
+    sections: [
+        {
+            id: 'section-1',
+            type: 'Paragraph',
+            lines: [[{ id: 'token-1', text: 'Hello' }]],
+        },
+    ],
+};
+
+describe('Canvas routes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.tokenize.mockReturnValue(tokenAst);
+        mocks.analyzeText.mockResolvedValue({
+            annotations: [],
+            meta: { theme: 'Greeting', tone: 'Warm', summary: 'A greeting.' },
+            modelUsed: 'gpt-oss-120b',
+            providerUsed: 'cerebras',
+        });
+    });
+
+    it('persists the provider metadata returned by the analyzer', async () => {
+        const response = await canvasFlowRoutes.handle(
+            new Request('http://localhost/api/canvas', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: 'Hello', title: 'Test' }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(mocks.saveAnalysis).toHaveBeenCalledWith(
+            expect.objectContaining({
+                modelUsed: 'gpt-oss-120b',
+                providerUsed: 'cerebras',
+            }),
+        );
+        await expect(response.json()).resolves.toEqual(
+            expect.objectContaining({
+                modelUsed: 'gpt-oss-120b',
+                providerUsed: 'cerebras',
+            }),
+        );
+    });
+});

--- a/packages/flows/canvas/tests/backend/text-analyzer.test.ts
+++ b/packages/flows/canvas/tests/backend/text-analyzer.test.ts
@@ -4,12 +4,22 @@ import type { TextAnalysisResult } from '../../src/backend/schemas';
 
 // ── Mock the external edge: @flows/core's LLMClient + logger ──────────
 //
-// analyzeText() calls LLMClient.createRotation().generateObject(...). We mock
+// analyzeText() calls LLMClient.createRotation().generateObjectWithMetadata(...). We mock
 // the LLM rotation (the network/SDK edge) and run the REAL expansion domain
 // logic in text-analyzer.ts against a fixed structured result.
 
 const generateObject = vi.fn();
-const createRotation = vi.fn(() => ({ generateObject }));
+const generateObjectWithMetadata = vi.fn(async (request: unknown, schema: unknown) => ({
+    value: await generateObject(request, schema),
+    response: {
+        content: '{}',
+        model: 'gpt-oss-120b',
+        provider: 'cerebras',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        latencyMs: 1,
+    },
+}));
+const createRotation = vi.fn(() => ({ generateObjectWithMetadata }));
 
 vi.mock('@flows/core', () => {
     const noopLog = {
@@ -59,7 +69,7 @@ function makeResult(overrides: Partial<TextAnalysisResult> = {}): TextAnalysisRe
 
 beforeEach(() => {
     vi.clearAllMocks();
-    createRotation.mockReturnValue({ generateObject });
+    createRotation.mockReturnValue({ generateObjectWithMetadata });
 });
 
 // ── Wiring ────────────────────────────────────────────────────────────
@@ -68,10 +78,12 @@ describe('analyzeText — LLM wiring', () => {
     it('obtains a rotation client and calls generateObject once', async () => {
         generateObject.mockResolvedValue(makeResult());
 
-        await analyzeText(makeAst());
+        const result = await analyzeText(makeAst());
 
         expect(createRotation).toHaveBeenCalledOnce();
         expect(generateObject).toHaveBeenCalledOnce();
+        expect(result.providerUsed).toBe('cerebras');
+        expect(result.modelUsed).toBe('gpt-oss-120b');
     });
 
     it('passes the analysis schema and deterministic request params to generateObject', async () => {
@@ -81,7 +93,7 @@ describe('analyzeText — LLM wiring', () => {
 
         const [request, schema] = generateObject.mock.calls[0];
         expect(request.temperature).toBe(0.2);
-        expect(request.maxTokens).toBe(8192);
+        expect(request.maxTokens).toBe(4096);
         expect(request.messages).toHaveLength(1);
         expect(request.messages[0].role).toBe('user');
         expect(schema).toBeDefined();

--- a/packages/flows/lyrics/src/backend/canvas/canvas.routes.ts
+++ b/packages/flows/lyrics/src/backend/canvas/canvas.routes.ts
@@ -1,7 +1,10 @@
+import { logger } from '@flows/core';
 import { Elysia, t } from 'elysia';
 import type { LyricsRepository } from '../../domain/ports';
 import { SQLiteLyricsCanvasRepository } from './repository';
 import { LyricsCanvasService } from './service';
+
+const log = logger.child({ module: 'LyricsCanvasRoutes' });
 
 export function createCanvasRoutes(lyricsRepository: LyricsRepository) {
   const service = new LyricsCanvasService(new SQLiteLyricsCanvasRepository(), lyricsRepository);
@@ -22,9 +25,7 @@ export function createCanvasRoutes(lyricsRepository: LyricsRepository) {
             set.status = 404;
             return { error: 'Lyrics not available for this track' };
           case 'analysis_missing':
-            set.status = 404;
             return {
-              error: 'Analysis not found',
               needsAnalysis: true,
               source: result.source,
             };
@@ -39,14 +40,26 @@ export function createCanvasRoutes(lyricsRepository: LyricsRepository) {
     .post(
       '/analyze',
       async ({ params, set }) => {
-        const result = await service.analyze(params.trackId);
+        try {
+          const result = await service.analyze(params.trackId);
 
-        if (result.kind === 'source_unavailable') {
-          set.status = 400;
-          return { error: 'Track or lyrics not available' };
+          if (result.kind === 'source_unavailable') {
+            set.status = 400;
+            return { error: 'Track or lyrics not available' };
+          }
+
+          return result.analysis;
+        } catch (error) {
+          log.error(
+            {
+              trackId: params.trackId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            'Canvas analysis failed',
+          );
+          set.status = 503;
+          return { error: 'AI analysis is temporarily unavailable' };
         }
-
-        return result.analysis;
       },
       {
         params: t.Object({

--- a/packages/flows/lyrics/src/backend/canvas/music-analyzer.ts
+++ b/packages/flows/lyrics/src/backend/canvas/music-analyzer.ts
@@ -32,7 +32,12 @@ export async function analyzeLyrics(
     trackTitle: string, 
     artistName: string, 
     interpretation?: string | null
-): Promise<{ annotations: Annotation[]; meta: MusicalAnalysisResult['meta'] }> {
+): Promise<{
+    annotations: Annotation[];
+    meta: MusicalAnalysisResult['meta'];
+    modelUsed: string;
+    providerUsed: string;
+}> {
     const client = LLMClient.createRotation();
     
     const tokenizedLyrics = formatAstForPrompt(ast);
@@ -105,11 +110,11 @@ EXAMPLE JSON OUTPUT:
     const startTime = Date.now();
     
     try {
-        const result = await client.generateObject(
+        const { value: result, response } = await client.generateObjectWithMetadata(
             {
                 messages: [{ role: 'user', content: prompt }],
                 temperature: 0.2, // Low temperature for deterministic/factual analysis
-                maxTokens: 8192,  // Ensure the model has enough tokens for high density output
+                maxTokens: 4096,
             },
             musicalAnalysisSchema
         );
@@ -124,10 +129,15 @@ EXAMPLE JSON OUTPUT:
         
         return {
             ...result,
-            annotations: expandedAnnotations
+            annotations: expandedAnnotations,
+            modelUsed: response.model,
+            providerUsed: response.provider,
         };
     } catch (error) {
-        log.error({ error, trackTitle }, 'Failed to generate musical analysis');
+        log.error(
+            { error: error instanceof Error ? error.message : String(error), trackTitle },
+            'Failed to generate musical analysis',
+        );
         throw error;
     }
 }

--- a/packages/flows/lyrics/src/backend/canvas/service.ts
+++ b/packages/flows/lyrics/src/backend/canvas/service.ts
@@ -77,8 +77,8 @@ export class LyricsCanvasService {
       annotations: analysisResult.annotations,
       layers: [...MUSIC_LAYERS, MEANING_LAYER],
       meta: analysisResult.meta,
-      modelUsed: 'gemini-2.5-pro',
-      providerUsed: 'gemini',
+      modelUsed: analysisResult.modelUsed,
+      providerUsed: analysisResult.providerUsed,
       createdAt: now,
       updatedAt: now,
     };

--- a/packages/flows/lyrics/tests/backend/canvas/canvas.routes.test.ts
+++ b/packages/flows/lyrics/tests/backend/canvas/canvas.routes.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasAnalysis } from '@flows/shared';
+import type { LyricsRepository } from '../../../src/domain/ports';
+
+const mocks = vi.hoisted(() => ({
+  load: vi.fn(),
+  analyze: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('@flows/core', () => ({
+  logger: {
+    child: () => ({
+      error: mocks.logError,
+    }),
+  },
+}));
+
+vi.mock('../../../src/backend/canvas/repository', () => ({
+  SQLiteLyricsCanvasRepository: class {},
+}));
+
+vi.mock('../../../src/backend/canvas/service', () => ({
+  LyricsCanvasService: class {
+    load = mocks.load;
+    analyze = mocks.analyze;
+  },
+}));
+
+const { createCanvasRoutes } = await import('../../../src/backend/canvas/canvas.routes');
+
+const lyricsRepository = {} as LyricsRepository;
+
+function makeAnalysis(): CanvasAnalysis {
+  return {
+    id: 'canvas-1',
+    sourceId: 'track-1',
+    sourceType: 'track',
+    sourceTextHash: 'hash',
+    tokenAst: { sections: [], totalTokens: 0 },
+    annotations: [],
+    layers: [],
+    modelUsed: 'llama-3.3-70b-versatile',
+    providerUsed: 'groq',
+    createdAt: '2026-07-17T00:00:00.000Z',
+    updatedAt: '2026-07-17T00:00:00.000Z',
+  };
+}
+
+function request(path: string, method = 'GET'): Promise<Response> {
+  return createCanvasRoutes(lyricsRepository).handle(
+    new Request(`http://localhost${path}`, { method }),
+  );
+}
+
+describe('Lyrics canvas routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns analysis_missing as a successful domain state', async () => {
+    mocks.load.mockResolvedValue({
+      kind: 'analysis_missing',
+      source: {
+        sourceId: 'track-1',
+        sourceType: 'track',
+        title: 'A Song',
+        author: 'An Artist',
+        imageUrl: null,
+      },
+    });
+
+    const response = await request('/track-1/canvas');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      needsAnalysis: true,
+      source: {
+        sourceId: 'track-1',
+        sourceType: 'track',
+        title: 'A Song',
+        author: 'An Artist',
+        imageUrl: null,
+      },
+    });
+  });
+
+  it('keeps a genuinely missing track as 404', async () => {
+    mocks.load.mockResolvedValue({ kind: 'track_not_found' });
+
+    const response = await request('/missing/canvas');
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Track not found' });
+  });
+
+  it('maps provider failures to a sanitized 503 response', async () => {
+    mocks.analyze.mockRejectedValue(
+      new Error('[mistral] API error 400: secret provider response'),
+    );
+
+    const response = await request('/track-1/canvas/analyze', 'POST');
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'AI analysis is temporarily unavailable',
+    });
+    expect(mocks.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ trackId: 'track-1' }),
+      'Canvas analysis failed',
+    );
+  });
+
+  it('returns a created analysis from the provider service', async () => {
+    const analysis = makeAnalysis();
+    mocks.analyze.mockResolvedValue({ kind: 'created', analysis });
+
+    const response = await request('/track-1/canvas/analyze', 'POST');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(analysis);
+  });
+});

--- a/packages/flows/lyrics/tests/backend/canvas/music-analyzer.test.ts
+++ b/packages/flows/lyrics/tests/backend/canvas/music-analyzer.test.ts
@@ -6,13 +6,23 @@ import type { MusicalAnalysisResult } from '../../../src/backend/canvas/schemas'
 // generateObject resolves to a fixed structured result. The real analyzeLyrics
 // expansion logic runs against it.
 const generateObject = vi.fn();
+const generateObjectWithMetadata = vi.fn(async (request: unknown, schema: unknown) => ({
+    value: await generateObject(request, schema),
+    response: {
+        content: '{}',
+        model: 'llama-3.3-70b-versatile',
+        provider: 'groq',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        latencyMs: 1,
+    },
+}));
 
 vi.mock('@flows/core', () => {
     const noop = () => {};
     const childLogger = { info: noop, error: noop, warn: noop, debug: noop };
     return {
         LLMClient: {
-            createRotation: vi.fn(() => ({ generateObject })),
+            createRotation: vi.fn(() => ({ generateObjectWithMetadata })),
         },
         logger: { child: () => childLogger },
     };
@@ -168,7 +178,12 @@ describe('analyzeLyrics', () => {
             meta: { key: null, bpm: null, mood: null },
         } satisfies MusicalAnalysisResult);
 
-        await analyzeLyrics(makeAst(), TRACK_TITLE, ARTIST_NAME, 'A song about resilience.');
+        const result = await analyzeLyrics(
+            makeAst(),
+            TRACK_TITLE,
+            ARTIST_NAME,
+            'A song about resilience.',
+        );
 
         expect(generateObject).toHaveBeenCalledOnce();
         const [request] = generateObject.mock.calls[0];
@@ -181,6 +196,9 @@ describe('analyzeLyrics', () => {
         expect(prompt).toContain('A song about resilience.');
         // Deterministic generation params.
         expect(request.temperature).toBe(0.2);
+        expect(request.maxTokens).toBe(4096);
+        expect(result.providerUsed).toBe('groq');
+        expect(result.modelUsed).toBe('llama-3.3-70b-versatile');
     });
 
     it('returns an empty annotations array when the LLM yields none', async () => {

--- a/packages/flows/lyrics/tests/backend/canvas/service.test.ts
+++ b/packages/flows/lyrics/tests/backend/canvas/service.test.ts
@@ -73,6 +73,8 @@ describe('LyricsCanvasService', () => {
     mocks.analyzeLyrics.mockResolvedValue({
       annotations: [{ tokenId: 't_001', layerId: 'meaning', label: 'Theme', detail: 'Detail' }],
       meta: { key: 'C', bpm: 90, mood: 'Calm' },
+      modelUsed: 'llama-3.3-70b-versatile',
+      providerUsed: 'groq',
     });
   });
 
@@ -140,6 +142,8 @@ describe('LyricsCanvasService', () => {
         sourceType: 'track',
         sourceTextHash: expect.any(String),
         tokenAst: mocks.tokenAst,
+        modelUsed: 'llama-3.3-70b-versatile',
+        providerUsed: 'groq',
       }),
     );
   });

--- a/packages/ui/e2e/lyrics-canvas.spec.ts
+++ b/packages/ui/e2e/lyrics-canvas.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const track = {
+  id: 'track-1',
+  title: 'Test Song',
+  artist: 'Test Artist',
+  imageUrl: null,
+  status: 'found',
+};
+
+const analysis = {
+  id: 'canvas-1',
+  sourceId: track.id,
+  sourceType: 'track',
+  sourceTextHash: 'hash',
+  tokenAst: {
+    totalTokens: 2,
+    sections: [
+      {
+        id: 'section-1',
+        type: 'Verse',
+        lines: [
+          [
+            { id: 'token-1', text: 'Hello' },
+            { id: 'token-2', text: 'world' },
+          ],
+        ],
+      },
+    ],
+  },
+  annotations: [],
+  layers: [{ id: 'meaning', name: 'Meaning', icon: 'Insight', color: '#22d3ee' }],
+  meta: { key: 'C major', bpm: 100, mood: 'Bright' },
+  modelUsed: 'llama-3.3-70b-versatile',
+  providerUsed: 'groq',
+  createdAt: '2026-07-16T00:00:00.000Z',
+  updatedAt: '2026-07-16T00:00:00.000Z',
+};
+
+async function mockLyricsCanvas(page: Page): Promise<void> {
+  await page.route('**/api/lyrics/stats', (route) =>
+    route.fulfill({ json: { total: 1, found: 1, notFound: 0, pending: 0 } })
+  );
+  await page.route('**/api/lyrics/tracks**', (route) => route.fulfill({ json: [track] }));
+  await page.route('**/api/lyrics/track-1/canvas', (route) => route.fulfill({ json: analysis }));
+  await page.route(/\/api\/lyrics\/track-1(?:\?.*)?$/, (route) =>
+    route.fulfill({
+      json: {
+        trackId: track.id,
+        plainLyrics: 'Hello world',
+        syncedLyrics: null,
+        status: 'found',
+        interpretation: 'A short test interpretation.',
+        fetchedAt: '2026-07-16T00:00:00.000Z',
+      },
+    })
+  );
+}
+
+for (const viewport of [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 375, height: 667 },
+]) {
+  test(`lyrics canvas deep-link and history are clean on ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockLyricsCanvas(page);
+    const runtimeProblems: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'warning' || message.type() === 'error') {
+        runtimeProblems.push(message.text());
+      }
+    });
+    page.on('pageerror', (error) => runtimeProblems.push(error.message));
+
+    await page.goto('/lyrics?canvasTrackId=track-1');
+
+    await expect(page.getByRole('heading', { name: 'Canvas Analysis' })).toBeVisible();
+    await expect(page.getByText('Hello')).toBeVisible();
+    expect(runtimeProblems).toEqual([]);
+
+    await page.getByRole('button', { name: 'Back to Dashboard' }).click();
+    await expect(page).toHaveURL(/\/lyrics$/);
+    await expect(page.getByRole('heading', { name: 'Recent Tracks' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open Canvas' }).click();
+    await expect(page).toHaveURL(/\/lyrics\?canvasTrackId=track-1$/);
+    await expect(page.getByRole('heading', { name: 'Canvas Analysis' })).toBeVisible();
+
+    const hasPageOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasPageOverflow).toBe(false);
+    expect(runtimeProblems).toEqual([]);
+  });
+}

--- a/packages/ui/src/lib/client.ts
+++ b/packages/ui/src/lib/client.ts
@@ -16,6 +16,8 @@ export function createApiClient(customFetch?: typeof fetch) {
   });
 }
 
+export type ApiClient = ReturnType<typeof createApiClient>;
+
 export const api = createApiClient();
 
 // Re-export types from the client for convenience

--- a/packages/ui/src/lib/flows/chat/api.ts
+++ b/packages/ui/src/lib/flows/chat/api.ts
@@ -1,4 +1,4 @@
-import { api } from '@lib/client';
+import { api, type ApiClient } from '@lib/client';
 import type { ChatConversation, ChatMessage, ChatProviderGroup, ChatMode } from '@flows/shared';
 
 // Typed Eden client for the chat routes (mounted under /api/chat, like every flow)
@@ -33,14 +33,14 @@ function extractError(error: unknown): Error {
   return new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
 }
 
-export async function fetchModelCatalog(): Promise<ChatProviderGroup[]> {
-  const { data, error } = await chatApi.models.get();
+export async function fetchModelCatalog(client: ApiClient = api): Promise<ChatProviderGroup[]> {
+  const { data, error } = await client.api.chat.models.get();
   if (error) throw extractError(error);
   return data as ChatProviderGroup[];
 }
 
-export async function fetchConversations(): Promise<ChatConversation[]> {
-  const { data, error } = await chatApi.conversations.get();
+export async function fetchConversations(client: ApiClient = api): Promise<ChatConversation[]> {
+  const { data, error } = await client.api.chat.conversations.get();
   if (error) throw extractError(error);
   return data as ChatConversation[];
 }

--- a/packages/ui/src/lib/flows/lyrics/LyricsFlow.svelte
+++ b/packages/ui/src/lib/flows/lyrics/LyricsFlow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { untrack } from 'svelte';
+  import { replaceState } from '$app/navigation';
   import type { LyricsStats, LyricsStatus, Track } from '@flows/shared';
   import type { LyricsPageData, LyricsTrackRow } from '../../../routes/lyrics/+page';
   import { getLyricsStats, getLyricsLibrary, fetchAllLyrics, getLyrics } from './api';
@@ -86,15 +87,16 @@
     return loadData(true);
   }
 
-  // Sync state to URL
-  $effect(() => {
-    const basePath = window.location.pathname;
-    if (canvasTrackId) {
-      window.history.replaceState(null, '', `${basePath}?canvasTrackId=${canvasTrackId}`);
-    } else if (window.location.search.includes('canvasTrackId')) {
-      window.history.replaceState(null, '', basePath);
+  function setCanvasTrack(trackId: string | null) {
+    canvasTrackId = trackId;
+    const url = new URL(window.location.href);
+    if (trackId) {
+      url.searchParams.set('canvasTrackId', trackId);
+    } else {
+      url.searchParams.delete('canvasTrackId');
     }
-  });
+    replaceState(url, {});
+  }
 
   async function handleFetchAllLyrics(retryFailed = false) {
     if (retryFailed) {
@@ -246,7 +248,7 @@
     {:else if canvasTrackId}
       <div class="flex flex-col h-full">
         <div class="border-b border-border p-4">
-          <Button variant="ghost" onclick={() => (canvasTrackId = null)}>Back to Dashboard</Button>
+          <Button variant="ghost" onclick={() => setCanvasTrack(null)}>Back to Dashboard</Button>
         </div>
         <div class="flex-grow overflow-hidden relative">
           <LyricsCanvas trackId={canvasTrackId} />
@@ -427,7 +429,7 @@
                             size="sm"
                             onclick={(e) => {
                               e.stopPropagation();
-                              canvasTrackId = track.id;
+                              setCanvasTrack(track.id);
                             }}
                           >
                             <svg

--- a/packages/ui/src/lib/flows/lyrics/LyricsFlow.svelte.test.ts
+++ b/packages/ui/src/lib/flows/lyrics/LyricsFlow.svelte.test.ts
@@ -4,6 +4,9 @@ import type { LyricsStats } from '@flows/shared';
 import type { LyricsPageData, LyricsTrackRow } from '../../../routes/lyrics/+page';
 import LyricsFlow from './LyricsFlow.svelte';
 
+const replaceState = vi.hoisted(() => vi.fn());
+vi.mock('$app/navigation', () => ({ replaceState }));
+
 // Mock the flow's data edge. The INITIAL stats + first page now arrive via the
 // loader (passed in as the `data` prop); these mocks back the interactive
 // re-fetches that stay in the component (filtering, load-more, refresh, retry).
@@ -80,6 +83,7 @@ describe('LyricsFlow', () => {
     getLyricsLibrary.mockReset();
     fetchAllLyrics.mockReset();
     getLyrics.mockReset();
+    replaceState.mockReset();
     toast.loading.mockClear();
     toast.dismiss.mockClear();
     toast.success.mockClear();
@@ -260,6 +264,9 @@ describe('LyricsFlow', () => {
 
     expect(await screen.findByText('Back to Dashboard')).toBeInTheDocument();
     expect(screen.getByTestId('canvas-stub')).toHaveTextContent('track-1');
+    const openUrl = new URL(String(replaceState.mock.calls[0][0]));
+    expect(openUrl.pathname).toBe('/lyrics');
+    expect(openUrl.searchParams.get('canvasTrackId')).toBe('track-1');
   });
 
   it('restores the canvas view from a canvasTrackId provided by the loader', async () => {
@@ -267,6 +274,7 @@ describe('LyricsFlow', () => {
 
     expect(await screen.findByText('Back to Dashboard')).toBeInTheDocument();
     expect(screen.getByTestId('canvas-stub')).toHaveTextContent('track-99');
+    expect(replaceState).not.toHaveBeenCalled();
   });
 
   it('returns to the dashboard from the canvas view', async () => {
@@ -276,6 +284,9 @@ describe('LyricsFlow', () => {
     await fireEvent.click(screen.getByText('Back to Dashboard'));
 
     expect(await screen.findByText('Recent Tracks')).toBeInTheDocument();
+    const dashboardUrl = new URL(String(replaceState.mock.calls[0][0]));
+    expect(dashboardUrl.pathname).toBe('/lyrics');
+    expect(dashboardUrl.searchParams.has('canvasTrackId')).toBe(false);
   });
 
   it('retries an individual not_found track and flips it to found on success', async () => {

--- a/packages/ui/src/lib/flows/lyrics/api.ts
+++ b/packages/ui/src/lib/flows/lyrics/api.ts
@@ -1,5 +1,5 @@
 import type { Lyrics, LyricsStats, LyricsStatus } from '@flows/shared';
-import { api } from '@lib/client';
+import { api, type ApiClient } from '@lib/client';
 
 /**
  * Fetch lyrics for a specific track
@@ -38,8 +38,8 @@ export async function fetchAllLyrics(retryFailed = false): Promise<{
 /**
  * Get lyrics statistics
  */
-export async function getLyricsStats(): Promise<LyricsStats> {
-  const { data, error } = await api.api.lyrics.stats.get();
+export async function getLyricsStats(client: ApiClient = api): Promise<LyricsStats> {
+  const { data, error } = await client.api.lyrics.stats.get();
 
   if (error) throw new Error('Failed to fetch lyrics stats');
   return data as unknown as LyricsStats;
@@ -51,7 +51,8 @@ export async function getLyricsStats(): Promise<LyricsStats> {
 export async function getLyricsLibrary(
   page = 1,
   limit = 50,
-  status?: LyricsStatus
+  status?: LyricsStatus,
+  client: ApiClient = api
 ): Promise<
   Array<{
     id: string;
@@ -62,7 +63,7 @@ export async function getLyricsLibrary(
   }>
 > {
   const offset = (page - 1) * limit;
-  const { data, error } = await api.api.lyrics.tracks.get({
+  const { data, error } = await client.api.lyrics.tracks.get({
     query: {
       limit: limit.toString(),
       offset: offset.toString(),

--- a/packages/ui/src/lib/flows/lyrics/canvas-api.test.ts
+++ b/packages/ui/src/lib/flows/lyrics/canvas-api.test.ts
@@ -58,14 +58,20 @@ describe('canvas-api', () => {
       expect('id' in result && result.id).toBe('canvas-1');
     });
 
-    it('returns the needsAnalysis status body on a 404 without throwing', async () => {
-      (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
-        jsonResponse(makeNeedsAnalysis(), { ok: false, status: 404 })
-      );
+    it('returns the needsAnalysis status body as a successful domain state', async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(jsonResponse(makeNeedsAnalysis()));
 
       const result = await getCanvasAnalysis('track-1');
 
       expect('needsAnalysis' in result && result.needsAnalysis).toBe(true);
+    });
+
+    it('throws the server-provided message on a 404', async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        jsonResponse({ error: 'Track not found' }, { ok: false, status: 404 })
+      );
+
+      await expect(getCanvasAnalysis('track-1')).rejects.toThrow('Track not found');
     });
 
     it('throws on non-404 error responses', async () => {

--- a/packages/ui/src/lib/flows/lyrics/canvas-api.ts
+++ b/packages/ui/src/lib/flows/lyrics/canvas-api.ts
@@ -3,14 +3,13 @@ import type { CanvasAnalysis } from '@flows/shared';
 const API_BASE = '/api/lyrics';
 
 export interface CanvasStatusResponse {
-  error?: string;
-  needsAnalysis?: boolean;
+  needsAnalysis: true;
   source?: {
     sourceId: string;
     sourceType: string;
     title: string;
     author: string;
-    imageUrl: string;
+    imageUrl: string | null;
   };
 }
 
@@ -23,11 +22,18 @@ export async function getCanvasAnalysis(
 ): Promise<CanvasAnalysis | CanvasStatusResponse> {
   const res = await fetch(`${API_BASE}/${trackId}/canvas`);
 
-  if (!res.ok && res.status !== 404) {
-    throw new Error('Failed to fetch canvas analysis');
+  const data = (await res.json().catch(() => ({}))) as
+    | CanvasAnalysis
+    | CanvasStatusResponse
+    | {
+        error?: string;
+      };
+
+  if (!res.ok) {
+    throw new Error('error' in data && data.error ? data.error : 'Failed to fetch canvas analysis');
   }
 
-  return res.json();
+  return data as CanvasAnalysis | CanvasStatusResponse;
 }
 
 /**

--- a/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte
+++ b/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { replaceState } from '$app/navigation';
   import { toast } from 'svelte-5-french-toast';
   import type { GenreCount, SearchOptions, Track, YearCount } from '@flows/shared';
   import { AsyncState, Button, FlowLayout, Panel } from '@lib/components';
@@ -49,7 +50,7 @@
         position: 'bottom-right',
       });
       url.searchParams.delete('connected');
-      window.history.replaceState({}, '', url.toString());
+      replaceState(url, {});
     }
   });
 

--- a/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte.test.ts
+++ b/packages/ui/src/lib/flows/spotify/SpotifyFlow.svelte.test.ts
@@ -4,6 +4,9 @@ import type { Track, SearchOptions } from '@flows/shared';
 import type { TopStats } from '@lib/types';
 
 const loadTracks = vi.fn();
+const replaceState = vi.hoisted(() => vi.fn());
+
+vi.mock('$app/navigation', () => ({ replaceState }));
 
 // Mock the flow's interactive API edge; route data is loader-owned.
 // Initial tracks, stats, options, and auth arrive through loader props.
@@ -86,6 +89,7 @@ describe('SpotifyFlow render states', () => {
   beforeEach(() => {
     resetStore();
     loadTracks.mockClear();
+    replaceState.mockReset();
   });
 
   it('hydrates auth from loader props and does not refetch tracks', async () => {

--- a/packages/ui/src/routes/canvas/+page.ts
+++ b/packages/ui/src/routes/canvas/+page.ts
@@ -1,5 +1,5 @@
 import type { CanvasAnalysis } from '@flows/shared';
-import { api } from '@lib/client';
+import { createApiClient } from '@lib/client';
 import { INVALIDATION } from '@lib/invalidation';
 import type { PageLoad } from './$types';
 
@@ -17,8 +17,9 @@ export interface CanvasPageData {
  * its data before the component mounts. Interactive actions (load/create/
  * delete) still run through the flow's store + api.ts.
  */
-export const load: PageLoad = async ({ depends }): Promise<CanvasPageData> => {
+export const load: PageLoad = async ({ depends, fetch }): Promise<CanvasPageData> => {
   depends(INVALIDATION.CANVAS_LIST);
+  const api = createApiClient(fetch);
   const { data, error } = await api.api.canvas.get();
 
   if (error) {

--- a/packages/ui/src/routes/canvas/page.test.ts
+++ b/packages/ui/src/routes/canvas/page.test.ts
@@ -3,16 +3,24 @@ import type { CanvasAnalysis } from '@flows/shared';
 
 // ── Mock the typed Eden client edge ─────────────────────────────────
 const canvasGet = vi.fn();
+const createApiClient = vi.fn();
 
-vi.mock('@lib/client', () => ({
-  api: {
+vi.mock('@lib/client', () => {
+  const client = {
     api: {
       canvas: {
         get: (...args: unknown[]) => canvasGet(...args),
       },
     },
-  },
-}));
+  };
+  return {
+    api: client,
+    createApiClient: (requestFetch: typeof fetch) => {
+      createApiClient(requestFetch);
+      return client;
+    },
+  };
+});
 
 import { load } from './+page';
 
@@ -37,13 +45,16 @@ function makeCanvas(overrides: Partial<CanvasAnalysis> = {}): CanvasAnalysis {
 // The loader takes no inputs we rely on, but `load` is typed as PageLoad —
 // pass a minimal typed stand-in for the SvelteKit load event.
 const depends = vi.fn();
-const event = { depends } as unknown as Parameters<typeof load>[0];
+const requestFetch = vi.fn();
+const event = { depends, fetch: requestFetch } as unknown as Parameters<typeof load>[0];
 const runLoad = () => load(event);
 
 describe('canvas +page loader', () => {
   beforeEach(() => {
     canvasGet.mockReset();
+    createApiClient.mockReset();
     depends.mockReset();
+    requestFetch.mockReset();
   });
 
   it('returns the canvas list fetched from the Eden client', async () => {
@@ -53,6 +64,7 @@ describe('canvas +page loader', () => {
     const result = await runLoad();
 
     expect(canvasGet).toHaveBeenCalledOnce();
+    expect(createApiClient).toHaveBeenCalledWith(requestFetch);
     expect(depends).toHaveBeenCalledWith('app:canvas-list');
     expect(result).toEqual({ canvases: list });
   });

--- a/packages/ui/src/routes/chat/+page.ts
+++ b/packages/ui/src/routes/chat/+page.ts
@@ -1,4 +1,5 @@
 import { fetchModelCatalog, fetchConversations } from '@lib/flows/chat/api';
+import { createApiClient } from '@lib/client';
 import type { ChatInitialData } from '@lib/flows/chat/stores.svelte';
 import { showError } from '@lib/toast';
 import type { PageLoad } from './$types';
@@ -12,9 +13,13 @@ import type { PageLoad } from './$types';
  * page falls back to empty defaults so it still renders — matching the old
  * `init()` try/catch behaviour. SSR is disabled at the root layout.
  */
-export const load: PageLoad = async (): Promise<ChatInitialData> => {
+export const load: PageLoad = async ({ fetch }): Promise<ChatInitialData> => {
   try {
-    const [catalog, conversations] = await Promise.all([fetchModelCatalog(), fetchConversations()]);
+    const requestApi = createApiClient(fetch);
+    const [catalog, conversations] = await Promise.all([
+      fetchModelCatalog(requestApi),
+      fetchConversations(requestApi),
+    ]);
 
     // Default: first model of first provider
     let selectedModel = '';

--- a/packages/ui/src/routes/chat/page.test.ts
+++ b/packages/ui/src/routes/chat/page.test.ts
@@ -4,13 +4,14 @@ import type { ChatConversation, ChatProviderGroup } from '@flows/shared';
 // ── Mock the typed Eden client at the edge so the loader exercises the real
 //    flow api.ts (error extraction) without touching the network. The mock fns
 //    are hoisted alongside vi.mock so the factory can safely reference them. ──
-const { modelsGet, conversationsGet } = vi.hoisted(() => ({
+const { modelsGet, conversationsGet, createApiClient } = vi.hoisted(() => ({
   modelsGet: vi.fn(),
   conversationsGet: vi.fn(),
+  createApiClient: vi.fn(),
 }));
 
-vi.mock('@lib/client', () => ({
-  api: {
+vi.mock('@lib/client', () => {
+  const client = {
     // Chat routes are mounted under /api/chat, so the Eden tree is api.api.chat
     api: {
       chat: {
@@ -20,8 +21,15 @@ vi.mock('@lib/client', () => ({
         }),
       },
     },
-  },
-}));
+  };
+  return {
+    api: client,
+    createApiClient: (requestFetch: typeof fetch) => {
+      createApiClient(requestFetch);
+      return client;
+    },
+  };
+});
 
 vi.mock('@lib/toast', () => ({ showError: vi.fn() }));
 
@@ -54,11 +62,13 @@ function makeConversations(): ChatConversation[] {
 }
 
 /** Minimal SvelteKit load event — the loader takes no params/fetch. */
-const loadEvent = {} as Parameters<typeof load>[0];
+const requestFetch = vi.fn();
+const loadEvent = { fetch: requestFetch } as unknown as Parameters<typeof load>[0];
 
 describe('chat +page loader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    requestFetch.mockReset();
   });
 
   it('returns the catalog, conversations, and defaults to the first model of the first provider', async () => {
@@ -74,6 +84,7 @@ describe('chat +page loader', () => {
       conversations,
       selectedModel: 'openai:gpt-4o',
     });
+    expect(createApiClient).toHaveBeenCalledWith(requestFetch);
     expect(mockShowError).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/routes/lyrics/+page.ts
+++ b/packages/ui/src/routes/lyrics/+page.ts
@@ -1,5 +1,6 @@
 import type { PageLoad } from './$types';
 import type { LyricsStats, LyricsStatus } from '@flows/shared';
+import { createApiClient } from '@lib/client';
 import { getLyricsStats, getLyricsLibrary } from '@lib/flows/lyrics/api';
 
 /** A single row in the lyrics library table, as rendered by the dashboard. */
@@ -34,13 +35,14 @@ const LIMIT = 50;
  * Errors are returned (not thrown) so the flow can render its existing inline
  * error UI instead of SvelteKit's error page — behaviour-preserving.
  */
-export const load: PageLoad = async ({ url }): Promise<LyricsPageData> => {
+export const load: PageLoad = async ({ url, fetch }): Promise<LyricsPageData> => {
   const canvasTrackId = url.searchParams.get('canvasTrackId');
+  const requestApi = createApiClient(fetch);
 
   try {
     const [stats, tracks] = await Promise.all([
-      getLyricsStats(), // Stats are always global
-      getLyricsLibrary(1, LIMIT),
+      getLyricsStats(requestApi), // Stats are always global
+      getLyricsLibrary(1, LIMIT, undefined, requestApi),
     ]);
 
     return { stats, tracks, canvasTrackId, error: null };

--- a/packages/ui/src/routes/lyrics/page.test.ts
+++ b/packages/ui/src/routes/lyrics/page.test.ts
@@ -7,6 +7,16 @@ import { load, type LyricsTrackRow, type LyricsPageData } from './+page';
 // in the component.
 const getLyricsStats = vi.fn();
 const getLyricsLibrary = vi.fn();
+const clientMocks = vi.hoisted(() => ({
+  requestApi: { scope: 'request' },
+  createApiClient: vi.fn(),
+}));
+vi.mock('@lib/client', () => ({
+  createApiClient: (requestFetch: typeof fetch) => {
+    clientMocks.createApiClient(requestFetch);
+    return clientMocks.requestApi;
+  },
+}));
 vi.mock('@lib/flows/lyrics/api', () => ({
   getLyricsStats: (...a: unknown[]) => getLyricsStats(...a),
   getLyricsLibrary: (...a: unknown[]) => getLyricsLibrary(...a),
@@ -28,14 +38,21 @@ function makeRow(overrides: Partial<LyricsTrackRow> = {}): LyricsTrackRow {
 }
 
 // Minimal stand-in for the SvelteKit load event — the loader only reads `url`.
+const requestFetch = vi.fn();
+
 function makeEvent(search = '') {
-  return { url: new URL(`http://localhost/lyrics${search}`) } as Parameters<typeof load>[0];
+  return {
+    url: new URL(`http://localhost/lyrics${search}`),
+    fetch: requestFetch,
+  } as unknown as Parameters<typeof load>[0];
 }
 
 describe('lyrics +page load', () => {
   beforeEach(() => {
     getLyricsStats.mockReset();
     getLyricsLibrary.mockReset();
+    clientMocks.createApiClient.mockReset();
+    requestFetch.mockReset();
   });
 
   it('returns the global stats and the first page of tracks', async () => {
@@ -60,8 +77,9 @@ describe('lyrics +page load', () => {
 
     await load(makeEvent());
 
-    expect(getLyricsStats).toHaveBeenCalledTimes(1);
-    expect(getLyricsLibrary).toHaveBeenCalledWith(1, 50);
+    expect(clientMocks.createApiClient).toHaveBeenCalledWith(requestFetch);
+    expect(getLyricsStats).toHaveBeenCalledWith(clientMocks.requestApi);
+    expect(getLyricsLibrary).toHaveBeenCalledWith(1, 50, undefined, clientMocks.requestApi);
   });
 
   it('restores the canvasTrackId deep-link from the URL', async () => {

--- a/packages/ui/src/routes/spotify/+page.ts
+++ b/packages/ui/src/routes/spotify/+page.ts
@@ -1,6 +1,6 @@
 import type { GenreCount, Track, PaginatedResult, SearchOptions, YearCount } from '@flows/shared';
 import type { TopStats } from '@lib/types';
-import { api } from '@lib/client';
+import { createApiClient } from '@lib/client';
 import { mapTopStats } from '@lib/flows/spotify/api';
 import type { PageLoad } from './$types';
 import { INVALIDATION } from '@lib/invalidation';
@@ -31,8 +31,9 @@ export interface SpotifyPageData {
   isAuthenticated: boolean;
 }
 
-export const load: PageLoad = async ({ depends }): Promise<SpotifyPageData> => {
+export const load: PageLoad = async ({ depends, fetch }): Promise<SpotifyPageData> => {
   depends(INVALIDATION.SPOTIFY_LIBRARY);
+  const api = createApiClient(fetch);
   const searchOptions = { ...DEFAULT_SEARCH_OPTIONS };
 
   // Initial tracks (page 1, no filters).

--- a/packages/ui/src/routes/spotify/page.test.ts
+++ b/packages/ui/src/routes/spotify/page.test.ts
@@ -6,10 +6,11 @@ const statsGet = vi.fn();
 const genresGet = vi.fn();
 const yearsGet = vi.fn();
 const authGet = vi.fn();
+const createApiClient = vi.fn();
 
 // Mock the typed Eden client the loader calls for its initial fetch.
-vi.mock('@lib/client', () => ({
-  api: {
+vi.mock('@lib/client', () => {
+  const client = {
     api: {
       spotify: {
         tracks: { search: { get: (...args: unknown[]) => tracksSearchGet(...args) } },
@@ -19,8 +20,15 @@ vi.mock('@lib/client', () => ({
         auth: { status: { get: (...args: unknown[]) => authGet(...args) } },
       },
     },
-  },
-}));
+  };
+  return {
+    api: client,
+    createApiClient: (requestFetch: typeof fetch) => {
+      createApiClient(requestFetch);
+      return client;
+    },
+  };
+});
 // Keep the toast re-export (pulled in transitively via api.ts) inert.
 vi.mock('@lib/toast', () => ({
   showError: vi.fn(),
@@ -46,7 +54,8 @@ const STATS_PAYLOAD = {
 
 // Minimal LoadEvent stub — the loader takes no arguments off the event.
 const depends = vi.fn();
-const event = { depends } as unknown as Parameters<typeof load>[0];
+const requestFetch = vi.fn();
+const event = { depends, fetch: requestFetch } as unknown as Parameters<typeof load>[0];
 
 describe('spotify +page loader', () => {
   beforeEach(() => {
@@ -55,7 +64,9 @@ describe('spotify +page loader', () => {
     genresGet.mockReset();
     yearsGet.mockReset();
     authGet.mockReset();
+    createApiClient.mockReset();
     depends.mockReset();
+    requestFetch.mockReset();
     genresGet.mockResolvedValue({ data: [], error: null });
     yearsGet.mockResolvedValue({ data: [], error: null });
     authGet.mockResolvedValue({ data: { connected: false }, error: null });
@@ -68,6 +79,7 @@ describe('spotify +page loader', () => {
     await load(event);
 
     expect(depends).toHaveBeenCalledWith('app:spotify-library');
+    expect(createApiClient).toHaveBeenCalledWith(requestFetch);
 
     expect(tracksSearchGet).toHaveBeenCalledWith({
       query: {

--- a/packages/ui/src/routes/trading/+page.ts
+++ b/packages/ui/src/routes/trading/+page.ts
@@ -5,7 +5,7 @@
 // client-side only (SSR is disabled in the root +layout.ts). The live
 // EventSource stream and all interactive mutations stay in the component /
 // flow api.ts.
-import { api } from '@lib/client';
+import { createApiClient, type ApiClient } from '@lib/client';
 import type {
   StatusResponse,
   CandlesResponse,
@@ -18,7 +18,7 @@ import { clientLogger } from '@lib/client-logger';
 // SPA only — SSR is disabled (also set globally in the root +layout.ts).
 export const ssr = false;
 
-async function loadStatus(): Promise<Pick<TradingPageData, 'trading' | 'advisor'>> {
+async function loadStatus(api: ApiClient): Promise<Pick<TradingPageData, 'trading' | 'advisor'>> {
   try {
     const { data, error } = await api.api.trading.status.get();
     if (error) throw new Error('Failed to fetch status');
@@ -33,7 +33,7 @@ async function loadStatus(): Promise<Pick<TradingPageData, 'trading' | 'advisor'
   }
 }
 
-async function loadCandles(limit: number): Promise<TradingPageData['candles']> {
+async function loadCandles(api: ApiClient, limit: number): Promise<TradingPageData['candles']> {
   try {
     const { data, error } = await api.api.trading.candles.get({
       query: { limit: limit.toString() },
@@ -47,7 +47,7 @@ async function loadCandles(limit: number): Promise<TradingPageData['candles']> {
   }
 }
 
-async function loadInsight(): Promise<TradingPageData['insight']> {
+async function loadInsight(api: ApiClient): Promise<TradingPageData['insight']> {
   try {
     const { data, error } = await api.api.trading.insight.get();
     if (error) throw new Error('Failed to fetch insight');
@@ -62,11 +62,12 @@ async function loadInsight(): Promise<TradingPageData['insight']> {
   }
 }
 
-export const load: PageLoad = async (): Promise<TradingPageData> => {
+export const load: PageLoad = async ({ fetch }): Promise<TradingPageData> => {
+  const api = createApiClient(fetch);
   const [status, candles, insight] = await Promise.all([
-    loadStatus(),
-    loadCandles(100),
-    loadInsight(),
+    loadStatus(api),
+    loadCandles(api, 100),
+    loadInsight(api),
   ]);
 
   return {

--- a/packages/ui/src/routes/trading/page.test.ts
+++ b/packages/ui/src/routes/trading/page.test.ts
@@ -9,14 +9,15 @@ import type { Candle, AdvisorNote } from '@flows/shared';
 
 // --- Mock the network edge (typed Eden client). Never hit a real backend. ---
 // `vi.hoisted` lets the mock fns exist before the hoisted vi.mock factory runs.
-const { statusGet, candlesGet, insightGet } = vi.hoisted(() => ({
+const { statusGet, candlesGet, insightGet, createApiClient } = vi.hoisted(() => ({
   statusGet: vi.fn(),
   candlesGet: vi.fn(),
   insightGet: vi.fn(),
+  createApiClient: vi.fn(),
 }));
 
-vi.mock('@lib/client', () => ({
-  api: {
+vi.mock('@lib/client', () => {
+  const client = {
     api: {
       trading: {
         status: { get: statusGet },
@@ -24,13 +25,20 @@ vi.mock('@lib/client', () => ({
         insight: { get: insightGet },
       },
     },
-  },
-}));
+  };
+  return {
+    createApiClient: (requestFetch: typeof fetch) => {
+      createApiClient(requestFetch);
+      return client;
+    },
+  };
+});
 
 import { load } from './+page';
 
 // Minimal SvelteKit load event — the trading loader reads nothing off it.
-const event = {} as Parameters<typeof load>[0];
+const requestFetch = vi.fn();
+const event = { fetch: requestFetch } as unknown as Parameters<typeof load>[0];
 
 // --- Fixtures (fixed, deterministic) ---------------------------------------
 function statusFixture(): StatusResponse {
@@ -81,6 +89,8 @@ beforeEach(() => {
   statusGet.mockReset();
   candlesGet.mockReset();
   insightGet.mockReset();
+  createApiClient.mockReset();
+  requestFetch.mockReset();
 });
 
 describe('trading loader — happy path', () => {
@@ -99,6 +109,7 @@ describe('trading loader — happy path', () => {
 
     const data = (await load(event)) as TradingPageData;
 
+    expect(createApiClient).toHaveBeenCalledWith(requestFetch);
     expect(data.trading?.isRunning).toBe(true);
     expect(data.trading?.candleCount).toBe(1234);
     expect(data.advisor?.isEnabled).toBe(true);

--- a/packages/ui/src/test/app-navigation.ts
+++ b/packages/ui/src/test/app-navigation.ts
@@ -1,0 +1,8 @@
+/** Vitest adapter for the SvelteKit virtual navigation module. */
+export function replaceState(url: string | URL, state: Record<string, unknown>): void {
+  window.history.replaceState(state, '', url);
+}
+
+export async function invalidate(): Promise<void> {
+  await Promise.resolve();
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     alias: {
       '@lib': path.resolve(__dirname, './src/lib'),
       '@components': path.resolve(__dirname, './src/lib/components'),
+      '$app/navigation': path.resolve(__dirname, './src/test/app-navigation.ts'),
     },
     conditions: ['browser'],
   },


### PR DESCRIPTION
## Why

Lyrics Canvas QA exposed invalid cross-provider model propagation, stale provider defaults, raw provider failures reaching the browser, and SvelteKit runtime warnings.

## What changed

- make LLM rotation use each provider's model default and refresh the OpenRouter/Cerebras defaults
- return and persist the provider/model that actually generated structured output in both Canvas flows
- treat missing Lyrics Canvas analysis as normal state and sanitize provider failures as 503 responses
- use request-scoped Eden clients in universal loaders and SvelteKit navigation APIs for Canvas state
- add focused core, backend, UI, and desktop/mobile Playwright coverage
- update environment, architecture, testing, provider, and flow documentation

## Impact

Canvas generation now survives provider rotation correctly, reports actionable client errors without leaking provider internals, and no longer emits the observed SvelteKit fetch/navigation warnings.

## Validation

- `pnpm verify` (982 tests, lint/types/Svelte/docs/architecture clean)
- `pnpm build`
- `pnpm --filter @flows/ui test:e2e -- e2e/lyrics-canvas.spec.ts` (desktop and mobile)
- real Lyrics Canvas generation for `2C5SI38AMmqckQGnD1H2FO`: Groq / `llama-3.3-70b-versatile`, 77 annotations persisted
- manual in-app browser QA with a clean console

Closes #66